### PR TITLE
Formatting, Javadoc fixes and Javadoc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,64 +16,89 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>jakarta.jms</groupId>
-  <artifactId>jakarta.jms-api</artifactId>
-  <packaging>jar</packaging>
-  <version>2.1-SNAPSHOT</version>
-  <name>jms</name>
-  <url>https://projects.eclipse.org/projects/ee4j.jms</url>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!--  Temporarily disable doclint. See JMS_SPEC-175 -->
-    <additionalparam>-Xdoclint:none</additionalparam>
-  </properties>  
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.8</version>
-        <configuration>
-          <!--  Specifies the text to be placed at the bottom of each output file.  -->
-          <bottom>Copyright 1997-2018 Oracle America Inc. All rights reserved. Use is subject to &lt;a href="http://java.net/downloads/jms-spec/Licences/JSR 368 Java Message Service EDR 10.8.15.pdf"&gt;licence terms&lt;/a&gt; &lt;br/&gt;</bottom>
-          <!-- Specifies the header text to be placed at the top of each output file, to the right of the upper navigation bar. -->
-          <header>JMS 2.1</header>          
-          <!-- Specifies the footer text to be placed at the top of each output file, to the right of the lower navigation bar. -->
-          <footer>JMS 2.1</footer>
-          
-          
-          <links>
-            <link>https://javaee.github.io/javaee-spec/javadocs/</link>
-          </links>          
-        </configuration>
-      </plugin>
-      <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-compiler-plugin</artifactId>
-         <version>2.3.2</version>
-         <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-         </configuration>
-      </plugin>      
-      <!-- configure where the javadocs will be placed, so that after we commit them they will appear in the jms-spec website -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!-- javadoc:jar uses outputDirectory - but disabled since it doesn't create the jar for some reason -->
-          <!-- outputDirectory>${project.reporting.outputDirectory}/../../../www/2.1-SNAPSHOT</outputDirectory -->
-          <!-- javadoc:javadoc uses reportOutputDirectory -->
-          <reportOutputDirectory>${project.reporting.outputDirectory}/../../../www/2.1-SNAPSHOT</reportOutputDirectory>
-          <destDir>apidocs</destDir>
-        </configuration>
-      </plugin>      
-    </plugins>     
-  </build>
-  
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.1</version>
+    </parent>
+
+    <groupId>jakarta.jms</groupId>
+    <artifactId>jakarta.jms-api</artifactId>
+    <version>2.1-SNAPSHOT</version>
+    
+    <name>jms</name>
+    <url>https://projects.eclipse.org/projects/ee4j.jms</url>
+
+    <build>
+        <plugins>
+           <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <includePom>true</includePom>
+                </configuration>
+                <executions>
+                    <execution>
+                       <id>attach-sources</id>
+                       <goals>
+                           <goal>jar-no-fork</goal> 
+                       </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                    <groups>
+                        <group>
+                            <title>JMS API Documentation</title>
+                            <packages>
+                                javax.jms
+                            </packages>
+                        </group>
+                    </groups>
+                
+                    <!-- Specifies the text to be placed at the bottom of each output file. -->
+                    <bottom>Copyright 1997-2018 Oracle America Inc. All rights reserved. Use is subject to &lt;a
+                        href="http://java.net/downloads/jms-spec/Licences/JSR 368 Java Message Service EDR 10.8.15.pdf"&gt;licence
+                        terms&lt;/a&gt; &lt;br/&gt;</bottom>
+                    
+                    <!-- Specifies the header text to be placed at the top of each output file, to the right of the upper navigation bar. -->
+                    <header>JMS 2.1</header>
+                    
+                    <!-- Specifies the footer text to be placed at the top of each output file, to the right of the lower navigation bar. -->
+                    <footer>JMS 2.1</footer>
+
+                    <links>
+                        <link>https://javaee.github.io/javaee-spec/javadocs/</link>
+                    </links>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                     </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/src/main/java/javax/jms/AutoAcknowledge.java
+++ b/src/main/java/javax/jms/AutoAcknowledge.java
@@ -24,37 +24,32 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies that a callback method on a JMS message-driven bean
- * must receive messages with an acknowledgement type of auto-acknowledge. It
- * may be specified either on the callback method or on the message-driven bean
- * class.
+ * This annotation specifies that a callback method on a JMS message-driven bean must receive messages with an
+ * acknowledgement type of auto-acknowledge. It may be specified either on the callback method or on the message-driven
+ * bean class.
  * <p>
- * The message-driven bean must also be configured to use a transaction
- * management type of BEAN. This may be configured by specifying the annotation
- * {code @TransactionManagement(value=TransactionManagementType.BEAN)} on the
- * message-driven bean. If a transaction management type of BEAN is not
- * configured then it is recommended that deployment will fail.
+ * The message-driven bean must also be configured to use a transaction management type of BEAN. This may be configured
+ * by specifying the annotation {code @TransactionManagement(value=TransactionManagementType.BEAN)} on the
+ * message-driven bean. If a transaction management type of BEAN is not configured then it is recommended that
+ * deployment will fail.
  * <p>
- * If this annotation is specified on a method of a message-driven bean class
- * then that method must also be annotated with {@code QueueListener} or
- * {@code TopicListener}. If it is not then deployment will fail.
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
  * <p>
- * If this annotation is specified on the message-driven bean class then at
- * least one method must be annotated with {@code QueueListener} or
- * {@code TopicListener}. If no method is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
  * <p>
- * If either this annotation or {@code DupsOKAcknowledge} are specified on both
- * a method of a message-driven bean class and on the message-driven bean class
- * itself then deployment will fail.
- * 
+ * If either this annotation or {@code DupsOKAcknowledge} are specified on both a method of a message-driven bean class
+ * and on the message-driven bean class itself then deployment will fail.
+ *
  * @see QueueListener
  * @see TopicListener
  * @see DupsOKAcknowledge
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
+ *
  */
 @Retention(RUNTIME)
 @Target({ METHOD, TYPE })

--- a/src/main/java/javax/jms/BytesMessage.java
+++ b/src/main/java/javax/jms/BytesMessage.java
@@ -16,556 +16,391 @@
 
 package javax.jms;
 
-
-/** A {@code BytesMessage} object is used to send a message containing a 
-  * stream of uninterpreted bytes. It inherits from the {@code Message} 
-  * interface and adds a bytes
-  * message body. The receiver of the message supplies the interpretation
-  * of the bytes.
-  *
-  * <P>The {@code BytesMessage} methods are based largely on those found in
-  * {@code java.io.DataInputStream} and
-  * {@code java.io.DataOutputStream}.
-  *
-  * <P>This message type is for client encoding of existing message formats. 
-  * If possible, one of the other self-defining message types should be used 
-  * instead.
-  *
-  * <P>Although the JMS API allows the use of message properties with byte 
-  * messages, they are typically not used, since the inclusion of properties 
-  * may affect the format.
-  *
-  * <P>The primitive types can be written explicitly using methods
-  * for each type. They may also be written generically as objects.
-  * For instance, a call to {@code BytesMessage.writeInt(6)} is
-  * equivalent to {@code BytesMessage.writeObject(new Integer(6))}.
-  * Both forms are provided, because the explicit form is convenient for
-  * static programming, and the object form is needed when types are not known
-  * at compile time.
-  *
-  * <P>When the message is first created, and when {@code clearBody}
-  * is called, the body of the message is in write-only mode. After the 
-  * first call to {@code reset} has been made, the message body is in 
-  * read-only mode. 
-  * When a {@code BytesMessage} is sent asynchronously, the provider 
-  * must call {@code reset} on the {@code BytesMessage} passed to 
-  * the {@code CompletionListener}. This means that the 
-  * {@code CompletionListener} can read the message body without 
-  * needing to call {@code reset}. 
-  * After a message has been sent, the client that sent it can retain and 
-  * modify it without affecting the message that has been sent. The same message
-  * object can be sent multiple times.
-  * When a message has been received, the provider has called 
-  * {@code reset} so that the message body is in read-only mode for the client.
-  *
-  * <P>If {@code clearBody} is called on a message in read-only mode, 
-  * the message body is cleared and the message is in write-only mode.
-  *
-  * <P>If a client attempts to read a message in write-only mode, a 
-  * {@code MessageNotReadableException} is thrown.
-  *
-  * <P>If a client attempts to write a message in read-only mode, a 
-  * {@code MessageNotWriteableException} is thrown.
-  *
-  * @see         javax.jms.Session#createBytesMessage()
-  * @see         javax.jms.MapMessage
-  * @see         javax.jms.Message
-  * @see         javax.jms.ObjectMessage
-  * @see         javax.jms.StreamMessage
-  * @see         javax.jms.TextMessage
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A {@code BytesMessage} object is used to send a message containing a stream of uninterpreted bytes. It inherits from
+ * the {@code Message} interface and adds a bytes message body. The receiver of the message supplies the interpretation
+ * of the bytes.
+ *
+ * <p>
+ * The {@code BytesMessage} methods are based largely on those found in {@code java.io.DataInputStream} and
+ * {@code java.io.DataOutputStream}.
+ *
+ * <p>
+ * This message type is for client encoding of existing message formats. If possible, one of the other self-defining
+ * message types should be used instead.
+ *
+ * <p>
+ * Although the JMS API allows the use of message properties with byte messages, they are typically not used, since the
+ * inclusion of properties may affect the format.
+ *
+ * <p>
+ * The primitive types can be written explicitly using methods for each type. They may also be written generically as
+ * objects. For instance, a call to {@code BytesMessage.writeInt(6)} is equivalent to
+ * {@code BytesMessage.writeObject(new Integer(6))}. Both forms are provided, because the explicit form is convenient
+ * for static programming, and the object form is needed when types are not known at compile time.
+ *
+ * <p>
+ * When the message is first created, and when {@code clearBody} is called, the body of the message is in write-only
+ * mode. After the first call to {@code reset} has been made, the message body is in read-only mode. When a
+ * {@code BytesMessage} is sent asynchronously, the provider must call {@code reset} on the {@code BytesMessage} passed
+ * to the {@code CompletionListener}. This means that the {@code CompletionListener} can read the message body without
+ * needing to call {@code reset}. After a message has been sent, the client that sent it can retain and modify it
+ * without affecting the message that has been sent. The same message object can be sent multiple times. When a message
+ * has been received, the provider has called {@code reset} so that the message body is in read-only mode for the
+ * client.
+ *
+ * <p>
+ * If {@code clearBody} is called on a message in read-only mode, the message body is cleared and the message is in
+ * write-only mode.
+ *
+ * <p>
+ * If a client attempts to read a message in write-only mode, a {@code MessageNotReadableException} is thrown.
+ *
+ * <p>
+ * If a client attempts to write a message in read-only mode, a {@code MessageNotWriteableException} is thrown.
+ *
+ * @see javax.jms.Session#createBytesMessage()
+ * @see javax.jms.MapMessage
+ * @see javax.jms.Message
+ * @see javax.jms.ObjectMessage
+ * @see javax.jms.StreamMessage
+ * @see javax.jms.TextMessage
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 public interface BytesMessage extends Message {
-    
-     /** Gets the number of bytes of the message body when the message
-       * is in read-only mode. The value returned can be used to allocate 
-       * a byte array. The value returned is the entire length of the message
-       *  body, regardless of where the pointer for reading the message 
-       * is currently located.
-       * 
-       * @return number of bytes in the message 
-       * @exception JMSException if the JMS provider fails to read the message 
-       *                         due to some internal error.
-       * @exception MessageNotReadableException if the message is in write-only
-       *                         mode.
-       * @since JMS 1.1 
-       */
-       
-      long getBodyLength() throws JMSException;
-
-    /** Reads a {@code boolean} from the bytes message stream.
-      *
-      * @return the {@code boolean} value read
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */
-    
- 
-    boolean 
-    readBoolean() throws JMSException;
-
-
-    /** Reads a signed 8-bit value from the bytes message stream.
-      *
-      * @return the next byte from the bytes message stream as a signed 8-bit
-      * {@code byte}
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    byte 
-    readByte() throws JMSException;
-
-
-    /** Reads an unsigned 8-bit number from the bytes message stream.
-      *  
-      * @return the next byte from the bytes message stream, interpreted as an
-      * unsigned 8-bit number
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */
-
-    int
-    readUnsignedByte() throws JMSException;
-
-
-    /** Reads a signed 16-bit number from the bytes message stream.
-      *
-      * @return the next two bytes from the bytes message stream, interpreted as
-      * a signed 16-bit number
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    short 
-    readShort() throws JMSException;
-
-
-    /** Reads an unsigned 16-bit number from the bytes message stream.
-      *  
-      * @return the next two bytes from the bytes message stream, interpreted as
-      * an unsigned 16-bit integer
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
- 
-    int
-    readUnsignedShort() throws JMSException;
-
 
-    /** Reads a Unicode character value from the bytes message stream.
-      *
-      * @return the next two bytes from the bytes message stream as a Unicode
-      * character
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    char 
-    readChar() throws JMSException;
-
-
-    /** Reads a signed 32-bit integer from the bytes message stream.
-      *
-      * @return the next four bytes from the bytes message stream, interpreted
-      * as an {@code int}
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    int 
-    readInt() throws JMSException;
-
-
-    /** Reads a signed 64-bit integer from the bytes message stream.
-      *
-      * @return the next eight bytes from the bytes message stream, interpreted
-      * as a {@code long}
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    long 
-    readLong() throws JMSException;
-
-
-    /** Reads a {@code float} from the bytes message stream.
-      *
-      * @return the next four bytes from the bytes message stream, interpreted
-      * as a {@code float}
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    float 
-    readFloat() throws JMSException;
-
-
-    /** Reads a {@code double} from the bytes message stream.
-      *
-      * @return the next eight bytes from the bytes message stream, interpreted
-      * as a {@code double}
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    double 
-    readDouble() throws JMSException;
-
-
-    /** Reads a string that has been encoded using a modified UTF-8
-      * format from the bytes message stream.
-      *
-      * <P>For more information on the UTF-8 format, see "File System Safe
-      * UCS Transformation Format (FSS_UTF)", X/Open Preliminary Specification,
-      * X/Open Company Ltd., Document Number: P316. This information also
-      * appears in ISO/IEC 10646, Annex P.
-      *
-      * @return a Unicode string from the bytes message stream
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of bytes stream has 
-      *                                been reached.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    String 
-    readUTF() throws JMSException;
-
-
-    /** Reads a byte array from the bytes message stream.
-      *
-      * <P>If the length of array {@code value} is less than the number of 
-      * bytes remaining to be read from the stream, the array should 
-      * be filled. A subsequent call reads the next increment, and so on.
-      * 
-      * <P>If the number of bytes remaining in the stream is less than the 
-      * length of 
-      * array {@code value}, the bytes should be read into the array. 
-      * The return value of the total number of bytes read will be less than
-      * the length of the array, indicating that there are no more bytes left 
-      * to be read from the stream. The next read of the stream returns -1.
-      *
-      * @param value the buffer into which the data is read
-      *
-      * @return the total number of bytes read into the buffer, or -1 if 
-      * there is no more data because the end of the stream has been reached
-      *
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    int
-    readBytes(byte[] value) throws JMSException;
-
-
-    /** Reads a portion of the bytes message stream.
-      *
-      * <P>If the length of array {@code value} is less than the number of
-      * bytes remaining to be read from the stream, the array should 
-      * be filled. A subsequent call reads the next increment, and so on.
-      * 
-      * <P>If the number of bytes remaining in the stream is less than the 
-      * length of 
-      * array {@code value}, the bytes should be read into the array. 
-      * The return value of the total number of bytes read will be less than
-      * the length of the array, indicating that there are no more bytes left 
-      * to be read from the stream. The next read of the stream returns -1.
-      *
-      * <p> If {@code length} is negative, or
-      * {@code length} is greater than the length of the array
-      * {@code value}, then an {@code IndexOutOfBoundsException} is
-      * thrown. No bytes will be read from the stream for this exception case.
-      *  
-      * @param value the buffer into which the data is read
-      * @param length the number of bytes to read; must be less than or equal to
-      *        {@code value.length}
-      * 
-      * @return the total number of bytes read into the buffer, or -1 if
-      * there is no more data because the end of the stream has been reached
-      *  
-      * @exception JMSException if the JMS provider fails to read the message 
-      *                         due to some internal error.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    int
-    readBytes(byte[] value, int length) 
-			throws JMSException;
-
-
-    /** Writes a {@code boolean} to the bytes message stream as a 1-byte 
-      * value.
-      * The value {@code true} is written as the value 
-      * {@code (byte)1}; the value {@code false} is written as 
-      * the value {@code (byte)0}.
-      *
-      * @param value the {@code boolean} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */
-
-    void 
-    writeBoolean(boolean value) 
-			throws JMSException;
-
-
-    /** Writes a {@code byte} to the bytes message stream as a 1-byte 
-      * value.
-      *
-      * @param value the {@code byte} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeByte(byte value) throws JMSException;
-
-
-    /** Writes a {@code short} to the bytes message stream as two bytes,
-      * high byte first.
-      *
-      * @param value the {@code short} to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeShort(short value) throws JMSException;
-
-
-    /** Writes a {@code char} to the bytes message stream as a 2-byte
-      * value, high byte first.
-      *
-      * @param value the {@code char} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeChar(char value) throws JMSException;
-
-
-    /** Writes an {@code int} to the bytes message stream as four bytes, 
-      * high byte first.
-      *
-      * @param value the {@code int} to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeInt(int value) throws JMSException;
-
-
-    /** Writes a {@code long} to the bytes message stream as eight bytes, 
-      * high byte first.
-      *
-      * @param value the {@code long} to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeLong(long value) throws JMSException;
-
-
-    /** Converts the {@code float} argument to an {@code int} using 
-      * the
-      * {@code floatToIntBits} method in class {@code Float},
-      * and then writes that {@code int} value to the bytes message
-      * stream as a 4-byte quantity, high byte first.
-      *
-      * @param value the {@code float} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeFloat(float value) throws JMSException;
-
-
-    /** Converts the {@code double} argument to a {@code long} using 
-      * the
-      * {@code doubleToLongBits} method in class {@code Double},
-      * and then writes that {@code long} value to the bytes message
-      * stream as an 8-byte quantity, high byte first.
-      *
-      * @param value the {@code double} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeDouble(double value) throws JMSException;
-
-
-    /** Writes a string to the bytes message stream using UTF-8 encoding in a 
-      * machine-independent manner.
-      *
-      * <P>For more information on the UTF-8 format, see "File System Safe 
-      * UCS Transformation Format (FSS_UTF)", X/Open Preliminary Specification,       
-      * X/Open Company Ltd., Document Number: P316. This information also 
-      * appears in ISO/IEC 10646, Annex P. 
-      *
-      * @param value the {@code String} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeUTF(String value) throws JMSException;
-
-
-    /** Writes a byte array to the bytes message stream.
-      *
-      * @param value the byte array to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void
-    writeBytes(byte[] value) throws JMSException;
-
-
-    /** Writes a portion of a byte array to the bytes message stream.
-      *  
-      * @param value the byte array value to be written
-      * @param offset the initial offset within the byte array
-      * @param length the number of bytes to use
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
- 
-    void
-    writeBytes(byte[] value, int offset, int length) 
-			throws JMSException;
-
-
-    /** Writes an object to the bytes message stream.
-      *
-      * <P>This method works only for the objectified primitive
-      * object types ({@code Integer}, {@code Double}, 
-      * {@code Long}&nbsp;...), {@code String} objects, and byte 
-      * arrays.
-      *
-      * @param value the object in the Java programming language ("Java 
-      *              object") to be written; it must not be null
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if the object is of an invalid type.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      * @exception java.lang.NullPointerException if the parameter 
-      *                                           {@code value} is null.
-      */ 
-
-    void 
-    writeObject(Object value) throws JMSException;
-
-
-    /** Puts the message body in read-only mode and repositions the stream of 
-      * bytes to the beginning.
-      *  
-      * @exception JMSException if the JMS provider fails to reset the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if the message has an invalid
-      *                         format.
-      */ 
-
-    void
-    reset() throws JMSException;
+    /**
+     * Gets the number of bytes of the message body when the message is in read-only mode. The value returned can be used to
+     * allocate a byte array. The value returned is the entire length of the message body, regardless of where the pointer
+     * for reading the message is currently located.
+     *
+     * @return number of bytes in the message
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     * @since JMS 1.1
+     */
+    long getBodyLength() throws JMSException;
+
+    /**
+     * Reads a {@code boolean} from the bytes message stream.
+     *
+     * @return the {@code boolean} value read
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    boolean readBoolean() throws JMSException;
+
+    /**
+     * Reads a signed 8-bit value from the bytes message stream.
+     *
+     * @return the next byte from the bytes message stream as a signed 8-bit {@code byte}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    byte readByte() throws JMSException;
+
+    /**
+     * Reads an unsigned 8-bit number from the bytes message stream.
+     *
+     * @return the next byte from the bytes message stream, interpreted as an unsigned 8-bit number
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    int readUnsignedByte() throws JMSException;
+
+    /**
+     * Reads a signed 16-bit number from the bytes message stream.
+     *
+     * @return the next two bytes from the bytes message stream, interpreted as a signed 16-bit number
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    short readShort() throws JMSException;
+
+    /**
+     * Reads an unsigned 16-bit number from the bytes message stream.
+     *
+     * @return the next two bytes from the bytes message stream, interpreted as an unsigned 16-bit integer
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    int readUnsignedShort() throws JMSException;
+
+    /**
+     * Reads a Unicode character value from the bytes message stream.
+     *
+     * @return the next two bytes from the bytes message stream as a Unicode character
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    char readChar() throws JMSException;
+
+    /**
+     * Reads a signed 32-bit integer from the bytes message stream.
+     *
+     * @return the next four bytes from the bytes message stream, interpreted as an {@code int}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    int readInt() throws JMSException;
+
+    /**
+     * Reads a signed 64-bit integer from the bytes message stream.
+     *
+     * @return the next eight bytes from the bytes message stream, interpreted as a {@code long}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    long readLong() throws JMSException;
+
+    /**
+     * Reads a {@code float} from the bytes message stream.
+     *
+     * @return the next four bytes from the bytes message stream, interpreted as a {@code float}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    float readFloat() throws JMSException;
+
+    /**
+     * Reads a {@code double} from the bytes message stream.
+     *
+     * @return the next eight bytes from the bytes message stream, interpreted as a {@code double}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    double readDouble() throws JMSException;
+
+    /**
+     * Reads a string that has been encoded using a modified UTF-8 format from the bytes message stream.
+     *
+     * <p>
+     * For more information on the UTF-8 format, see "File System Safe UCS Transformation Format (FSS_UTF)", X/Open
+     * Preliminary Specification, X/Open Company Ltd., Document Number: P316. This information also appears in ISO/IEC
+     * 10646, Annex P.
+     *
+     * @return a Unicode string from the bytes message stream
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of bytes stream has been reached.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    String readUTF() throws JMSException;
+
+    /**
+     * Reads a byte array from the bytes message stream.
+     *
+     * <p>
+     * If the length of array {@code value} is less than the number of bytes remaining to be read from the stream, the array
+     * should be filled. A subsequent call reads the next increment, and so on.
+     *
+     * <p>
+     * If the number of bytes remaining in the stream is less than the length of array {@code value}, the bytes should be
+     * read into the array. The return value of the total number of bytes read will be less than the length of the array,
+     * indicating that there are no more bytes left to be read from the stream. The next read of the stream returns -1.
+     *
+     * @param value the buffer into which the data is read
+     *
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data because the end of the stream
+     * has been reached
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    int readBytes(byte[] value) throws JMSException;
+
+    /**
+     * Reads a portion of the bytes message stream.
+     *
+     * <p>
+     * If the length of array {@code value} is less than the number of bytes remaining to be read from the stream, the array
+     * should be filled. A subsequent call reads the next increment, and so on.
+     *
+     * <p>
+     * If the number of bytes remaining in the stream is less than the length of array {@code value}, the bytes should be
+     * read into the array. The return value of the total number of bytes read will be less than the length of the array,
+     * indicating that there are no more bytes left to be read from the stream. The next read of the stream returns -1.
+     *
+     * <p>
+     * If {@code length} is negative, or {@code length} is greater than the length of the array {@code value}, then an
+     * {@code IndexOutOfBoundsException} is thrown. No bytes will be read from the stream for this exception case.
+     *
+     * @param value the buffer into which the data is read
+     * @param length the number of bytes to read; must be less than or equal to {@code value.length}
+     *
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data because the end of the stream
+     * has been reached
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    int readBytes(byte[] value, int length) throws JMSException;
+
+    /**
+     * Writes a {@code boolean} to the bytes message stream as a 1-byte value. The value {@code true} is written as the
+     * value {@code (byte)1}; the value {@code false} is written as the value {@code (byte)0}.
+     *
+     * @param value the {@code boolean} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeBoolean(boolean value) throws JMSException;
+
+    /**
+     * Writes a {@code byte} to the bytes message stream as a 1-byte value.
+     *
+     * @param value the {@code byte} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeByte(byte value) throws JMSException;
+
+    /**
+     * Writes a {@code short} to the bytes message stream as two bytes, high byte first.
+     *
+     * @param value the {@code short} to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeShort(short value) throws JMSException;
+
+    /**
+     * Writes a {@code char} to the bytes message stream as a 2-byte value, high byte first.
+     *
+     * @param value the {@code char} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeChar(char value) throws JMSException;
+
+    /**
+     * Writes an {@code int} to the bytes message stream as four bytes, high byte first.
+     *
+     * @param value the {@code int} to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeInt(int value) throws JMSException;
+
+    /**
+     * Writes a {@code long} to the bytes message stream as eight bytes, high byte first.
+     *
+     * @param value the {@code long} to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeLong(long value) throws JMSException;
+
+    /**
+     * Converts the {@code float} argument to an {@code int} using the {@code floatToIntBits} method in class {@code Float},
+     * and then writes that {@code int} value to the bytes message stream as a 4-byte quantity, high byte first.
+     *
+     * @param value the {@code float} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeFloat(float value) throws JMSException;
+
+    /**
+     * Converts the {@code double} argument to a {@code long} using the {@code doubleToLongBits} method in class
+     * {@code Double}, and then writes that {@code long} value to the bytes message stream as an 8-byte quantity, high byte
+     * first.
+     *
+     * @param value the {@code double} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeDouble(double value) throws JMSException;
+
+    /**
+     * Writes a string to the bytes message stream using UTF-8 encoding in a machine-independent manner.
+     *
+     * <p>
+     * For more information on the UTF-8 format, see "File System Safe UCS Transformation Format (FSS_UTF)", X/Open
+     * Preliminary Specification, X/Open Company Ltd., Document Number: P316. This information also appears in ISO/IEC
+     * 10646, Annex P.
+     *
+     * @param value the {@code String} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeUTF(String value) throws JMSException;
+
+    /**
+     * Writes a byte array to the bytes message stream.
+     *
+     * @param value the byte array to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeBytes(byte[] value) throws JMSException;
+
+    /**
+     * Writes a portion of a byte array to the bytes message stream.
+     *
+     * @param value the byte array value to be written
+     * @param offset the initial offset within the byte array
+     * @param length the number of bytes to use
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeBytes(byte[] value, int offset, int length) throws JMSException;
+
+    /**
+     * Writes an object to the bytes message stream.
+     *
+     * <p>
+     * This method works only for the objectified primitive object types ({@code Integer}, {@code Double},
+     * {@code Long}&nbsp;...), {@code String} objects, and byte arrays.
+     *
+     * @param value the object in the Java programming language ("Java object") to be written; it must not be null
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageFormatException if the object is of an invalid type.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     * @exception java.lang.NullPointerException if the parameter {@code value} is null.
+     */
+    void writeObject(Object value) throws JMSException;
+
+    /**
+     * Puts the message body in read-only mode and repositions the stream of bytes to the beginning.
+     *
+     * @exception JMSException if the JMS provider fails to reset the message due to some internal error.
+     * @exception MessageFormatException if the message has an invalid format.
+     */
+    void reset() throws JMSException;
 }

--- a/src/main/java/javax/jms/ClientId.java
+++ b/src/main/java/javax/jms/ClientId.java
@@ -23,27 +23,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies that a callback method on a JMS message-driven bean
- * must use the specified client identifier.
+ * This annotation specifies that a callback method on a JMS message-driven bean must use the specified client
+ * identifier.
  * <p>
- * The method must also be annotated with either {@code TopicListener} or
- * {@code QueueListener}. If it is not then deployment will fail.
+ * The method must also be annotated with either {@code TopicListener} or {@code QueueListener}. If it is not then
+ * deployment will fail.
  * <p>
- * 
+ *
  * @see TopicListener
  * @see QueueListener
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
+ *
  */
 @Retention(RUNTIME)
 @Target({ METHOD })
 public @interface ClientId {
 
-	/**
-	 * The client identifier that will be used.
-	 */
-	String value();
+    /**
+     * The client identifier that will be used.
+     *
+     * @return The client identifier that will be used.
+     */
+    String value();
 
 }

--- a/src/main/java/javax/jms/CompletionListener.java
+++ b/src/main/java/javax/jms/CompletionListener.java
@@ -17,46 +17,41 @@
 package javax.jms;
 
 /**
- * A {@code CompletionListener} is implemented by the application and may
- * be specified when a message is sent asynchronously.
+ * A {@code CompletionListener} is implemented by the application and may be specified when a message is sent
+ * asynchronously.
+ *
  * <p>
- * When the sending of the message is complete, the JMS provider notifies the
- * application by calling the {@code onCompletion(Message)} method of the
- * specified completion listener. If the sending if the message fails for any
- * reason, and an exception cannot be thrown by the {@code send} method,
- * then the JMS provider calls the {@code onException(Exception)} method of
- * the specified completion listener.
- * 
+ * When the sending of the message is complete, the JMS provider notifies the application by calling the
+ * {@code onCompletion(Message)} method of the specified completion listener. If the sending if the message fails for
+ * any reason, and an exception cannot be thrown by the {@code send} method, then the JMS provider calls the
+ * {@code onException(Exception)} method of the specified completion listener.
+ *
  * @see javax.jms.MessageProducer#send(javax.jms.Message,int,int,long,javax.jms.CompletionListener)
  * @see javax.jms.MessageProducer#send(javax.jms.Destination,javax.jms.Message,javax.jms.CompletionListener)
  * @see javax.jms.MessageProducer#send(javax.jms.Destination,javax.jms.Message,int,int,long,javax.jms.CompletionListener)
  * @see javax.jms.JMSProducer#setAsync(javax.jms.CompletionListener)
  * @see javax.jms.JMSProducer#getAsync()
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  */
 public interface CompletionListener {
 
-	/**
-	 * Notifies the application that the message has been successfully sent
-	 * 
-	 * @param message
-	 *            the message that was sent.
-	 */
-	void onCompletion(Message message);
+    /**
+     * Notifies the application that the message has been successfully sent
+     *
+     * @param message the message that was sent.
+     */
+    void onCompletion(Message message);
 
-	/**
-	 * Notifies user that the specified exception was thrown while attempting to
-	 * send the specified message. If an exception occurs it is undefined
-	 * whether or not the message was successfully sent.
-	 * 
-	 * @param message
-	 *            the message that was sent.
-	 * @param exception
-	 *            the exception
-	 * 
-	 */
-	void onException(Message message, Exception exception);
+    /**
+     * Notifies user that the specified exception was thrown while attempting to send the specified message. If an exception
+     * occurs it is undefined whether or not the message was successfully sent.
+     *
+     * @param message the message that was sent.
+     * @param exception the exception
+     *
+     */
+    void onException(Message message, Exception exception);
 }

--- a/src/main/java/javax/jms/Connection.java
+++ b/src/main/java/javax/jms/Connection.java
@@ -16,835 +16,669 @@
 
 package javax.jms;
 
-/** A {@code Connection} object is a client's active connection to its JMS 
-  * provider. It typically allocates provider resources outside the Java virtual
-  * machine (JVM).
-  *
-  * <P>Connections support concurrent use.
-  *
-  * <P>A connection serves several purposes:
-  *
-  * <UL>
-  *   <LI>It encapsulates an open connection with a JMS provider. It 
-  *       typically represents an open TCP/IP socket between a client and 
-  *       the service provider software.
-  *   <LI>Its creation is where client authentication takes place.
-  *   <LI>It can specify a unique client identifier.
-  *   <LI>It provides a {@code ConnectionMetaData} object.
-  *   <LI>It supports an optional {@code ExceptionListener} object.
-  * </UL>
-  *
-  * <P>Because the creation of a connection involves setting up authentication 
-  * and communication, a connection is a relatively heavyweight 
-  * object. Most clients will do all their messaging with a single connection.
-  * Other more advanced applications may use several connections. The JMS API
-  * does 
-  * not architect a reason for using multiple connections; however, there may 
-  * be operational reasons for doing so.
-  *
-  * <P>A JMS client typically creates a connection, one or more sessions, 
-  * and a number of message producers and consumers. When a connection is
-  * created, it is in stopped mode. That means that no messages are being
-  * delivered.
-  *
-  * <P>It is typical to leave the connection in stopped mode until setup 
-  * is complete (that is, until all message consumers have been 
-  * created).  At that point, the client calls 
-  * the connection's {@code start} method, and messages begin arriving at 
-  * the connection's consumers. This setup
-  * convention minimizes any client confusion that may result from 
-  * asynchronous message delivery while the client is still in the process 
-  * of setting itself up.
-  *
-  * <P>A connection can be started immediately, and the setup can be done 
-  * afterwards. Clients that do this must be prepared to handle asynchronous 
-  * message delivery while they are still in the process of setting up.
-  *
-  * <P>A message producer can send messages while a connection is stopped.
-  * 
-  * @see         javax.jms.ConnectionFactory
-  * @see         javax.jms.QueueConnection
-  * @see         javax.jms.TopicConnection
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
+/**
+ * A {@code Connection} object is a client's active connection to its JMS provider. It typically allocates provider
+ * resources outside the Java virtual machine (JVM).
+ *
+ * <p>
+ * Connections support concurrent use.
+ *
+ * <p>
+ * A connection serves several purposes:
+ *
+ * <ul>
+ * <li>It encapsulates an open connection with a JMS provider. It typically represents an open TCP/IP socket between a
+ * client and the service provider software.
+ * <li>Its creation is where client authentication takes place.
+ * <li>It can specify a unique client identifier.
+ * <li>It provides a {@code ConnectionMetaData} object.
+ * <li>It supports an optional {@code ExceptionListener} object.
+ * </ul>
+ *
+ * <p>
+ * Because the creation of a connection involves setting up authentication and communication, a connection is a
+ * relatively heavyweight object. Most clients will do all their messaging with a single connection. Other more advanced
+ * applications may use several connections. The JMS API does not architect a reason for using multiple connections;
+ * however, there may be operational reasons for doing so.
+ *
+ * <p>
+ * A JMS client typically creates a connection, one or more sessions, and a number of message producers and consumers.
+ * When a connection is created, it is in stopped mode. That means that no messages are being delivered.
+ *
+ * <p>
+ * It is typical to leave the connection in stopped mode until setup is complete (that is, until all message consumers
+ * have been created). At that point, the client calls the connection's {@code start} method, and messages begin
+ * arriving at the connection's consumers. This setup convention minimizes any client confusion that may result from
+ * asynchronous message delivery while the client is still in the process of setting itself up.
+ *
+ * <p>
+ * A connection can be started immediately, and the setup can be done afterwards. Clients that do this must be prepared
+ * to handle asynchronous message delivery while they are still in the process of setting up.
+ *
+ * <p>
+ * A message producer can send messages while a connection is stopped.
+ *
+ * @see javax.jms.ConnectionFactory
+ * @see javax.jms.QueueConnection
+ * @see javax.jms.TopicConnection
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 
 public interface Connection extends AutoCloseable {
 
-    /** 
-     * Creates a {@code Session} object, 
-     * specifying {@code transacted} and {@code acknowledgeMode}.
+    /**
+     * Creates a {@code Session} object, specifying {@code transacted} and {@code acknowledgeMode}.
+     *
      * <p>
-     * This method has been superseded by the method {@code createSession(int sessionMode)}
-     * which specifies the same information using a single argument, 
-     * and by the method {@code createSession()} which is for use in a Java EE JTA transaction.
-     * Applications should consider using those methods instead of this one.
-     * <p> 
-     * The effect of setting the {@code transacted} and {@code acknowledgeMode} 
-     * arguments depends on whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * effect of setting the transacted} and {@code acknowledgeMode} 
-     * arguments also depends on whether or not there is an active JTA transaction 
-     * in progress.  
+     * This method has been superseded by the method {@code createSession(int sessionMode)} which specifies the same
+     * information using a single argument, and by the method {@code createSession()} which is for use in a Java EE JTA
+     * transaction. Applications should consider using those methods instead of this one.
+     *
+     * <p>
+     * The effect of setting the {@code transacted} and {@code acknowledgeMode} arguments depends on whether this method is
+     * called in a Java SE environment, in the Java EE application client container, or in the Java EE web or EJB container.
+     * If this method is called in the Java EE web or EJB container then the effect of setting the transacted} and
+     * {@code acknowledgeMode} arguments also depends on whether or not there is an active JTA transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
      * <ul>
-     * <li>If {@code transacted} is set to {@code true} then the session 
-     * will use a local transaction which may subsequently be committed or rolled back 
-     * by calling the session's {@code commit} or {@code rollback} methods. 
-     * The argument {@code acknowledgeMode} is ignored.
-     * <li>If {@code transacted} is set to {@code false} then the session 
-     * will be non-transacted. In this case the argument {@code acknowledgeMode}
-     * is used to specify how messages received by this session will be acknowledged.
-     * The permitted values are 
-     * {@code Session.CLIENT_ACKNOWLEDGE}, 
-     * {@code Session.AUTO_ACKNOWLEDGE} and
-     * {@code Session.DUPS_OK_ACKNOWLEDGE}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
+     * <li>If {@code transacted} is set to {@code true} then the session will use a local transaction which may subsequently
+     * be committed or rolled back by calling the session's {@code commit} or {@code rollback} methods. The argument
+     * {@code acknowledgeMode} is ignored.
+     * <li>If {@code transacted} is set to {@code false} then the session will be non-transacted. In this case the argument
+     * {@code acknowledgeMode} is used to specify how messages received by this session will be acknowledged. The permitted
+     * values are {@code Session.CLIENT_ACKNOWLEDGE}, {@code Session.AUTO_ACKNOWLEDGE} and
+     * {@code Session.DUPS_OK_ACKNOWLEDGE}. For a definition of the meaning of these acknowledgement modes see the links
+     * below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
      * <ul>
-     * <li>Both arguments {@code transacted} and {@code acknowledgeMode} are ignored.
-     * The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the session's {@code commit} or {@code rollback} methods.
-     * Since both arguments are ignored, developers are recommended to use 
-     * {@code createSession()}, which has no arguments, instead of this method.
+     * <li>Both arguments {@code transacted} and {@code acknowledgeMode} are ignored. The session will participate in the
+     * JTA transaction and will be committed or rolled back when that transaction is committed or rolled back, not by
+     * calling the session's {@code commit} or {@code rollback} methods. Since both arguments are ignored, developers are
+     * recommended to use {@code createSession()}, which has no arguments, instead of this method.
      * </ul>
+     *
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
      * <ul>
-     * <li>
-     * If {@code transacted} is set to false and {@code acknowledgeMode} is set to
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} then the
-     * session will be non-transacted and messages will be acknowledged according
-     * to the value of {@code acknowledgeMode}.
-     * <li>
-     * If {@code transacted} is set to false and {@code acknowledgeMode} is set to
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE} then the JMS provider is recommended to
-     * ignore the specified parameters and instead provide a non-transacted,
-     * auto-acknowledged session. However the JMS provider may alternatively
-     * provide a non-transacted session with client acknowledgement.
-     * <li>
-     * If {@code transacted} is set to true, then the JMS provider is recommended to
-     * ignore the specified parameters and instead provide a non-transacted,
-     * auto-acknowledged session. However the JMS provider may alternatively
-     * provide a local transacted session.
-     * <li>
-     * Applications are recommended to set {@code transacted} to false and
-     * {@code acknowledgeMode} to {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code Session.DUPS_OK_ACKNOWLEDGE} since since applications which set
-     * {@code transacted} to false and set {@code acknowledgeMode} to
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, or which set {@code transacted} 
-     * to true, may not be portable. 
-     * </ul> 
+     * <li>If {@code transacted} is set to false and {@code acknowledgeMode} is set to {@code JMSContext.AUTO_ACKNOWLEDGE}
+     * or {@code Session.DUPS_OK_ACKNOWLEDGE} then the session will be non-transacted and messages will be acknowledged
+     * according to the value of {@code acknowledgeMode}.
+     * <li>If {@code transacted} is set to false and {@code acknowledgeMode} is set to {@code JMSContext.CLIENT_ACKNOWLEDGE}
+     * then the JMS provider is recommended to ignore the specified parameters and instead provide a non-transacted,
+     * auto-acknowledged session. However the JMS provider may alternatively provide a non-transacted session with client
+     * acknowledgement.
+     * <li>If {@code transacted} is set to true, then the JMS provider is recommended to ignore the specified parameters and
+     * instead provide a non-transacted, auto-acknowledged session. However the JMS provider may alternatively provide a
+     * local transacted session.
+     * <li>Applications are recommended to set {@code transacted} to false and {@code acknowledgeMode} to
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} since since applications which set
+     * {@code transacted} to false and set {@code acknowledgeMode} to {@code JMSContext.CLIENT_ACKNOWLEDGE}, or which set
+     * {@code transacted} to true, may not be portable.
+     * </ul>
+     *
      * <p>
-     * Applications running in the Java EE web and EJB containers must not attempt 
-     * to create more than one active (not closed) {@code Session} object per connection. 
-     * If this method is called in a Java EE web or EJB container when an active
-     * {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
-     * 
-     * @param transacted indicates whether the session will use a local transaction,
-     * except in the cases described above when this value is ignored..
-     * 
-     * @param acknowledgeMode when transacted is false, indicates how messages received
-     * by the session will be acknowledged, except in the cases described above
-     * when this value is ignored.
-     * 
-     * @return a newly created  session
-     *  
-     * @exception JMSException if the {@code Connection} object fails
-     *                         to create a session due to 
-     *                         <ul>
-     *                         <li>some internal error, 
-     *                         <li>lack of support for the specific transaction and acknowledgement mode, or
-     *                         <li>because this method is being called in a Java EE web or EJB application 
-     *                         and an active session already exists for this connection.
-     *                         </ul>
+     * Applications running in the Java EE web and EJB containers must not attempt to create more than one active (not
+     * closed) {@code Session} object per connection. If this method is called in a Java EE web or EJB container when an
+     * active {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
+     *
+     * @param transacted indicates whether the session will use a local transaction, except in the cases described above
+     * when this value is ignored..
+     *
+     * @param acknowledgeMode when transacted is false, indicates how messages received by the session will be acknowledged,
+     * except in the cases described above when this value is ignored.
+     *
+     * @return a newly created session
+     *
+     * @exception JMSException if the {@code Connection} object fails to create a session due to
+     * <ul>
+     * <li>some internal error,
+     * <li>lack of support for the specific transaction and acknowledgement mode, or
+     * <li>because this method is being called in a Java EE web or EJB application and an active session already exists for
+     * this connection.
+     * </ul>
      * @since JMS 1.1
      *
-     * @see Session#AUTO_ACKNOWLEDGE 
-     * @see Session#CLIENT_ACKNOWLEDGE 
-     * @see Session#DUPS_OK_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.Connection#createSession(int) 
-     * @see javax.jms.Connection#createSession() 
-     */ 
-
+     * @see Session#AUTO_ACKNOWLEDGE
+     * @see Session#CLIENT_ACKNOWLEDGE
+     * @see Session#DUPS_OK_ACKNOWLEDGE
+     *
+     * @see javax.jms.Connection#createSession(int)
+     * @see javax.jms.Connection#createSession()
+     */
     Session createSession(boolean transacted, int acknowledgeMode) throws JMSException;
-    
-     /** 
+
+    /**
      * Creates a {@code Session} object, specifying {@code sessionMode}.
+     *
      * <p>
-     * The effect of setting the {@code sessionMode}  
-     * argument depends on whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * effect of setting the {@code sessionMode} argument also depends on 
-     * whether or not there is an active JTA transaction in progress. 
+     * The effect of setting the {@code sessionMode} argument depends on whether this method is called in a Java SE
+     * environment, in the Java EE application client container, or in the Java EE web or EJB container. If this method is
+     * called in the Java EE web or EJB container then the effect of setting the {@code sessionMode} argument also depends
+     * on whether or not there is an active JTA transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
      * <ul>
-     * <li>If {@code sessionMode} is set to {@code Session.SESSION_TRANSACTED} then the session 
-     * will use a local transaction which may subsequently be committed or rolled back 
-     * by calling the session's {@code commit} or {@code rollback} methods. 
-     * <li>If {@code sessionMode} is set to any of 
-     * {@code Session.CLIENT_ACKNOWLEDGE}, 
-     * {@code Session.AUTO_ACKNOWLEDGE} or
-     * {@code Session.DUPS_OK_ACKNOWLEDGE}.
-     * then the session will be non-transacted and 
-     * messages received by this session will be acknowledged
-     * according to the value of {@code sessionMode}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
+     * <li>If {@code sessionMode} is set to {@code Session.SESSION_TRANSACTED} then the session will use a local transaction
+     * which may subsequently be committed or rolled back by calling the session's {@code commit} or {@code rollback}
+     * methods.
+     * <li>If {@code sessionMode} is set to any of {@code Session.CLIENT_ACKNOWLEDGE}, {@code Session.AUTO_ACKNOWLEDGE} or
+     * {@code Session.DUPS_OK_ACKNOWLEDGE}. then the session will be non-transacted and messages received by this session
+     * will be acknowledged according to the value of {@code sessionMode}. For a definition of the meaning of these
+     * acknowledgement modes see the links below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
      * <ul>
-     * <li>The argument {@code sessionMode} is ignored.
-     * The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the session's {@code commit} or {@code rollback} methods.
-     * Since the argument is ignored, developers are recommended to use 
+     * <li>The argument {@code sessionMode} is ignored. The session will participate in the JTA transaction and will be
+     * committed or rolled back when that transaction is committed or rolled back, not by calling the session's
+     * {@code commit} or {@code rollback} methods. Since the argument is ignored, developers are recommended to use
      * {@code createSession()}, which has no arguments, instead of this method.
      * </ul>
+     *
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
      * <ul>
-     * <li>
-     * If {@code sessionMode} is set to {@code Session.AUTO_ACKNOWLEDGE} or
-     * {@code Session.DUPS_OK_ACKNOWLEDGE} then the session will be
-     * non-transacted and messages will be acknowledged according to the value
-     * of {@code sessionMode}. 
-     * <li>
-     * If {@code sessionMode} is set to {@code Session.CLIENT_ACKNOWLEDGE} then the JMS
-     * provider is recommended to ignore the specified parameter and instead
-     * provide a non-transacted, auto-acknowledged session. However the JMS
-     * provider may alternatively provide a non-transacted session with
-     * client acknowledgement.
-     * <li>
-     * If {@code sessionMode} is set to {@code Session.SESSION_TRANSACTED}, then the JMS
-     * provider is recommended to ignore the specified parameter and instead
-     * provide a non-transacted, auto-acknowledged session. However the JMS
-     * provider may alternatively provide a local transacted session. 
-     * <li>
-     * Applications are recommended to use only the values
-     * {@code Session.AUTO_ACKNOWLEDGE} and {@code Session.DUPS_OK_ACKNOWLEDGE}
-     * since applications which use {@code Session.CLIENT_ACKNOWLEDGE} or
+     * <li>If {@code sessionMode} is set to {@code Session.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} then the
+     * session will be non-transacted and messages will be acknowledged according to the value of {@code sessionMode}.
+     * <li>If {@code sessionMode} is set to {@code Session.CLIENT_ACKNOWLEDGE} then the JMS provider is recommended to
+     * ignore the specified parameter and instead provide a non-transacted, auto-acknowledged session. However the JMS
+     * provider may alternatively provide a non-transacted session with client acknowledgement.
+     * <li>If {@code sessionMode} is set to {@code Session.SESSION_TRANSACTED}, then the JMS provider is recommended to
+     * ignore the specified parameter and instead provide a non-transacted, auto-acknowledged session. However the JMS
+     * provider may alternatively provide a local transacted session.
+     * <li>Applications are recommended to use only the values {@code Session.AUTO_ACKNOWLEDGE} and
+     * {@code Session.DUPS_OK_ACKNOWLEDGE} since applications which use {@code Session.CLIENT_ACKNOWLEDGE} or
      * {@code Session.SESSION_TRANSACTED} may not be portable.
-     * </ul> 
+     * </ul>
+     *
      * <p>
-     * Applications running in the Java EE web and EJB containers must not attempt 
-     * to create more than one active (not closed) {@code Session} object per connection. 
-     * If this method is called in a Java EE web or EJB container when an active
-     * {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
-     * 
-     * @param sessionMode specifies the session mode that will be used, except in the
-     * cases described above when this value is ignored. Legal values are
-     * {@code JMSContext.SESSION_TRANSACTED}, {@code JMSContext.CLIENT_ACKNOWLEDGE},
+     * Applications running in the Java EE web and EJB containers must not attempt to create more than one active (not
+     * closed) {@code Session} object per connection. If this method is called in a Java EE web or EJB container when an
+     * active {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
+     *
+     * @param sessionMode specifies the session mode that will be used, except in the cases described above when this value
+     * is ignored. Legal values are {@code JMSContext.SESSION_TRANSACTED}, {@code JMSContext.CLIENT_ACKNOWLEDGE},
      * {@code JMSContext.AUTO_ACKNOWLEDGE} and {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * 
-     * @return a newly created  session
-     *  
-     * @exception JMSException if the {@code Connection} object fails
-     *                         to create a session due to 
-     *                         <ul>
-     *                         <li>some internal error, 
-     *                         <li>lack of support for the specific transaction and acknowledgement mode, or
-     *                         <li>because this method is being called in a Java EE web or EJB application 
-     *                         and an active session already exists for this connection.
-     *                         </ul>
+     *
+     * @return a newly created session
+     *
+     * @exception JMSException if the {@code Connection} object fails to create a session due to
+     * <ul>
+     * <li>some internal error,
+     * <li>lack of support for the specific transaction and acknowledgement mode, or
+     * <li>because this method is being called in a Java EE web or EJB application and an active session already exists for
+     * this connection.
+     * </ul>
      * @since JMS 2.0
      *
-     * @see Session#SESSION_TRANSACTED 
-     * @see Session#AUTO_ACKNOWLEDGE 
-     * @see Session#CLIENT_ACKNOWLEDGE 
-     * @see Session#DUPS_OK_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.Connection#createSession(boolean, int) 
-     * @see javax.jms.Connection#createSession() 
-     */   
+     * @see Session#SESSION_TRANSACTED
+     * @see Session#AUTO_ACKNOWLEDGE
+     * @see Session#CLIENT_ACKNOWLEDGE
+     * @see Session#DUPS_OK_ACKNOWLEDGE
+     *
+     * @see javax.jms.Connection#createSession(boolean, int)
+     * @see javax.jms.Connection#createSession()
+     */
     Session createSession(int sessionMode) throws JMSException;
-                       
-    /** 
-     * Creates a {@code Session} object, 
-     * specifying no arguments.
+
+    /**
+     * Creates a {@code Session} object, specifying no arguments.
+     *
      * <p>
-     * The behaviour of the session that is created depends on 
-     * whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * behaviour of the session also depends on whether or not 
-     * there is an active JTA transaction in progress.   
+     * The behaviour of the session that is created depends on whether this method is called in a Java SE environment, in
+     * the Java EE application client container, or in the Java EE web or EJB container. If this method is called in the
+     * Java EE web or EJB container then the behaviour of the session also depends on whether or not there is an active JTA
+     * transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
      * <ul>
-     * <li>The session will be non-transacted and received messages will be acknowledged automatically
-     * using an acknowledgement mode of {@code Session.AUTO_ACKNOWLEDGE} 
-     * For a definition of the meaning of this acknowledgement mode see the link below.
+     * <li>The session will be non-transacted and received messages will be acknowledged automatically using an
+     * acknowledgement mode of {@code Session.AUTO_ACKNOWLEDGE} For a definition of the meaning of this acknowledgement mode
+     * see the link below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
      * <ul>
-     * <li>The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the session's {@code commit} or {@code rollback} methods.
+     * <li>The session will participate in the JTA transaction and will be committed or rolled back when that transaction is
+     * committed or rolled back, not by calling the session's {@code commit} or {@code rollback} methods.
      * </ul>
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
      * <ul>
-     * <li>The session will be non-transacted and received messages will be acknowledged automatically
-     * using an acknowledgement mode of {@code Session.AUTO_ACKNOWLEDGE} 
-     * For a definition of the meaning of this acknowledgement mode see the link below.
-     * </ul> 
+     * <li>The session will be non-transacted and received messages will be acknowledged automatically using an
+     * acknowledgement mode of {@code Session.AUTO_ACKNOWLEDGE} For a definition of the meaning of this acknowledgement mode
+     * see the link below.
+     * </ul>
+     *
      * <p>
-     * Applications running in the Java EE web and EJB containers must not attempt 
-     * to create more than one active (not closed) {@code Session} object per connection. 
-     * If this method is called in a Java EE web or EJB container when an active
-     * {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
-     * 
-     * @return a newly created  session
-     *  
-     * @exception JMSException if the {@code Connection} object fails
-     *                         to create a session due to 
-     *                         <ul>
-     *                         <li>some internal error or  
-     *                         <li>because this method is being called in a Java EE web or EJB application 
-     *                         and an active session already exists for this connection.
-     *                         </ul>
-     *                       
+     * Applications running in the Java EE web and EJB containers must not attempt to create more than one active (not
+     * closed) {@code Session} object per connection. If this method is called in a Java EE web or EJB container when an
+     * active {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
+     *
+     * @return a newly created session
+     *
+     * @exception JMSException if the {@code Connection} object fails to create a session due to
+     * <ul>
+     * <li>some internal error or
+     * <li>because this method is being called in a Java EE web or EJB application and an active session already exists for
+     * this connection.
+     * </ul>
+     *
      * @since JMS 2.0
      *
-     * @see Session#AUTO_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.Connection#createSession(boolean, int) 
-     * @see javax.jms.Connection#createSession(int) 
-     */ 
-
-    Session createSession() throws JMSException;    
-    
-    
-    /** Gets the client identifier for this connection.
-      *  
-      * <P>This value is specific to the JMS provider.  It is either preconfigured 
-      * by an administrator in a {@code ConnectionFactory} object
-      * or assigned dynamically by the application by calling the
-      * {@code setClientID} method.
-      * 
-      * 
-      * @return the unique client identifier
-      *  
-      * @exception JMSException if the JMS provider fails to return
-      *                         the client ID for this connection due
-      *                         to some internal error.
-      *
-      **/
-    String
-    getClientID() throws JMSException;
-
-
-    /** Sets the client identifier for this connection.
-     *  
-     * <P>The preferred way to assign a JMS client's client identifier is for
-     * it to be configured in a client-specific {@code ConnectionFactory}
-     * object and transparently assigned to the {@code Connection} object
-     * it creates.
-     * 
-     * <P>Alternatively, a client can set a connection's client identifier
-     * using a provider-specific value. The facility to set a connection's
-     * client identifier explicitly is not a mechanism for overriding the
-     * identifier that has been administratively configured. It is provided
-     * for the case where no administratively specified identifier exists.
-     * If one does exist, an attempt to change it by setting it must throw an
-     * {@code IllegalStateException}. If a client sets the client identifier
-     * explicitly, it must do so immediately after it creates the connection 
-     * and before any other
-     * action on the connection is taken. After this point, setting the
-     * client identifier is a programming error that should throw an
-     * {@code IllegalStateException}.
+     * @see Session#AUTO_ACKNOWLEDGE
      *
-     * <P>The purpose of the client identifier is to associate a connection and
-     * its objects with a state maintained on behalf of the client by a 
-     * provider. The only such state identified by the JMS API is that required
-     * to support durable subscriptions.
+     * @see javax.jms.Connection#createSession(boolean, int)
+     * @see javax.jms.Connection#createSession(int)
+     */
+    Session createSession() throws JMSException;
+
+    /**
+     * Gets the client identifier for this connection.
      *
-     * <P>If another connection with the same {@code clientID} is already running when
-     * this method is called, the JMS provider should detect the duplicate ID and throw
-     * an {@code InvalidClientIDException}.
      * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSException} to be thrown though this is not guaranteed.
-     * 
+     * This value is specific to the JMS provider. It is either preconfigured by an administrator in a
+     * {@code ConnectionFactory} object or assigned dynamically by the application by calling the {@code setClientID}
+     * method.
+     *
+     *
+     * @return the unique client identifier
+     *
+     * @exception JMSException if the JMS provider fails to return the client ID for this connection due to some internal
+     * error.
+     *
+     **/
+    String getClientID() throws JMSException;
+
+    /**
+     * Sets the client identifier for this connection.
+     *
+     * <p>
+     * The preferred way to assign a JMS client's client identifier is for it to be configured in a client-specific
+     * {@code ConnectionFactory} object and transparently assigned to the {@code Connection} object it creates.
+     *
+     * <p>
+     * Alternatively, a client can set a connection's client identifier using a provider-specific value. The facility to set
+     * a connection's client identifier explicitly is not a mechanism for overriding the identifier that has been
+     * administratively configured. It is provided for the case where no administratively specified identifier exists. If
+     * one does exist, an attempt to change it by setting it must throw an {@code IllegalStateException}. If a client sets
+     * the client identifier explicitly, it must do so immediately after it creates the connection and before any other
+     * action on the connection is taken. After this point, setting the client identifier is a programming error that should
+     * throw an {@code IllegalStateException}.
+     *
+     * <p>
+     * The purpose of the client identifier is to associate a connection and its objects with a state maintained on behalf
+     * of the client by a provider. The only such state identified by the JMS API is that required to support durable
+     * subscriptions.
+     *
+     * <p>
+     * If another connection with the same {@code clientID} is already running when this method is called, the JMS provider
+     * should detect the duplicate ID and throw an {@code InvalidClientIDException}.
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
      * @param clientID the unique client identifier
-     * 
-     * @exception JMSException if the JMS provider fails to set the client ID for the the connection
-     *                         for one of the following reasons:
-     *                         <ul>
-     *                         <li>an internal error has occurred or  
-     *                         <li>this method has been called in a Java EE web or EJB application 
-     *                         (though it is not guaranteed that an exception is thrown in this case)
-     *                         </ul>  
-     * @exception InvalidClientIDException if the JMS client specifies an
-     *                         invalid or duplicate client ID.
-     * @exception IllegalStateException if the JMS client attempts to set
-     *       a connection's client ID at the wrong time or
-     *       when it has been administratively configured.
+     *
+     * @exception JMSException if the JMS provider fails to set the client ID for the the connection for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     * @exception InvalidClientIDException if the JMS client specifies an invalid or duplicate client ID.
+     * @exception IllegalStateException if the JMS client attempts to set a connection's client ID at the wrong time or when
+     * it has been administratively configured.
      */
     void setClientID(String clientID) throws JMSException;
 
- 
-    /** Gets the metadata for this connection.
-      *  
-      * @return the connection metadata
-      *  
-      * @exception JMSException if the JMS provider fails to
-      *                         get the connection metadata for this connection.
-      *
-      * @see javax.jms.ConnectionMetaData
-      */
-
-    ConnectionMetaData
-    getMetaData() throws JMSException;
+    /**
+     * Gets the metadata for this connection.
+     *
+     * @return the connection metadata
+     *
+     * @exception JMSException if the JMS provider fails to get the connection metadata for this connection.
+     *
+     * @see javax.jms.ConnectionMetaData
+     */
+    ConnectionMetaData getMetaData() throws JMSException;
 
     /**
-     * Gets the {@code ExceptionListener} object for this connection. 
-     * Not every {@code Connection} has an {@code ExceptionListener}
-     * associated with it.
+     * Gets the {@code ExceptionListener} object for this connection. Not every {@code Connection} has an
+     * {@code ExceptionListener} associated with it.
      *
-     * @return the {@code ExceptionListener} for this connection, or null. 
-     *              if no {@code ExceptionListener} is associated
-     *              with this connection.
+     * @return the {@code ExceptionListener} for this connection, or null. if no {@code ExceptionListener} is associated
+     * with this connection.
      *
-     * @exception JMSException if the JMS provider fails to
-     *                         get the {@code ExceptionListener} for this 
-     *                         connection. 
+     * @exception JMSException if the JMS provider fails to get the {@code ExceptionListener} for this connection.
      * @see javax.jms.Connection#setExceptionListener
      */
+    ExceptionListener getExceptionListener() throws JMSException;
 
-    ExceptionListener 
-    getExceptionListener() throws JMSException;
-
-
-    /** Sets an exception listener for this connection.
-      *
-      * <P>If a JMS provider detects a serious problem with a connection, it
-      * informs the connection's {@code ExceptionListener}, if one has been
-      * registered. It does this by calling the listener's
-      * {@code onException} method, passing it a {@code JMSException}
-      * object describing the problem.
-      *
-      * <P>An exception listener allows a client to be notified of a problem
-      * asynchronously.
-      * Some connections only consume messages, so they would have no other 
-      * way to learn their connection has failed.
-      *
-      * <P>A connection serializes execution of its
-      * {@code ExceptionListener}.
-      *
-      * <P>A JMS provider should attempt to resolve connection problems 
-      * itself before it notifies the client of them.
-     * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSException} to be thrown though this is not guaranteed.
-     * 
-      * @param listener the exception listener
-      *
-     * @exception JMSException if the JMS provider fails to set the exception listener
-     *                         for one of the following reasons:
-     *                         <ul>
-     *                         <li>an internal error has occurred or  
-     *                         <li>this method has been called in a Java EE web or EJB application 
-     *                         (though it is not guaranteed that an exception is thrown in this case)
-     *                         </ul> 
-      *
-      *
-      */
-
-    void 
-    setExceptionListener(ExceptionListener listener) throws JMSException;
-
-    /** Starts (or restarts) a connection's delivery of incoming messages.
-      * A call to {@code start} on a connection that has already been
-      * started is ignored.
-      * 
-      * @exception JMSException if the JMS provider fails to start
-      *                         message delivery due to some internal error.
-      *
-      * @see javax.jms.Connection#stop
-      */
-
-    void
-    start() throws JMSException;
-
- 
     /**
-	 * Temporarily stops a connection's delivery of incoming messages. Delivery
-	 * can be restarted using the connection's {@code start} method. When
-	 * the connection is stopped, delivery to all the connection's message
-	 * consumers is inhibited: synchronous receives block, and messages are not
-	 * delivered to message listeners.
-	 * 
-	 * <P>
-	 * Stopping a connection has no effect on its ability to send messages. A
-	 * call to {@code stop} on a connection that has already been stopped
-	 * is ignored.
-	 * 
-	 * <P>
-	 * A call to {@code stop} must not return until delivery of messages
-	 * has paused. This means that a client can rely on the fact that none of
-	 * its message listeners will be called and that all threads of control
-	 * waiting for {@code receive} calls to return will not return with a
-	 * message until the connection is restarted. The receive timers for a
-	 * stopped connection continue to advance, so receives may time out while
-	 * the connection is stopped.
-	 * 
-	 * <P>
-	 * If message listeners are running when {@code stop} is invoked, the
-	 * {@code stop} call must wait until all of them have returned before
-	 * it may return. While these message listeners are completing, they must
-	 * have the full services of the connection available to them.
-	 * <p>
-	 * However if the {@code stop} method is called from a message listener on its own
-	 * connection, then it will either fail and throw a
-	 * {@code javax.jms.IllegalStateException}, or it will succeed and stop the connection,
-	 * blocking until all other message listeners that may have been running have
-	 * returned.
-	 * <p>
-	 * Since two alternative behaviors are permitted in this case, applications
-	 * should avoid calling {@code stop} from a message listener on its own
-	 * Connection because this is not portable.
-	 * <p>
-	 * For the avoidance of doubt, if an exception listener for this connection
-	 * is running when {@code stop} is invoked, there is no requirement for
-	 * the {@code stop} call to wait until the exception listener has
-	 * returned before it may return.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSException} to be thrown though this is not
-	 * guaranteed.
-	 * 
-	 * @exception IllegalStateException
-	 *                this method has been called by a <tt>MessageListener</tt>
-	 *                on its own <tt>Connection</tt>
-	 * @exception JMSException
-	 *                if the JMS provider fails to stop message delivery for one
-	 *                of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred or <li>this method has
-	 *                been called in a Java EE web or EJB application (though it
-	 *                is not guaranteed that an exception is thrown in this
-	 *                case)
-	 *                </ul>
-	 * 
-	 * @see javax.jms.Connection#start
-	 */
+     * Sets an exception listener for this connection.
+     *
+     * <p>
+     * If a JMS provider detects a serious problem with a connection, it informs the connection's {@code ExceptionListener},
+     * if one has been registered. It does this by calling the listener's {@code onException} method, passing it a
+     * {@code JMSException} object describing the problem.
+     *
+     * <p>
+     * An exception listener allows a client to be notified of a problem asynchronously. Some connections only consume
+     * messages, so they would have no other way to learn their connection has failed.
+     *
+     * <p>
+     * A connection serializes execution of its {@code ExceptionListener}.
+     *
+     * <p>
+     * A JMS provider should attempt to resolve connection problems itself before it notifies the client of them.
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @param listener the exception listener
+     *
+     * @exception JMSException if the JMS provider fails to set the exception listener for one of the following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     *
+     */
+    void setExceptionListener(ExceptionListener listener) throws JMSException;
 
-    void
-    stop() throws JMSException;
+    /**
+     * Starts (or restarts) a connection's delivery of incoming messages. A call to {@code start} on a connection that has
+     * already been started is ignored.
+     *
+     * @exception JMSException if the JMS provider fails to start message delivery due to some internal error.
+     *
+     * @see javax.jms.Connection#stop
+     */
+    void start() throws JMSException;
 
- 
-    /** Closes the connection.
-      *
-      * <P>Since a provider typically allocates significant resources outside 
-      * the JVM on behalf of a connection, clients should close these resources
-      * when they are not needed. Relying on garbage collection to eventually 
-      * reclaim these resources may not be timely enough.
-      *
-      * <P>There is no need to close the sessions, producers, and consumers
-      * of a closed connection.
-      *
-      * <P>Closing a connection causes all temporary destinations to be
-      * deleted.
-      *
-      * <P>When this method is invoked, it should not return until message
-      * processing has been shut down in an orderly fashion. This means that all
-      * message 
-      * listeners that may have been running have returned, and that all pending 
-      * receives have returned. 
-      * 
-      * <p>However if the close method is called from a message listener on its own
-      * connection, then it will either fail and throw a
-      * {@code javax.jms.IllegalStateException}, or it will succeed and close the connection,
-      * blocking until all other message listeners that may have been running have
-      * returned, and all pending receive calls have completed. If close succeeds and
-      * the acknowledge mode of the session is set to {@code AUTO_ACKNOWLEDGE}, the current
-      * message will still be acknowledged automatically when the {@code onMessage} call
-      * completes.
-      * Since two alternative behaviors are permitted in this case, applications
-      * should avoid calling close from a message listener on its own
-      * connection because this is not portable.
-      * 
-      * <p>A close terminates all pending message receives 
-      * on the connection's sessions' consumers. The receives may return with a 
-      * message or with null, depending on whether there was a message available 
-      * at the time of the close. If one or more of the connection's sessions' 
-      * message listeners is processing a message at the time when connection 
-      * {@code close} is invoked, all the facilities of the connection and 
-      * its sessions must remain available to those listeners until they return 
-      * control to the JMS provider. 
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>Connection</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-      * For the avoidance of doubt, if an exception listener for this connection 
-      * is running when {@code close} is invoked, there is no requirement for 
-      * the {@code close} call to wait until the exception listener has returned
-      * before it may return. 
-      * 
-      * <P>Closing a connection causes any of its sessions' transactions
-      * in progress to be rolled back. In the case where a session's
-      * work is coordinated by an external transaction manager, a session's 
-      * {@code commit} and {@code rollback} methods are
-      * not used and the result of a closed session's work is determined
-      * later by the transaction manager.
-      * Closing a connection does NOT force an 
-      * acknowledgment of client-acknowledged sessions.  
-	  * <p>
- 	  * A <tt>CompletionListener</tt> callback method must not call
- 	  * <tt>close</tt> on its own <tt>Connection</tt>. Doing so will cause an
-  	  * <tt>IllegalStateException</tt> to be thrown.
-	  * <p>
-      * Invoking the {@code acknowledge} method of a received message 
-      * from a closed connection's session must throw an 
-      * {@code IllegalStateException}.  Closing a closed connection must 
-      * NOT throw an exception.
-      * 
-	  * @exception IllegalStateException
-	  *                <ul>
-	  *                <li>this method has been called by a <tt>MessageListener
-	  *                </tt> on its own <tt>Connection</tt></li> 
-	  *                <li>this method has
-	  *                been called by a <tt>CompletionListener</tt> callback
-	  *                method on its own <tt>Connection</tt></li>
-	  *                </ul>
-      * @exception JMSException if the JMS provider fails to close the
-      *                         connection due to some internal error. For 
-      *                         example, a failure to release resources
-      *                         or to close a socket connection can cause
-      *                         this exception to be thrown.
-      *                         
-      */
+    /**
+     * Temporarily stops a connection's delivery of incoming messages. Delivery can be restarted using the connection's
+     * {@code start} method. When the connection is stopped, delivery to all the connection's message consumers is
+     * inhibited: synchronous receives block, and messages are not delivered to message listeners.
+     *
+     * <p>
+     * Stopping a connection has no effect on its ability to send messages. A call to {@code stop} on a connection that has
+     * already been stopped is ignored.
+     *
+     * <p>
+     * A call to {@code stop} must not return until delivery of messages has paused. This means that a client can rely on
+     * the fact that none of its message listeners will be called and that all threads of control waiting for
+     * {@code receive} calls to return will not return with a message until the connection is restarted. The receive timers
+     * for a stopped connection continue to advance, so receives may time out while the connection is stopped.
+     *
+     * <p>
+     * If message listeners are running when {@code stop} is invoked, the {@code stop} call must wait until all of them have
+     * returned before it may return. While these message listeners are completing, they must have the full services of the
+     * connection available to them.
+     * <p>
+     * However if the {@code stop} method is called from a message listener on its own connection, then it will either fail
+     * and throw a {@code javax.jms.IllegalStateException}, or it will succeed and stop the connection, blocking until all
+     * other message listeners that may have been running have returned.
+     * <p>
+     * Since two alternative behaviors are permitted in this case, applications should avoid calling {@code stop} from a
+     * message listener on its own Connection because this is not portable.
+     * <p>
+     * For the avoidance of doubt, if an exception listener for this connection is running when {@code stop} is invoked,
+     * there is no requirement for the {@code stop} call to wait until the exception listener has returned before it may
+     * return.
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @exception IllegalStateException this method has been called by a <tt>MessageListener</tt> on its own
+     * <tt>Connection</tt>
+     * @exception JMSException if the JMS provider fails to stop message delivery for one of the following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @see javax.jms.Connection#start
+     */
+    void stop() throws JMSException;
 
-    void 
-    close() throws JMSException; 
-    
-	/**
-	 * Creates a connection consumer for this connection (optional operation)
-	 * on the specific destination.
-	 * <p>
-	 * This is an expert facility not used by ordinary JMS clients.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSException} to be thrown though this is not
-	 * guaranteed.
-	 * 
-	 * @param destination
-	 *            the destination to access
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the message
-	 *            consumer.
-	 * @param sessionPool
-	 *            the server session pool to associate with this connection
-	 *            consumer
-	 * @param maxMessages
-	 *            the maximum number of messages that can be assigned to a
-	 *            server session at one time
-	 * 
-	 * @return the connection consumer
-	 * 
-	 * @exception InvalidDestinationException
-	 *                if an invalid destination is specified.
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * @exception JMSException
-	 *                if the {@code Connection} object fails to create a
-	 *                connection consumer for one of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred 
-	 *                <li>invalid arguments for {@code sessionPool} and 
-	 *                {@code messageSelector} or 
-	 *                <li>this method has been called in a Java EE web or EJB
-	 *                application (though it is not guaranteed that an exception
-	 *                is thrown in this case)
-	 *                </ul>
-	 * 
-	 * @since JMS 1.1
-	 * 
-	 * @see javax.jms.ConnectionConsumer
-	 */
-	ConnectionConsumer createConnectionConsumer(Destination destination,
-			String messageSelector, ServerSessionPool sessionPool,
-			int maxMessages) throws JMSException;
-	
-	/**
-	 * Creates a connection consumer for this connection (optional operation)
-	 * on the specific topic using a shared non-durable subscription with
-	 * the specified name.
-	 * <p>
-	 * This is an expert facility not used by ordinary JMS clients.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSException} to be thrown though this is not
-	 * guaranteed.
-	 * 
-	 * @param topic
-	 *            the topic to access
-	 * @param subscriptionName
-	 *            the name used to identify the shared non-durable subscription
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the message
-	 *            consumer.
-	 * @param sessionPool
-	 *            the server session pool to associate with this connection
-	 *            consumer
-	 * @param maxMessages
-	 *            the maximum number of messages that can be assigned to a
-	 *            server session at one time
-	 * 
-	 * @return the connection consumer
-	 * 
-	 * @exception IllegalStateException
-	 *                if called on a {@code QueueConnection}
-	 * @exception InvalidDestinationException
-	 *                if an invalid destination is specified.
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * @exception JMSException
-	 *                if the {@code Connection} object fails to create a
-	 *                connection consumer for one of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred 
-	 *                <li>invalid arguments for {@code sessionPool} and 
-	 *                {@code messageSelector} or 
-	 *                <li>this method has been called in a Java EE web or EJB
-	 *                application (though it is not guaranteed that an exception
-	 *                is thrown in this case)
-	 *                </ul>
-	 * 
-	 * @since JMS 2.0
-	 * 
-	 * @see javax.jms.ConnectionConsumer
-	 */
-	ConnectionConsumer createSharedConnectionConsumer(Topic topic,
-			String subscriptionName,
-			String messageSelector, ServerSessionPool sessionPool,
-			int maxMessages) throws JMSException;
+    /**
+     * Closes the connection.
+     *
+     * <p>
+     * Since a provider typically allocates significant resources outside the JVM on behalf of a connection, clients should
+     * close these resources when they are not needed. Relying on garbage collection to eventually reclaim these resources
+     * may not be timely enough.
+     *
+     * <p>
+     * There is no need to close the sessions, producers, and consumers of a closed connection.
+     *
+     * <p>
+     * Closing a connection causes all temporary destinations to be deleted.
+     *
+     * <p>
+     * When this method is invoked, it should not return until message processing has been shut down in an orderly fashion.
+     * This means that all message listeners that may have been running have returned, and that all pending receives have
+     * returned.
+     *
+     * <p>
+     * However if the close method is called from a message listener on its own connection, then it will either fail and
+     * throw a {@code javax.jms.IllegalStateException}, or it will succeed and close the connection, blocking until all
+     * other message listeners that may have been running have returned, and all pending receive calls have completed. If
+     * close succeeds and the acknowledge mode of the session is set to {@code AUTO_ACKNOWLEDGE}, the current message will
+     * still be acknowledged automatically when the {@code onMessage} call completes. Since two alternative behaviors are
+     * permitted in this case, applications should avoid calling close from a message listener on its own connection because
+     * this is not portable.
+     *
+     * <p>
+     * A close terminates all pending message receives on the connection's sessions' consumers. The receives may return with
+     * a message or with null, depending on whether there was a message available at the time of the close. If one or more
+     * of the connection's sessions' message listeners is processing a message at the time when connection {@code close} is
+     * invoked, all the facilities of the connection and its sessions must remain available to those listeners until they
+     * return control to the JMS provider.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>Connection</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * For the avoidance of doubt, if an exception listener for this connection is running when {@code close} is invoked,
+     * there is no requirement for the {@code close} call to wait until the exception listener has returned before it may
+     * return.
+     *
+     * <p>
+     * Closing a connection causes any of its sessions' transactions in progress to be rolled back. In the case where a
+     * session's work is coordinated by an external transaction manager, a session's {@code commit} and {@code rollback}
+     * methods are not used and the result of a closed session's work is determined later by the transaction manager.
+     * Closing a connection does NOT force an acknowledgment of client-acknowledged sessions.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>Connection</tt>. Doing so
+     * will cause an <tt>IllegalStateException</tt> to be thrown.
+     * <p>
+     * Invoking the {@code acknowledge} method of a received message from a closed connection's session must throw an
+     * {@code IllegalStateException}. Closing a closed connection must NOT throw an exception.
+     *
+     * @exception IllegalStateException
+     * <ul>
+     * <li>this method has been called by a <tt>MessageListener
+     *                </tt> on its own <tt>Connection</tt></li>
+     * <li>this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>Connection</tt></li>
+     * </ul>
+     * @exception JMSException if the JMS provider fails to close the connection due to some internal error. For example, a
+     * failure to release resources or to close a socket connection can cause this exception to be thrown.
+     *
+     */
+    @Override
+    void close() throws JMSException;
 
+    /**
+     * Creates a connection consumer for this connection (optional operation) on the specific destination.
+     *
+     * <p>
+     * This is an expert facility not used by ordinary JMS clients.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @param destination the destination to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the connection consumer
+     *
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception JMSException if the {@code Connection} object fails to create a connection consumer for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred
+     * <li>invalid arguments for {@code sessionPool} and {@code messageSelector} or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @since JMS 1.1
+     *
+     * @see javax.jms.ConnectionConsumer
+     */
+    ConnectionConsumer createConnectionConsumer(Destination destination, String messageSelector, ServerSessionPool sessionPool, int maxMessages)
+            throws JMSException;
 
-	/**
-	 * Creates a connection consumer for this connection (optional operation)
-	 * on the specific topic using an unshared durable subscription with
-	 * the specified name.
-	 * <p>
-	 * This is an expert facility not used by ordinary JMS clients.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSException} to be thrown though this is not
-	 * guaranteed.
-	 * 
-	 * @param topic
-	 *            topic to access
-	 * @param subscriptionName
-	 *            the name used to identify the unshared durable subscription
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the message
-	 *            consumer.
-	 * @param sessionPool
-	 *            the server session pool to associate with this durable
-	 *            connection consumer
-	 * @param maxMessages
-	 *            the maximum number of messages that can be assigned to a
-	 *            server session at one time
-	 * 
-	 * @return the durable connection consumer
-	 * 
-	 * @exception IllegalStateException
-	 *                if called on a {@code QueueConnection}
-	 * @exception InvalidDestinationException
-	 *                if an invalid destination is specified.
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * @exception JMSException
-	 *                if the {@code Connection} object fails to create a
-	 *                connection consumer for one of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred 
-	 *                <li>invalid arguments
-	 *                for {@code sessionPool} and {@code messageSelector} or 
-	 *                <li>this method has been called in a Java EE web or EJB
-	 *                application (though it is not guaranteed that an exception
-	 *                is thrown in this case)
-	 *                </ul>
-	 * @since JMS 1.1
-	 * 
-	 * @see javax.jms.ConnectionConsumer
-	 */
-	ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector,
-			ServerSessionPool sessionPool, int maxMessages) throws JMSException;
-	
-	/**
-	 * Creates a connection consumer for this connection (optional operation)
-	 * on the specific topic using a shared durable subscription with
-	 * the specified name.
-	 * <p>
-	 * This is an expert facility not used by ordinary JMS clients.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSException} to be thrown though this is not
-	 * guaranteed.
-	 * 
-	 * @param topic
-	 *            topic to access
-	 * @param subscriptionName
-	 *            the name used to identify the shared durable subscription 
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the message
-	 *            consumer.
-	 * @param sessionPool
-	 *            the server session pool to associate with this durable
-	 *            connection consumer
-	 * @param maxMessages
-	 *            the maximum number of messages that can be assigned to a
-	 *            server session at one time
-	 * 
-	 * @return the durable connection consumer
-	 * 
-	 * @exception IllegalStateException
-	 *                if called on a {@code QueueConnection}
-	 * @exception InvalidDestinationException
-	 *                if an invalid destination is specified.
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * @exception JMSException
-	 *                if the {@code Connection} object fails to create a
-	 *                connection consumer for one of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred 
-	 *                <li>invalid arguments
-	 *                for {@code sessionPool} and {@code messageSelector} or 
-	 *                <li>this method has been called in a Java EE web or EJB
-	 *                application (though it is not guaranteed that an exception
-	 *                is thrown in this case)
-	 *                </ul>
-	 * @since JMS 2.0
-	 * 
-	 * @see javax.jms.ConnectionConsumer
-	 */
-	ConnectionConsumer createSharedDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector,
-			ServerSessionPool sessionPool, int maxMessages) throws JMSException;
-          
+    /**
+     * Creates a connection consumer for this connection (optional operation) on the specific topic using a shared
+     * non-durable subscription with the specified name.
+     *
+     * <p>
+     * This is an expert facility not used by ordinary JMS clients.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @param topic the topic to access
+     * @param subscriptionName the name used to identify the shared non-durable subscription
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the connection consumer
+     *
+     * @exception IllegalStateException if called on a {@code QueueConnection}
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception JMSException if the {@code Connection} object fails to create a connection consumer for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred
+     * <li>invalid arguments for {@code sessionPool} and {@code messageSelector} or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @since JMS 2.0
+     *
+     * @see javax.jms.ConnectionConsumer
+     */
+    ConnectionConsumer createSharedConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool,
+            int maxMessages) throws JMSException;
+
+    /**
+     * Creates a connection consumer for this connection (optional operation) on the specific topic using an unshared
+     * durable subscription with the specified name.
+     *
+     * <p>
+     * This is an expert facility not used by ordinary JMS clients.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @param topic topic to access
+     * @param subscriptionName the name used to identify the unshared durable subscription
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this durable connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the durable connection consumer
+     *
+     * @exception IllegalStateException if called on a {@code QueueConnection}
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception JMSException if the {@code Connection} object fails to create a connection consumer for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred
+     * <li>invalid arguments for {@code sessionPool} and {@code messageSelector} or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     * @since JMS 1.1
+     *
+     * @see javax.jms.ConnectionConsumer
+     */
+    ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool,
+            int maxMessages) throws JMSException;
+
+    /**
+     * Creates a connection consumer for this connection (optional operation) on the specific topic using a shared durable
+     * subscription with the specified name.
+     *
+     * <p>
+     * This is an expert facility not used by ordinary JMS clients.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @param topic topic to access
+     * @param subscriptionName the name used to identify the shared durable subscription
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this durable connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the durable connection consumer
+     *
+     * @exception IllegalStateException if called on a {@code QueueConnection}
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception JMSException if the {@code Connection} object fails to create a connection consumer for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred
+     * <li>invalid arguments for {@code sessionPool} and {@code messageSelector} or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     * @since JMS 2.0
+     *
+     * @see javax.jms.ConnectionConsumer
+     */
+    ConnectionConsumer createSharedDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool,
+            int maxMessages) throws JMSException;
+
 }
-

--- a/src/main/java/javax/jms/ConnectionConsumer.java
+++ b/src/main/java/javax/jms/ConnectionConsumer.java
@@ -16,62 +16,51 @@
 
 package javax.jms;
 
-/** For application servers, {@code Connection} objects provide a special 
-  * facility 
-  * for creating a {@code ConnectionConsumer} (optional). The messages it 
-  * is to consume are 
-  * specified by a {@code Destination} and a message selector. In addition,
-  * a {@code ConnectionConsumer} must be given a 
-  * {@code ServerSessionPool} to use for 
-  * processing its messages.
-  *
-  * <P>Normally, when traffic is light, a {@code ConnectionConsumer} gets a
-  * {@code ServerSession} from its pool, loads it with a single message, and
-  * starts it. As traffic picks up, messages can back up. If this happens, 
-  * a {@code ConnectionConsumer} can load each {@code ServerSession}
-  * with more than one 
-  * message. This reduces the thread context switches and minimizes resource 
-  * use at the expense of some serialization of message processing.
-  *
-  * @see javax.jms.Connection#createConnectionConsumer
-  * @see javax.jms.Connection#createDurableConnectionConsumer
-  * @see javax.jms.QueueConnection#createConnectionConsumer
-  * @see javax.jms.TopicConnection#createConnectionConsumer
-  * @see javax.jms.TopicConnection#createDurableConnectionConsumer
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * For application servers, {@code Connection} objects provide a special facility for creating a
+ * {@code ConnectionConsumer} (optional). The messages it is to consume are specified by a {@code Destination} and a
+ * message selector. In addition, a {@code ConnectionConsumer} must be given a {@code ServerSessionPool} to use for
+ * processing its messages.
+ *
+ * <p>
+ * Normally, when traffic is light, a {@code ConnectionConsumer} gets a {@code ServerSession} from its pool, loads it
+ * with a single message, and starts it. As traffic picks up, messages can back up. If this happens, a
+ * {@code ConnectionConsumer} can load each {@code ServerSession} with more than one message. This reduces the thread
+ * context switches and minimizes resource use at the expense of some serialization of message processing.
+ *
+ * @see javax.jms.Connection#createConnectionConsumer
+ * @see javax.jms.Connection#createDurableConnectionConsumer
+ * @see javax.jms.QueueConnection#createConnectionConsumer
+ * @see javax.jms.TopicConnection#createConnectionConsumer
+ * @see javax.jms.TopicConnection#createDurableConnectionConsumer
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 public interface ConnectionConsumer {
 
-    /** Gets the server session pool associated with this connection consumer.
-      *  
-      * @return the server session pool used by this connection consumer
-      *  
-      * @exception JMSException if the JMS provider fails to get the server 
-      *                         session pool associated with this consumer due
-      *                         to some internal error.
-      */
+    /**
+     * Gets the server session pool associated with this connection consumer.
+     *
+     * @return the server session pool used by this connection consumer
+     *
+     * @exception JMSException if the JMS provider fails to get the server session pool associated with this consumer due to
+     * some internal error.
+     */
+    ServerSessionPool getServerSessionPool() throws JMSException;
 
-    ServerSessionPool 
-    getServerSessionPool() throws JMSException; 
+    /**
+     * Closes the connection consumer.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a connection consumer outside the Java virtual machine,
+     * clients should close these resources when they are not needed. Relying on garbage collection to eventually reclaim
+     * these resources may not be timely enough.
+     *
+     * @exception JMSException if the JMS provider fails to release resources on behalf of the connection consumer or fails
+     * to close the connection consumer.
+     */
 
- 
-    /** Closes the connection consumer.
-      *
-      * <P>Since a provider may allocate some resources on behalf of a 
-      * connection consumer outside the Java virtual machine, clients should 
-      * close these resources when
-      * they are not needed. Relying on garbage collection to eventually 
-      * reclaim these resources may not be timely enough.
-      *  
-      * @exception JMSException if the JMS provider fails to release resources 
-      *                         on behalf of the connection consumer or fails
-      *                         to close the connection consumer.
-      */
-
-    void 
-    close() throws JMSException; 
+    void close() throws JMSException;
 }

--- a/src/main/java/javax/jms/ConnectionFactory.java
+++ b/src/main/java/javax/jms/ConnectionFactory.java
@@ -16,386 +16,341 @@
 
 package javax.jms;
 
-/** A {@code ConnectionFactory} object encapsulates a set of connection 
-  * configuration 
-  * parameters that has been defined by an administrator. A client uses 
-  * it to create a connection with a JMS provider.
-  *
-  * <P>A {@code ConnectionFactory} object is a JMS administered object and
-  *  supports concurrent use.
-  *
-  * <P>JMS administered objects are objects containing configuration 
-  * information that are created by an administrator and later used by 
-  * JMS clients. They make it practical to administer the JMS API in the 
-  * enterprise.
-  *
-  * <P>Although the interfaces for administered objects do not explicitly 
-  * depend on the Java Naming and Directory Interface (JNDI) API, the JMS API 
-  * establishes the convention that JMS clients find administered objects by 
-  * looking them up in a JNDI namespace.
-  *
-  * <P>An administrator can place an administered object anywhere in a 
-  * namespace. The JMS API does not define a naming policy.
-  *
-  * <P>It is expected that JMS providers will provide the tools an
-  * administrator needs to create and configure administered objects in a 
-  * JNDI namespace. JMS provider implementations of administered objects 
-  * should be both {@code javax.jndi.Referenceable} and 
-  * {@code java.io.Serializable} so that they can be stored in all 
-  * JNDI naming contexts. In addition, it is recommended that these 
-  * implementations follow the JavaBeans<SUP><FONT SIZE="-2">TM</FONT></SUP> 
-  * design patterns.
-  *
-  * <P>This strategy provides several benefits:
-  *
-  * <UL>
-  *   <LI>It hides provider-specific details from JMS clients.
-  *   <LI>It abstracts administrative information into objects in the Java 
-  *       programming language ("Java objects")
-  *       that are easily organized and administered from a common 
-  *       management console.
-  *   <LI>Since there will be JNDI providers for all popular naming 
-  *       services, this means that JMS providers can deliver one implementation 
-  *       of administered objects that will run everywhere.
-  * </UL>
-  *
-  * <P>An administered object should not hold on to any remote resources. 
-  * Its lookup should not use remote resources other than those used by the
-  * JNDI API itself.
-  *
-  * <P>Clients should think of administered objects as local Java objects. 
-  * Looking them up should not have any hidden side effects or use surprising 
-  * amounts of local resources.
-  *
-  * @see         javax.jms.Connection
-  * @see         javax.jms.QueueConnectionFactory
-  * @see         javax.jms.TopicConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A {@code ConnectionFactory} object encapsulates a set of connection configuration parameters that has been defined by
+ * an administrator. A client uses it to create a connection with a JMS provider.
+ *
+ * <p>
+ * A {@code ConnectionFactory} object is a JMS administered object and supports concurrent use.
+ *
+ * <p>
+ * JMS administered objects are objects containing configuration information that are created by an administrator and
+ * later used by JMS clients. They make it practical to administer the JMS API in the enterprise.
+ *
+ * <p>
+ * Although the interfaces for administered objects do not explicitly depend on the Java Naming and Directory Interface
+ * (JNDI) API, the JMS API establishes the convention that JMS clients find administered objects by looking them up in a
+ * JNDI namespace.
+ *
+ * <p>
+ * An administrator can place an administered object anywhere in a namespace. The JMS API does not define a naming
+ * policy.
+ *
+ * <p>
+ * It is expected that JMS providers will provide the tools an administrator needs to create and configure administered
+ * objects in a JNDI namespace. JMS provider implementations of administered objects should be both
+ * {@code javax.jndi.Referenceable} and {@code java.io.Serializable} so that they can be stored in all JNDI naming
+ * contexts. In addition, it is recommended that these implementations follow the
+ * JavaBeans<SUP>TM</SUP> design patterns.
+ *
+ * <p>
+ * This strategy provides several benefits:
+ *
+ * <ul>
+ * <li>It hides provider-specific details from JMS clients.
+ * <li>It abstracts administrative information into objects in the Java programming language ("Java objects") that are
+ * easily organized and administered from a common management console.
+ * <li>Since there will be JNDI providers for all popular naming services, this means that JMS providers can deliver one
+ * implementation of administered objects that will run everywhere.
+ * </ul>
+ *
+ * <p>
+ * An administered object should not hold on to any remote resources. Its lookup should not use remote resources other
+ * than those used by the JNDI API itself.
+ *
+ * <p>
+ * Clients should think of administered objects as local Java objects. Looking them up should not have any hidden side
+ * effects or use surprising amounts of local resources.
+ *
+ * @see javax.jms.Connection
+ * @see javax.jms.QueueConnectionFactory
+ * @see javax.jms.TopicConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface ConnectionFactory {
-        /** Creates a connection with the default user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *
-      * @return a newly created connection
-      *
-      * @exception JMSException if the JMS provider fails to create the
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      * @since JMS 1.1 
-     */ 
 
-    Connection
-    createConnection() throws JMSException;
-
-
-    /** Creates a connection with the specified user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *  
-      * @param userName the caller's user name
-      * @param password the caller's password
-      *  
-      * @return a newly created  connection
-      *
-      * @exception JMSException if the JMS provider fails to create the 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      * @since JMS 1.1  
-      */ 
-
-    Connection
-    createConnection(String userName, String password) 
-					     throws JMSException;
-    
-    /** 
-     * Creates a JMSContext with the default user identity
-     * and an unspecified sessionMode. 
-     * <p>
-     * A connection and session are created for use by the new JMSContext. 
-     * The connection is created in stopped mode but will be automatically started
-     * when a JMSConsumer is created.
-     * <p>
-     * The behaviour of the session that is created depends on 
-     * whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * behaviour of the session also depends on whether or not 
-     * there is an active JTA transaction in progress.   
-     * <p>
-     * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
-     * <ul>
-     * <li>The session will be non-transacted and received messages will be acknowledged automatically
-     * using an acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} 
-     * For a definition of the meaning of this acknowledgement mode see the link below.
-     * </ul>
-     * <p>
-     * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
-     * <ul>
-     * <li>The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods.
-     * </ul>
-     * <p>
-     * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
-     * <ul>
-     * <li>The session will be non-transacted and received messages will be acknowledged automatically
-     * using an acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} 
-     * For a definition of the meaning of this acknowledgement mode see the link below.
-     * </ul> 
+    /**
+     * Creates a connection with the default user identity. The connection is created in stopped mode. No messages will be
+     * delivered until the {@code Connection.start} method is explicitly called.
      *
-     * @return a newly created JMSContext
+     * @return a newly created connection
      *
-     * @exception JMSRuntimeException if the JMS provider fails to create the
-     *                         JMSContext due to some internal error.
-     * @exception JMSSecurityRuntimeException  if client authentication fails due to 
-     *                         an invalid user name or password.
-     * @since JMS 2.0 
-     * 
-     * @see JMSContext#AUTO_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.ConnectionFactory#createContext(int) 
-     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String) 
-     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int) 
-     * @see javax.jms.JMSContext#createContext(int) 
+     * @exception JMSException if the JMS provider fails to create the connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     * @since JMS 1.1
      */
-    JMSContext createContext();
-   
-    /** 
-     * Creates a JMSContext with the specified user identity
-     * and an unspecified sessionMode. 
-     * <p>
-     * A connection and session are created for use by the new JMSContext. 
-     * The connection is created in stopped mode but will be automatically started
-     * when a JMSConsumer.
-     * <p>
-     * The behaviour of the session that is created depends on 
-     * whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * behaviour of the session also depends on whether or not 
-     * there is an active JTA transaction in progress.   
-     * <p>
-     * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
-     * <ul>
-     * <li>The session will be non-transacted and received messages will be acknowledged automatically
-     * using an acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} 
-     * For a definition of the meaning of this acknowledgement mode see the link below.
-     * </ul>
-     * <p>
-     * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
-     * <ul>
-     * <li>The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods.
-     * </ul>
-     * <p>
-     * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
-     * <ul>
-     * <li>The session will be non-transacted and received messages will be acknowledged automatically
-     * using an acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} 
-     * For a definition of the meaning of this acknowledgement mode see the link below.
-     * </ul> 
-     *  
+    Connection createConnection() throws JMSException;
+
+    /**
+     * Creates a connection with the specified user identity. The connection is created in stopped mode. No messages will be
+     * delivered until the {@code Connection.start} method is explicitly called.
+     *
      * @param userName the caller's user name
      * @param password the caller's password
-     *  
+     *
+     * @return a newly created connection
+     *
+     * @exception JMSException if the JMS provider fails to create the connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     * @since JMS 1.1
+     */
+    Connection createConnection(String userName, String password) throws JMSException;
+
+    /**
+     * Creates a JMSContext with the default user identity and an unspecified sessionMode.
+     *
+     * <p>
+     * A connection and session are created for use by the new JMSContext. The connection is created in stopped mode but
+     * will be automatically started when a JMSConsumer is created.
+     *
+     * <p>
+     * The behaviour of the session that is created depends on whether this method is called in a Java SE environment, in
+     * the Java EE application client container, or in the Java EE web or EJB container. If this method is called in the
+     * Java EE web or EJB container then the behaviour of the session also depends on whether or not there is an active JTA
+     * transaction in progress.
+     *
+     * <p>
+     * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
+     * <ul>
+     * <li>The session will be non-transacted and received messages will be acknowledged automatically using an
+     * acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} For a definition of the meaning of this acknowledgement
+     * mode see the link below.
+     * </ul>
+     *
+     * <p>
+     * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
+     * <ul>
+     * <li>The session will participate in the JTA transaction and will be committed or rolled back when that transaction is
+     * committed or rolled back, not by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods.
+     * </ul>
+     *
+     * <p>
+     * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
+     * <ul>
+     * <li>The session will be non-transacted and received messages will be acknowledged automatically using an
+     * acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} For a definition of the meaning of this acknowledgement
+     * mode see the link below.
+     * </ul>
+     *
      * @return a newly created JMSContext
      *
-     * @exception JMSRuntimeException if the JMS provider fails to create the 
-     *                         JMSContext due to some internal error.
-     * @exception JMSSecurityRuntimeException  if client authentication fails due to 
-     *                         an invalid user name or password.
-     * @since JMS 2.0 
-     * 
-     * @see JMSContext#AUTO_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.ConnectionFactory#createContext() 
-     * @see javax.jms.ConnectionFactory#createContext(int) 
-     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int) 
+     * @exception JMSRuntimeException if the JMS provider fails to create the JMSContext due to some internal error.
+     * @exception JMSSecurityRuntimeException if client authentication fails due to an invalid user name or password.
+     * @since JMS 2.0
+     *
+     * @see JMSContext#AUTO_ACKNOWLEDGE
+     *
+     * @see javax.jms.ConnectionFactory#createContext(int)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int)
      * @see javax.jms.JMSContext#createContext(int)
      */
-    JMSContext createContext(String userName, String password);    
+    JMSContext createContext();
 
-   /** Creates a JMSContext with the specified user identity 
-     * and the specified session mode. 
+    /**
+     * Creates a JMSContext with the specified user identity and an unspecified sessionMode.
+     *
      * <p>
-     * A connection and session are created for use by the new JMSContext. 
-     * The JMSContext is created in stopped mode but will be automatically started
-     * when a JMSConsumer is created.
+     * A connection and session are created for use by the new JMSContext. The connection is created in stopped mode but
+     * will be automatically started when a JMSConsumer.
+     *
      * <p>
-     * The effect of setting the {@code sessionMode}  
-     * argument depends on whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * effect of setting the {@code sessionMode} argument also depends on 
-     * whether or not there is an active JTA transaction in progress. 
+     * The behaviour of the session that is created depends on whether this method is called in a Java SE environment, in
+     * the Java EE application client container, or in the Java EE web or EJB container. If this method is called in the
+     * Java EE web or EJB container then the behaviour of the session also depends on whether or not there is an active JTA
+     * transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
      * <ul>
-     * <li>If {@code sessionMode} is set to {@code JMSContext.SESSION_TRANSACTED} then the session 
-     * will use a local transaction which may subsequently be committed or rolled back 
-     * by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods. 
-     * <li>If {@code sessionMode} is set to any of 
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, 
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * then the session will be non-transacted and 
-     * messages received by this session will be acknowledged
-     * according to the value of {@code sessionMode}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
+     * <li>The session will be non-transacted and received messages will be acknowledged automatically using an
+     * acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} For a definition of the meaning of this acknowledgement
+     * mode see the link below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
      * <ul>
-     * <li>The argument {@code sessionMode} is ignored.
-     * The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods.
-     * Since the argument is ignored, developers are recommended to use 
-     * {@code createContext(String userName, String password)} instead of this method. 
+     * <li>The session will participate in the JTA transaction and will be committed or rolled back when that transaction is
+     * committed or rolled back, not by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods.
      * </ul>
+     *
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
      * <ul>
-     * <li>The argument {@code acknowledgeMode} must be set to either of 
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * The session will be non-transacted and messages received by this session will be acknowledged
-     * automatically according to the value of {@code acknowledgeMode}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
-     * The values {@code JMSContext.SESSION_TRANSACTED} and {@code JMSContext.CLIENT_ACKNOWLEDGE} may not be used.
-     * </ul> 
+     * <li>The session will be non-transacted and received messages will be acknowledged automatically using an
+     * acknowledgement mode of {@code JMSContext.AUTO_ACKNOWLEDGE} For a definition of the meaning of this acknowledgement
+     * mode see the link below.
+     * </ul>
+     *
+     * @param userName the caller's user name
+     * @param password the caller's password
+     *
+     * @return a newly created JMSContext
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create the JMSContext due to some internal error.
+     * @exception JMSSecurityRuntimeException if client authentication fails due to an invalid user name or password.
+     * @since JMS 2.0
+     *
+     * @see JMSContext#AUTO_ACKNOWLEDGE
+     *
+     * @see javax.jms.ConnectionFactory#createContext()
+     * @see javax.jms.ConnectionFactory#createContext(int)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int)
+     * @see javax.jms.JMSContext#createContext(int)
+     */
+    JMSContext createContext(String userName, String password);
+
+    /**
+     * Creates a JMSContext with the specified user identity and the specified session mode.
+     *
+     * <p>
+     * A connection and session are created for use by the new JMSContext. The JMSContext is created in stopped mode but
+     * will be automatically started when a JMSConsumer is created.
+     *
+     * <p>
+     * The effect of setting the {@code sessionMode} argument depends on whether this method is called in a Java SE
+     * environment, in the Java EE application client container, or in the Java EE web or EJB container. If this method is
+     * called in the Java EE web or EJB container then the effect of setting the {@code sessionMode} argument also depends
+     * on whether or not there is an active JTA transaction in progress.
+     *
+     * <p>
+     * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
+     * <ul>
+     * <li>If {@code sessionMode} is set to {@code JMSContext.SESSION_TRANSACTED} then the session will use a local
+     * transaction which may subsequently be committed or rolled back by calling the {@code JMSContext}'s {@code commit} or
+     * {@code rollback} methods.
+     * <li>If {@code sessionMode} is set to any of {@code JMSContext.CLIENT_ACKNOWLEDGE},
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. then the session will be
+     * non-transacted and messages received by this session will be acknowledged according to the value of
+     * {@code sessionMode}. For a definition of the meaning of these acknowledgement modes see the links below.
+     * </ul>
+     *
+     * <p>
+     * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
+     * <ul>
+     * <li>The argument {@code sessionMode} is ignored. The session will participate in the JTA transaction and will be
+     * committed or rolled back when that transaction is committed or rolled back, not by calling the {@code JMSContext}'s
+     * {@code commit} or {@code rollback} methods. Since the argument is ignored, developers are recommended to use
+     * {@code createContext(String userName, String password)} instead of this method.
+     * </ul>
+     *
+     * <p>
+     * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
+     * <ul>
+     * <li>The argument {@code acknowledgeMode} must be set to either of {@code JMSContext.AUTO_ACKNOWLEDGE} or
+     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. The session will be non-transacted and messages received by this session will
+     * be acknowledged automatically according to the value of {@code acknowledgeMode}. For a definition of the meaning of
+     * these acknowledgement modes see the links below. The values {@code JMSContext.SESSION_TRANSACTED} and
+     * {@code JMSContext.CLIENT_ACKNOWLEDGE} may not be used.
+     * </ul>
+     *
      * @param userName the caller's user name
      * @param password the caller's password
      * @param sessionMode indicates which of four possible session modes will be used.
      * <ul>
-     * <li>If this method is called in a Java SE environment or in the Java EE application client container, 
-     * the permitted values are 
-     * {@code JMSContext.SESSION_TRANSACTED}, 
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, 
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} and
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. 
-     * <li> If this method is called in the Java EE web or EJB container when there is an active JTA transaction in progress 
+     * <li>If this method is called in a Java SE environment or in the Java EE application client container, the permitted
+     * values are {@code JMSContext.SESSION_TRANSACTED}, {@code JMSContext.CLIENT_ACKNOWLEDGE},
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} and {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
+     * <li>If this method is called in the Java EE web or EJB container when there is an active JTA transaction in progress
      * then this argument is ignored.
-     * <li>If this method is called in the Java EE web or EJB container when there is no active JTA transaction in progress, the permitted values are
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} and
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * In this case the values {@code JMSContext.TRANSACTED} and {@code JMSContext.CLIENT_ACKNOWLEDGE} are not permitted.
+     * <li>If this method is called in the Java EE web or EJB container when there is no active JTA transaction in progress,
+     * the permitted values are {@code JMSContext.AUTO_ACKNOWLEDGE} and {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. In this case
+     * the values {@code JMSContext.TRANSACTED} and {@code JMSContext.CLIENT_ACKNOWLEDGE} are not permitted.
      * </ul>
-     *  
+     *
      * @return a newly created JMSContext
      *
-     * @exception JMSRuntimeException if the JMS provider fails to create the 
-     *                         JMSContext due to some internal error.
-     * @exception JMSSecurityRuntimeException  if client authentication fails due to 
-     *                         an invalid user name or password.
-     * @since JMS 2.0  
-     * 
-     * @see JMSContext#SESSION_TRANSACTED 
-     * @see JMSContext#CLIENT_ACKNOWLEDGE 
-     * @see JMSContext#AUTO_ACKNOWLEDGE 
-     * @see JMSContext#DUPS_OK_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.ConnectionFactory#createContext() 
-     * @see javax.jms.ConnectionFactory#createContext(int) 
-     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String) 
-     * @see javax.jms.JMSContext#createContext(int) 
-     */ 
-    JMSContext createContext(String userName, String password, int sessionMode);    
-   
-   /** Creates a JMSContext with the default user identity
-     * and the specified session mode. 
-     * <p> 
-     * A connection and session are created for use by the new JMSContext. 
-     * The JMSContext is created in stopped mode but will be automatically started
-     * when a JMSConsumer is created.
+     * @exception JMSRuntimeException if the JMS provider fails to create the JMSContext due to some internal error.
+     * @exception JMSSecurityRuntimeException if client authentication fails due to an invalid user name or password.
+     * @since JMS 2.0
+     *
+     * @see JMSContext#SESSION_TRANSACTED
+     * @see JMSContext#CLIENT_ACKNOWLEDGE
+     * @see JMSContext#AUTO_ACKNOWLEDGE
+     * @see JMSContext#DUPS_OK_ACKNOWLEDGE
+     *
+     * @see javax.jms.ConnectionFactory#createContext()
+     * @see javax.jms.ConnectionFactory#createContext(int)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String)
+     * @see javax.jms.JMSContext#createContext(int)
+     */
+    JMSContext createContext(String userName, String password, int sessionMode);
+
+    /**
+     * Creates a JMSContext with the default user identity and the specified session mode.
+     *
      * <p>
-     * The effect of setting the {@code sessionMode}  
-     * argument depends on whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * effect of setting the {@code sessionMode} argument also depends on 
-     * whether or not there is an active JTA transaction in progress. 
+     * A connection and session are created for use by the new JMSContext. The JMSContext is created in stopped mode but
+     * will be automatically started when a JMSConsumer is created.
+     *
+     * <p>
+     * The effect of setting the {@code sessionMode} argument depends on whether this method is called in a Java SE
+     * environment, in the Java EE application client container, or in the Java EE web or EJB container. If this method is
+     * called in the Java EE web or EJB container then the effect of setting the {@code sessionMode} argument also depends
+     * on whether or not there is an active JTA transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
      * <ul>
-     * <li>If {@code sessionMode} is set to {@code JMSContext.SESSION_TRANSACTED} then the session 
-     * will use a local transaction which may subsequently be committed or rolled back 
-     * by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods. 
-     * <li>If {@code sessionMode} is set to any of 
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, 
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * then the session will be non-transacted and 
-     * messages received by this session will be acknowledged
-     * according to the value of {@code sessionMode}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
+     * <li>If {@code sessionMode} is set to {@code JMSContext.SESSION_TRANSACTED} then the session will use a local
+     * transaction which may subsequently be committed or rolled back by calling the {@code JMSContext}'s {@code commit} or
+     * {@code rollback} methods.
+     * <li>If {@code sessionMode} is set to any of {@code JMSContext.CLIENT_ACKNOWLEDGE},
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. then the session will be
+     * non-transacted and messages received by this session will be acknowledged according to the value of
+     * {@code sessionMode}. For a definition of the meaning of these acknowledgement modes see the links below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
      * <ul>
-     * <li>The argument {@code sessionMode} is ignored.
-     * The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the {@code JMSContext}'s {@code commit} or {@code rollback} methods.
-     * Since the argument is ignored, developers are recommended to use 
+     * <li>The argument {@code sessionMode} is ignored. The session will participate in the JTA transaction and will be
+     * committed or rolled back when that transaction is committed or rolled back, not by calling the {@code JMSContext}'s
+     * {@code commit} or {@code rollback} methods. Since the argument is ignored, developers are recommended to use
      * {@code createContext()} instead of this method.
      * </ul>
+     *
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
      * <ul>
-     * <li>The argument {@code acknowledgeMode} must be set to either of 
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * The session will be non-transacted and messages received by this session will be acknowledged
-     * automatically according to the value of {@code acknowledgeMode}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
-     * The values {@code JMSContext.SESSION_TRANSACTED} and {@code JMSContext.CLIENT_ACKNOWLEDGE} may not be used.
-     * </ul> 
+     * <li>The argument {@code acknowledgeMode} must be set to either of {@code JMSContext.AUTO_ACKNOWLEDGE} or
+     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. The session will be non-transacted and messages received by this session will
+     * be acknowledged automatically according to the value of {@code acknowledgeMode}. For a definition of the meaning of
+     * these acknowledgement modes see the links below. The values {@code JMSContext.SESSION_TRANSACTED} and
+     * {@code JMSContext.CLIENT_ACKNOWLEDGE} may not be used.
+     * </ul>
      *
      * @param sessionMode indicates which of four possible session modes will be used.
      * <ul>
-     * <li>If this method is called in a Java SE environment or in the Java EE application client container, 
-     * the permitted values are 
-     * {@code JMSContext.SESSION_TRANSACTED}, 
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, 
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} and
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. 
-     * <li> If this method is called in the Java EE web or EJB container when there is an active JTA transaction in progress 
+     * <li>If this method is called in a Java SE environment or in the Java EE application client container, the permitted
+     * values are {@code JMSContext.SESSION_TRANSACTED}, {@code JMSContext.CLIENT_ACKNOWLEDGE},
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} and {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
+     * <li>If this method is called in the Java EE web or EJB container when there is an active JTA transaction in progress
      * then this argument is ignored.
-     * <li>If this method is called in the Java EE web or EJB container when there is no active JTA transaction in progress, the permitted values are
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} and
-     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-     * In this case the values {@code JMSContext.TRANSACTED} and {@code JMSContext.CLIENT_ACKNOWLEDGE} are not permitted.
+     * <li>If this method is called in the Java EE web or EJB container when there is no active JTA transaction in progress,
+     * the permitted values are {@code JMSContext.AUTO_ACKNOWLEDGE} and {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. In this case
+     * the values {@code JMSContext.TRANSACTED} and {@code JMSContext.CLIENT_ACKNOWLEDGE} are not permitted.
      * </ul>
-     * 
+     *
      * @return a newly created JMSContext
-     * 
-     * @exception JMSRuntimeException if the JMS provider fails to create the
-     *                         JMSContext due to some internal error.
-     * @exception JMSSecurityRuntimeException  if client authentication fails due to 
-     *                         an invalid user name or password.
-     * @since JMS 2.0 
-     * 
-     * @see JMSContext#SESSION_TRANSACTED 
-     * @see JMSContext#CLIENT_ACKNOWLEDGE 
-     * @see JMSContext#AUTO_ACKNOWLEDGE 
-     * @see JMSContext#DUPS_OK_ACKNOWLEDGE 
-     * 
-     * @see javax.jms.ConnectionFactory#createContext() 
-     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String) 
-     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int) 
-     * @see javax.jms.JMSContext#createContext(int) 
-	 */
-	JMSContext createContext(int sessionMode);
-      
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create the JMSContext due to some internal error.
+     * @exception JMSSecurityRuntimeException if client authentication fails due to an invalid user name or password.
+     * @since JMS 2.0
+     *
+     * @see JMSContext#SESSION_TRANSACTED
+     * @see JMSContext#CLIENT_ACKNOWLEDGE
+     * @see JMSContext#AUTO_ACKNOWLEDGE
+     * @see JMSContext#DUPS_OK_ACKNOWLEDGE
+     *
+     * @see javax.jms.ConnectionFactory#createContext()
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int)
+     * @see javax.jms.JMSContext#createContext(int)
+     */
+    JMSContext createContext(int sessionMode);
+
 }

--- a/src/main/java/javax/jms/ConnectionMetaData.java
+++ b/src/main/java/javax/jms/ConnectionMetaData.java
@@ -18,107 +18,83 @@ package javax.jms;
 
 import java.util.Enumeration;
 
-/** A {@code ConnectionMetaData} object provides information describing the 
-  * {@code Connection} object.
-  *
-  * @version JMS 2.0
-  * @since JMS 1.0
-  */
-
+/**
+ * A {@code ConnectionMetaData} object provides information describing the {@code Connection} object.
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface ConnectionMetaData {
 
-    /** Gets the JMS API version.
-      *
-      * @return the JMS API version
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */
+    /**
+     * Gets the JMS API version.
+     *
+     * @return the JMS API version
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    String getJMSVersion() throws JMSException;
 
-    String 
-    getJMSVersion() throws JMSException;
+    /**
+     * Gets the JMS major version number.
+     *
+     * @return the JMS API major version number
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    int getJMSMajorVersion() throws JMSException;
 
+    /**
+     * Gets the JMS minor version number.
+     *
+     * @return the JMS API minor version number
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    int getJMSMinorVersion() throws JMSException;
 
-    /** Gets the JMS major version number.
-      *  
-      * @return the JMS API major version number
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */
+    /**
+     * Gets the JMS provider name.
+     *
+     * @return the JMS provider name
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    String getJMSProviderName() throws JMSException;
 
-    int 
-    getJMSMajorVersion() throws JMSException; 
- 
+    /**
+     * Gets the JMS provider version.
+     *
+     * @return the JMS provider version
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    String getProviderVersion() throws JMSException;
 
-    /** Gets the JMS minor version number.
-      *  
-      * @return the JMS API minor version number
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */
+    /**
+     * Gets the JMS provider major version number.
+     *
+     * @return the JMS provider major version number
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    int getProviderMajorVersion() throws JMSException;
 
-    int  
-    getJMSMinorVersion() throws JMSException;
+    /**
+     * Gets the JMS provider minor version number.
+     *
+     * @return the JMS provider minor version number
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    int getProviderMinorVersion() throws JMSException;
 
-
-    /** Gets the JMS provider name.
-      *
-      * @return the JMS provider name
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */ 
-
-    String 
-    getJMSProviderName() throws JMSException;
-
-
-    /** Gets the JMS provider version.
-      *
-      * @return the JMS provider version
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */ 
-
-    String 
-    getProviderVersion() throws JMSException;
-
-
-    /** Gets the JMS provider major version number.
-      *  
-      * @return the JMS provider major version number
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */
-
-    int
-    getProviderMajorVersion() throws JMSException; 
-
- 
-    /** Gets the JMS provider minor version number.
-      *  
-      * @return the JMS provider minor version number
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */
-
-    int  
-    getProviderMinorVersion() throws JMSException;
-
- 
-    /** Gets an enumeration of the JMSX property names.
-      *  
-      * @return an Enumeration of JMSX property names
-      *  
-      * @exception JMSException if the JMS provider fails to retrieve the
-      *                         metadata due to some internal error.
-      */
-
-    Enumeration
-    getJMSXPropertyNames() throws JMSException;
+    /**
+     * Gets an enumeration of the JMSX property names.
+     *
+     * @return an Enumeration of JMSX property names
+     *
+     * @exception JMSException if the JMS provider fails to retrieve the metadata due to some internal error.
+     */
+    Enumeration getJMSXPropertyNames() throws JMSException;
 }

--- a/src/main/java/javax/jms/DeliveryMode.java
+++ b/src/main/java/javax/jms/DeliveryMode.java
@@ -16,53 +16,43 @@
 
 package javax.jms;
 
-/** The delivery modes supported by the JMS API are {@code PERSISTENT} and
-  * {@code NON_PERSISTENT}.
-  *
-  * <P>A client marks a message as persistent if it feels that the 
-  * application will have problems if the message is lost in transit.
-  * A client marks a message as non-persistent if an occasional
-  * lost message is tolerable. Clients use delivery mode to tell a
-  * JMS provider how to balance message transport reliability with throughput.
-  *
-  * <P>Delivery mode covers only the transport of the message to its 
-  * destination. Retention of a message at the destination until
-  * its receipt is acknowledged is not guaranteed by a {@code PERSISTENT} 
-  * delivery mode. Clients should assume that message retention 
-  * policies are set administratively. Message retention policy
-  * governs the reliability of message delivery from destination
-  * to message consumer. For example, if a client's message storage 
-  * space is exhausted, some messages may be dropped in accordance with 
-  * a site-specific message retention policy.
-  *
-  * <P>A message is guaranteed to be delivered once and only once
-  * by a JMS provider if the delivery mode of the message is 
-  * {@code PERSISTENT} 
-  * and if the destination has a sufficient message retention policy.
-  *
-  * @version JMS 2.0
-  * @since JMS 1.0
-  */
-
+/**
+ * The delivery modes supported by the JMS API are {@code PERSISTENT} and {@code NON_PERSISTENT}.
+ *
+ * <p>
+ * A client marks a message as persistent if it feels that the application will have problems if the message is lost in
+ * transit. A client marks a message as non-persistent if an occasional lost message is tolerable. Clients use delivery
+ * mode to tell a JMS provider how to balance message transport reliability with throughput.
+ *
+ * <p>
+ * Delivery mode covers only the transport of the message to its destination. Retention of a message at the destination
+ * until its receipt is acknowledged is not guaranteed by a {@code PERSISTENT} delivery mode. Clients should assume that
+ * message retention policies are set administratively. Message retention policy governs the reliability of message
+ * delivery from destination to message consumer. For example, if a client's message storage space is exhausted, some
+ * messages may be dropped in accordance with a site-specific message retention policy.
+ *
+ * <p>
+ * A message is guaranteed to be delivered once and only once by a JMS provider if the delivery mode of the message is
+ * {@code PERSISTENT} and if the destination has a sufficient message retention policy.
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface DeliveryMode {
 
-    /** This is the lowest-overhead delivery mode because it does not require 
-      * that the message be logged to stable storage. The level of JMS provider
-      * failure that causes a {@code NON_PERSISTENT} message to be lost is 
-      * not defined.
-      *
-      * <P>A JMS provider must deliver a {@code NON_PERSISTENT} message 
-      * with an 
-      * at-most-once guarantee. This means that it may lose the message, but it 
-      * must not deliver it twice.
-      */
+    /**
+     * This is the lowest-overhead delivery mode because it does not require that the message be logged to stable storage.
+     * The level of JMS provider failure that causes a {@code NON_PERSISTENT} message to be lost is not defined.
+     *
+     * <p>
+     * A JMS provider must deliver a {@code NON_PERSISTENT} message with an at-most-once guarantee. This means that it may
+     * lose the message, but it must not deliver it twice.
+     */
+    int NON_PERSISTENT = 1;
 
-    static final int NON_PERSISTENT = 1;
-
-    /** This delivery mode instructs the JMS provider to log the message to stable 
-      * storage as part of the client's send operation. Only a hard media 
-      * failure should cause a {@code PERSISTENT} message to be lost.
-      */
-
-    static final int PERSISTENT = 2;
+    /**
+     * This delivery mode instructs the JMS provider to log the message to stable storage as part of the client's send
+     * operation. Only a hard media failure should cause a {@code PERSISTENT} message to be lost.
+     */
+    int PERSISTENT = 2;
 }

--- a/src/main/java/javax/jms/Destination.java
+++ b/src/main/java/javax/jms/Destination.java
@@ -16,74 +16,69 @@
 
 package javax.jms;
 
-/** A {@code Destination} object encapsulates a provider-specific 
-  * address.
-  * The JMS API does not define a standard address syntax. Although a standard
-  * address syntax was considered, it was decided that the differences in 
-  * address semantics between existing message-oriented middleware (MOM) 
-  * products were too wide to bridge with a single syntax. 
-  *
-  * <P>Since {@code Destination} is an administered object, it may 
-  * contain 
-  * provider-specific configuration information in addition to its address.
-  *
-  * <P>The JMS API also supports a client's use of provider-specific address 
-  * names.
-  *
-  * <P>{@code Destination} objects support concurrent use.
-  *
-  * <P>A {@code Destination} object is a JMS administered object.
-  *
-  * <P>JMS administered objects are objects containing configuration 
-  * information that are created by an administrator and later used by 
-  * JMS clients. They make it practical to administer the JMS API in the 
-  * enterprise.
-  *
-  * <P>Although the interfaces for administered objects do not explicitly 
-  * depend on the Java Naming and Directory Interface (JNDI) API, the JMS API 
-  * establishes the convention that JMS clients find administered objects by
-  * looking them up in a JNDI namespace.
-  *
-  * <P>An administrator can place an administered object anywhere in a 
-  * namespace. The JMS API does not define a naming policy.
-  *
-  * <P>It is expected that JMS providers will provide the tools an
-  * administrator needs to create and configure administered objects in a
-  * JNDI namespace. JMS provider implementations of administered objects
-  * should implement the {@code javax.naming.Referenceable} and
-  * {@code java.io.Serializable} interfaces so that they can be stored in 
-  * all JNDI naming contexts. In addition, it is recommended that these
-  * implementations follow the JavaBeans<SUP><FONT SIZE="-2">TM</FONT></SUP> 
-  * design patterns.
-  *
-  * <P>This strategy provides several benefits:
-  *
-  * <UL>
-  *   <LI>It hides provider-specific details from JMS clients.
-  *   <LI>It abstracts JMS administrative information into objects in the Java 
-  *       programming language ("Java objects") 
-  *       that are easily organized and administered from a common 
-  *       management console.
-  *   <LI>Since there will be JNDI providers for all popular naming 
-  *       services, JMS providers can deliver one implementation
-  *       of administered objects that will run everywhere.
-  * </UL>
-  *
-  * <P>An administered object should not hold on to any remote resources. 
-  * Its lookup should not use remote resources other than those used by the
-  * JNDI API itself.
-  *
-  * <P>Clients should think of administered objects as local Java objects. 
-  * Looking them up should not have any hidden side effects or use surprising 
-  * amounts of local resources.
-  *
-  * @see         javax.jms.Queue
-  * @see         javax.jms.Topic
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A {@code Destination} object encapsulates a provider-specific address. The JMS API does not define a standard address
+ * syntax. Although a standard address syntax was considered, it was decided that the differences in address semantics
+ * between existing message-oriented middleware (MOM) products were too wide to bridge with a single syntax.
+ *
+ * <p>
+ * Since {@code Destination} is an administered object, it may contain provider-specific configuration information in
+ * addition to its address.
+ *
+ * <p>
+ * The JMS API also supports a client's use of provider-specific address names.
+ *
+ * <p>
+ * {@code Destination} objects support concurrent use.
+ *
+ * <p>
+ * A {@code Destination} object is a JMS administered object.
+ *
+ * <p>
+ * JMS administered objects are objects containing configuration information that are created by an administrator and
+ * later used by JMS clients. They make it practical to administer the JMS API in the enterprise.
+ *
+ * <p>
+ * Although the interfaces for administered objects do not explicitly depend on the Java Naming and Directory Interface
+ * (JNDI) API, the JMS API establishes the convention that JMS clients find administered objects by looking them up in a
+ * JNDI namespace.
+ *
+ * <p>
+ * An administrator can place an administered object anywhere in a namespace. The JMS API does not define a naming
+ * policy.
+ *
+ * <p>
+ * It is expected that JMS providers will provide the tools an administrator needs to create and configure administered
+ * objects in a JNDI namespace. JMS provider implementations of administered objects should implement the
+ * {@code javax.naming.Referenceable} and {@code java.io.Serializable} interfaces so that they can be stored in all JNDI
+ * naming contexts. In addition, it is recommended that these implementations follow the
+ * JavaBeans<SUP>TM</SUP> design patterns.
+ *
+ * <p>
+ * This strategy provides several benefits:
+ *
+ * <ul>
+ * <li>It hides provider-specific details from JMS clients.
+ * <li>It abstracts JMS administrative information into objects in the Java programming language ("Java objects") that
+ * are easily organized and administered from a common management console.
+ * <li>Since there will be JNDI providers for all popular naming services, JMS providers can deliver one implementation
+ * of administered objects that will run everywhere.
+ * </ul>
+ *
+ * <p>
+ * An administered object should not hold on to any remote resources. Its lookup should not use remote resources other
+ * than those used by the JNDI API itself.
+ *
+ * <p>
+ * Clients should think of administered objects as local Java objects. Looking them up should not have any hidden side
+ * effects or use surprising amounts of local resources.
+ *
+ * @see javax.jms.Queue
+ * @see javax.jms.Topic
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 public interface Destination {
 }

--- a/src/main/java/javax/jms/DupsOKAcknowledge.java
+++ b/src/main/java/javax/jms/DupsOKAcknowledge.java
@@ -24,37 +24,36 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies that a callback method on a JMS message-driven bean
- * must receive messages with an acknowledgement type of dups-ok-acknowledge. It
- * may be specified either on the callback method or on the message-driven bean
- * class.
+ * This annotation specifies that a callback method on a JMS message-driven bean must receive messages with an
+ * acknowledgement type of dups-ok-acknowledge. It may be specified either on the callback method or on the
+ * message-driven bean class.
+ *
  * <p>
- * The message-driven bean must also be configured to use a transaction
- * management type of BEAN. This may be configured by specifying the annotation
- * {code @TransactionManagement(value=TransactionManagementType.BEAN)} on the
- * message-driven bean. If a transaction management type of BEAN is not
- * configured then it is recommended that deployment will fail.
+ * The message-driven bean must also be configured to use a transaction management type of BEAN. This may be configured
+ * by specifying the annotation {code @TransactionManagement(value=TransactionManagementType.BEAN)} on the
+ * message-driven bean. If a transaction management type of BEAN is not configured then it is recommended that
+ * deployment will fail.
+ *
  * <p>
- * If this annotation is specified on a method of a message-driven bean class
- * then that method must also be annotated with {@code QueueListener} or
- * {@code TopicListener}. If it is not then deployment will fail.
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
  * <p>
- * If this annotation is specified on the message-driven bean class then at
- * least one method must be annotated with {@code QueueListener} or
- * {@code TopicListener}. If no method is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
  * <p>
- * If either this annotation or {@code AutoAcknowledge} are specified on both
- * a method of a message-driven bean class and on the message-driven bean class
- * itself then deployment will fail.
- * 
+ * If either this annotation or {@code AutoAcknowledge} are specified on both a method of a message-driven bean class
+ * and on the message-driven bean class itself then deployment will fail.
+ *
  * @see QueueListener
  * @see TopicListener
  * @see DupsOKAcknowledge
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
+ *
  */
 @Retention(RUNTIME)
 @Target({ METHOD, TYPE })

--- a/src/main/java/javax/jms/DurableSubscription.java
+++ b/src/main/java/javax/jms/DurableSubscription.java
@@ -23,20 +23,19 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies that a callback method on a JMS message-driven bean
- * must use a durable subscription.
+ * This annotation specifies that a callback method on a JMS message-driven bean must use a durable subscription.
+ *
  * <p>
- * The method must also be annotated with {@code TopicListener}. If it is not
- * then deployment will fail.
- * 
+ * The method must also be annotated with {@code TopicListener}. If it is not then deployment will fail.
+ *
  * @see TopicListener
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
+ *
  */
 @Retention(RUNTIME)
 @Target({ METHOD })
 public @interface DurableSubscription {
-	
+
 }

--- a/src/main/java/javax/jms/ExceptionListener.java
+++ b/src/main/java/javax/jms/ExceptionListener.java
@@ -16,34 +16,30 @@
 
 package javax.jms;
 
-
-/** If a JMS provider detects a serious problem with a {@code Connection}
-  * object, it informs the {@code Connection} object's 
-  * {@code ExceptionListener}, if one has been registered. 
-  * It does this by calling the listener's {@code onException} method, 
-  * passing it a {@code JMSException} argument describing the problem.
-  *
-  * <P>An exception listener allows a client to be notified of a problem 
-  * asynchronously. Some connections only consume messages, so they would have no
-  * other way to learn that their connection has failed.
-  *
-  * <P>A JMS provider should attempt to resolve connection problems 
-  * itself before it notifies the client of them.
-  *
-  * @see javax.jms.Connection#setExceptionListener(ExceptionListener)
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * If a JMS provider detects a serious problem with a {@code Connection} object, it informs the {@code Connection}
+ * object's {@code ExceptionListener}, if one has been registered. It does this by calling the listener's
+ * {@code onException} method, passing it a {@code JMSException} argument describing the problem.
+ *
+ * <p>
+ * An exception listener allows a client to be notified of a problem asynchronously. Some connections only consume
+ * messages, so they would have no other way to learn that their connection has failed.
+ *
+ * <p>
+ * A JMS provider should attempt to resolve connection problems itself before it notifies the client of them.
+ *
+ * @see javax.jms.Connection#setExceptionListener(ExceptionListener)
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 public interface ExceptionListener {
 
-    /** Notifies user of a JMS exception.
-      *
-      * @param exception the JMS exception
-      */
-
-    void 
-    onException(JMSException exception);
+    /**
+     * Notifies user of a JMS exception.
+     *
+     * @param exception the JMS exception
+     */
+    void onException(JMSException exception);
 }

--- a/src/main/java/javax/jms/IllegalStateException.java
+++ b/src/main/java/javax/jms/IllegalStateException.java
@@ -17,47 +17,41 @@
 package javax.jms;
 
 /**
- * <P> This exception is thrown when a method is 
- *     invoked at an illegal or inappropriate time or if the provider is 
- *     not in an appropriate state for the requested operation. For example, 
- *     this exception must be thrown if {@code Session.commit} is 
- *     called on a non-transacted session. This exception is also called when
- *     a domain inappropriate method is called, such as calling 
- *     {@code TopicSession.CreateQueueBrowser}.
+ * <p>
+ * This exception is thrown when a method is invoked at an illegal or inappropriate time or if the provider is not in an
+ * appropriate state for the requested operation. For example, this exception must be thrown if {@code Session.commit}
+ * is called on a non-transacted session. This exception is also called when a domain inappropriate method is called,
+ * such as calling {@code TopicSession.CreateQueueBrowser}.
  *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class IllegalStateException extends JMSException {
-	
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -6850763061112244487L;
 
-  /** Constructs an {@code IllegalStateException} with the specified reason
-   *  and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  IllegalStateException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -6850763061112244487L;
 
-  /** Constructs an {@code IllegalStateException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  IllegalStateException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs an {@code IllegalStateException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public IllegalStateException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs an {@code IllegalStateException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public IllegalStateException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/IllegalStateRuntimeException.java
+++ b/src/main/java/javax/jms/IllegalStateRuntimeException.java
@@ -17,60 +17,50 @@
 package javax.jms;
 
 /**
- * This unchecked exception is thrown when a method is invoked at an illegal or
- * inappropriate time or if the provider is not in an appropriate state for the
- * requested operation, and the method signature does not permit a
- * {@code IllegalStateRuntimeException} to be thrown. For example, this
- * exception must be thrown if {@code JMSContext.commit} is called on a
- * non-transacted session.
+ * This unchecked exception is thrown when a method is invoked at an illegal or inappropriate time or if the provider is
+ * not in an appropriate state for the requested operation, and the method signature does not permit a
+ * {@code IllegalStateRuntimeException} to be thrown. For example, this exception must be thrown if
+ * {@code JMSContext.commit} is called on a non-transacted session.
  *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
 public class IllegalStateRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 6838714637432837899L;
 
-	/**
-	 * Constructs a {@code IllegalStateRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public IllegalStateRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 6838714637432837899L;
 
-	/**
-	 * Constructs a {@code IllegalStateRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public IllegalStateRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage,errorCode);
-	}
+    /**
+     * Constructs a {@code IllegalStateRuntimeException} with the specified detail message
+     * 
+     * @param detailMessage a description of the exception
+     **/
+    public IllegalStateRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
 
-	/**
-	 * Constructs a {@code IllegalStateRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public IllegalStateRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage, errorCode, cause);
-	}
-	
+    /**
+     * Constructs a {@code IllegalStateRuntimeException} with the specified detail message and error code.
+     * 
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public IllegalStateRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code IllegalStateRuntimeException} with the specified detail message, error code and cause
+     * 
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public IllegalStateRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
+
 }

--- a/src/main/java/javax/jms/InvalidClientIDException.java
+++ b/src/main/java/javax/jms/InvalidClientIDException.java
@@ -17,43 +17,39 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a 
- *     client attempts to set a connection's client ID to a value that 
- *     is rejected by a provider.
+ * <p>
+ * This exception must be thrown when a client attempts to set a connection's client ID to a value that is rejected by a
+ * provider.
  *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class InvalidClientIDException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = 2410181719763491702L;
 
-  /** Constructs an {@code InvalidClientIDException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  InvalidClientIDException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = 2410181719763491702L;
 
-  /** Constructs an {@code InvalidClientIDException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  InvalidClientIDException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs an {@code InvalidClientIDException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public InvalidClientIDException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs an {@code InvalidClientIDException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public InvalidClientIDException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/InvalidClientIDRuntimeException.java
+++ b/src/main/java/javax/jms/InvalidClientIDRuntimeException.java
@@ -17,59 +17,47 @@
 package javax.jms;
 
 /**
- * This unchecked exception must be thrown when a client attempts to set a
- * connection's client ID to a value that is rejected by a provider, and the
- * method signature does not permit a {@code InvalidClientIDException} to
- * be thrown.
- * 
+ * This unchecked exception must be thrown when a client attempts to set a connection's client ID to a value that is
+ * rejected by a provider, and the method signature does not permit a {@code InvalidClientIDException} to be thrown.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
-
 public class InvalidClientIDRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = -1997236208457896631L;
-	
-	/**
-	 * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public InvalidClientIDRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
 
-	/**
-	 * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public InvalidClientIDRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage,errorCode);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = -1997236208457896631L;
 
+    /**
+     * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public InvalidClientIDRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
 
-	/**
-	 * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public InvalidClientIDRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage, errorCode, cause);
-	}
+    /**
+     * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public InvalidClientIDRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code InvalidClientIDRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public InvalidClientIDRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
 }

--- a/src/main/java/javax/jms/InvalidDestinationException.java
+++ b/src/main/java/javax/jms/InvalidDestinationException.java
@@ -17,43 +17,38 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a 
- *     destination either is not understood by a provider or is no 
- *     longer valid.
+ * <p>
+ * This exception must be thrown when a destination either is not understood by a provider or is no longer valid.
  *
  * @version JMS 2.0
  * @since JMS 1.0
  *
  **/
-
 public class InvalidDestinationException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -8588063794606036755L;
 
-  /** Constructs an {@code InvalidDestinationException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific 
-   *                        error code
-   *                        
-   **/
-  public 
-  InvalidDestinationException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -8588063794606036755L;
 
-  /** Constructs an {@code InvalidDestinationException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  InvalidDestinationException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs an {@code InvalidDestinationException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public InvalidDestinationException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs an {@code InvalidDestinationException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public InvalidDestinationException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/InvalidDestinationRuntimeException.java
+++ b/src/main/java/javax/jms/InvalidDestinationRuntimeException.java
@@ -17,58 +17,48 @@
 package javax.jms;
 
 /**
- * This unchecked exception must be thrown when a destination either is not
- * understood by a provider or is no longer valid, and the method signature does
- * not permit a {@code InvalidDestinationException} to be thrown.
+ * This unchecked exception must be thrown when a destination either is not understood by a provider or is no longer
+ * valid, and the method signature does not permit a {@code InvalidDestinationException} to be thrown.
  *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
-
 public class InvalidDestinationRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 2765276997130843763L;
 
-	/**
-	 * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public InvalidDestinationRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
-	
-	/**
-	 * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public InvalidDestinationRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage,errorCode);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 2765276997130843763L;
 
-	/**
-	 * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public InvalidDestinationRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage, errorCode, cause);
-	}
-  
+    /**
+     * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public InvalidDestinationRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    /**
+     * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public InvalidDestinationRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code InvalidDestinationRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public InvalidDestinationRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
+
 }

--- a/src/main/java/javax/jms/InvalidSelectorException.java
+++ b/src/main/java/javax/jms/InvalidSelectorException.java
@@ -17,43 +17,38 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a 
- *     JMS client attempts to give a provider a message selector with 
- *     invalid syntax.
+ * <p>
+ * This exception must be thrown when a JMS client attempts to give a provider a message selector with invalid syntax.
  *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class InvalidSelectorException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID =  6223038613086963841L;
 
-  /** Constructs an {@code InvalidSelectorException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  InvalidSelectorException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = 6223038613086963841L;
 
-  /** Constructs an {@code InvalidSelectorException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  InvalidSelectorException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs an {@code InvalidSelectorException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public InvalidSelectorException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs an {@code InvalidSelectorException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public InvalidSelectorException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/InvalidSelectorRuntimeException.java
+++ b/src/main/java/javax/jms/InvalidSelectorRuntimeException.java
@@ -17,58 +17,48 @@
 package javax.jms;
 
 /**
- * This unchecked exception must be thrown when a JMS client attempts to give a
- * provider a message selector with invalid syntax, and the method signature
- * does not permit a {@code InvalidSelectorException} to be thrown.
+ * This unchecked exception must be thrown when a JMS client attempts to give a provider a message selector with invalid
+ * syntax, and the method signature does not permit a {@code InvalidSelectorException} to be thrown.
  *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
-
 public class InvalidSelectorRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 1974783946275023548L;
 
-	/**
-	 * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public InvalidSelectorRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
-	
-	/**
-	 * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public InvalidSelectorRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage,errorCode);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 1974783946275023548L;
 
-	/**
-	 * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public InvalidSelectorRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage,errorCode,cause);
-	}
-  
+    /**
+     * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public InvalidSelectorRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    /**
+     * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public InvalidSelectorRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code InvalidSelectorRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public InvalidSelectorRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
+
 }

--- a/src/main/java/javax/jms/JMSConnectionFactory.java
+++ b/src/main/java/javax/jms/JMSConnectionFactory.java
@@ -26,36 +26,37 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation may be used on a field to specify the JNDI lookup name of a
- * {@code javax.jms.ConnectionFactory} to be used when injecting a
- * {@code javax.jms.JMSContext} object.
+ * This annotation may be used on a field to specify the JNDI lookup name of a {@code javax.jms.ConnectionFactory} to be
+ * used when injecting a {@code javax.jms.JMSContext} object.
+ *
  * <p>
- * It may also be used to specify that a callback method on a JMS message-driven
- * bean must use the specified message selector. In this case it may be
- * specified either on the callback method or on the message-driven bean class.
+ * It may also be used to specify that a callback method on a JMS message-driven bean must use the specified message
+ * selector. In this case it may be specified either on the callback method or on the message-driven bean class.
+ *
  * <p>
- * If this annotation is specified on a method of a message-driven bean class
- * then that method must also be annotated with {@code QueueListener} or
- * {@code TopicListener}. If it is not then deployment will fail.
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
  * <p>
- * If this annotation is specified on the message-driven bean class then at
- * least one method must be annotated with {@code QueueListener} or
- * {@code TopicListener}. If no method is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
  * <p>
- * If this annotation is specified on both a method of a message-driven bean
- * class and on the message-driven bean class itself then deployment will fail.
- * 
+ * If this annotation is specified on both a method of a message-driven bean class and on the message-driven bean class
+ * itself then deployment will fail.
+ *
  * @version JMS 2.1
  * @since JMS 2.0
- * 
  */
 @Retention(RUNTIME)
 @Target({ METHOD, FIELD, PARAMETER, TYPE })
 public @interface JMSConnectionFactory {
-	/**
-	 * Specifies the JNDI lookup name of a {@code javax.jms.ConnectionFactory}
-	 * to be used.
-	 */
-	String value();
+
+    /**
+     * Specifies the JNDI lookup name of a {@code javax.jms.ConnectionFactory} to be used.
+     *
+     * @return the JNDI lookup name of a {@code javax.jms.ConnectionFactory} to be used
+     */
+    String value();
 }

--- a/src/main/java/javax/jms/JMSConnectionFactoryDefinition.java
+++ b/src/main/java/javax/jms/JMSConnectionFactoryDefinition.java
@@ -16,116 +16,131 @@
 
 package javax.jms;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An application may use this annotation to specify a JMS {@code 
- * ConnectionFactory} resource that it requires in its operational 
- * environment. This provides information that can be used at the 
- * application's deployment to provision the required resource
- * and allows an application to be deployed into a Java EE environment 
- * with more minimal administrative configuration.
+ * An application may use this annotation to specify a JMS {@code
+ * ConnectionFactory} resource that it requires in its operational environment. This provides information that can be
+ * used at the application's deployment to provision the required resource and allows an application to be deployed into
+ * a Java EE environment with more minimal administrative configuration.
  * <p>
- * The {@code ConnectionFactory} resource may be configured by 
- * setting the annotation elements for commonly used properties. 
- * Additional properties may be specified using the {@code properties}
- * element. Once defined, a {@code ConnectionFactory} resource may be referenced by a
- * component in the same way as any other {@code ConnectionFactory} resource,
- * for example by using the {@code lookup} element of the {@code Resource}
+ * The {@code ConnectionFactory} resource may be configured by setting the annotation elements for commonly used
+ * properties. Additional properties may be specified using the {@code properties} element. Once defined, a
+ * {@code ConnectionFactory} resource may be referenced by a component in the same way as any other
+ * {@code ConnectionFactory} resource, for example by using the {@code lookup} element of the {@code Resource}
  * annotation.
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  * @see javax.annotation.Resource
  */
-@Target({ ElementType.TYPE })
-@Retention(RetentionPolicy.RUNTIME)
+@Target(TYPE)
+@Retention(RUNTIME)
 public @interface JMSConnectionFactoryDefinition {
 
-	/**
-	 * Description of this JMS connection factory.
-	 */
-	String description() default "";
+    /**
+     * Description of this JMS connection factory.
+     *
+     * @return The description of this JMS connection factory.
+     */
+    String description() default "";
 
-	/**
-	 * JNDI name of the JMS connection factory being defined.
-	 */
-	String name();
+    /**
+     * JNDI name of the JMS connection factory being defined.
+     *
+     * @return The JNDI name of the JMS connection factory being defined.
+     */
+    String name();
 
-	/**
-	 * Fully qualified name of the JMS connection factory interface.
-	 * Permitted values are
-	 * {@code javax.jms.ConnectionFactory} or
-	 * {@code javax.jms.QueueConnectionFactory} or
-	 * {@code javax.jms.TopicConnectionFactory}.
-	 * If not specified then {@code javax.jms.ConnectionFactory} will be used. 
-	 */
-	String interfaceName() default "javax.jms.ConnectionFactory";
-	
-	/**
-	 * Fully-qualified name of the JMS connection factory implementation class.
-	 * Ignored if a resource adapter is used.
-	 */
-	String className() default "";
+    /**
+     * Fully qualified name of the JMS connection factory interface. Permitted values are
+     * {@code javax.jms.ConnectionFactory} or {@code javax.jms.QueueConnectionFactory} or
+     * {@code javax.jms.TopicConnectionFactory}. If not specified then {@code javax.jms.ConnectionFactory} will be used.
+     *
+     * @return The fully qualified name of the JMS connection factory interface.
+     */
+    String interfaceName() default "javax.jms.ConnectionFactory";
 
-	/**
-	 * Resource adapter name.
-	 * If not specified then the application server will define the default behaviour,
-	 * which may or may not involve the use of a resource adapter.
-	 */
-	String resourceAdapter() default "";
+    /**
+     * Fully-qualified name of the JMS connection factory implementation class. Ignored if a resource adapter is used.
+     *
+     * @return The fully-qualified name of the JMS connection factory implementation class.
+     */
+    String className() default "";
 
-	/**
-	 * User name to use for connection authentication.
-	 */
-	String user() default "";
+    /**
+     * Resource adapter name. If not specified then the application server will define the default behaviour, which may or
+     * may not involve the use of a resource adapter.
+     *
+     * @return The resource adapter name.
+     */
+    String resourceAdapter() default "";
 
-	/**
-	 * Password to use for connection authentication.
-	 */
-	String password() default "";
+    /**
+     * User name to use for connection authentication.
+     *
+     * @return The user name to use for connection authentication.
+     */
+    String user() default "";
 
-	/**
-	 * Client id to use for connection.
-	 */
-	String clientId() default "";
+    /**
+     * Password to use for connection authentication.
+     *
+     * @return The password to use for connection authentication.
+     */
+    String password() default "";
 
-	/**
-	 * JMS connection factory property. This may be a vendor-specific property
-	 * or a less commonly used {@code ConnectionFactory} property.
-	 * <p>
-	 * Properties are specified using the format:
-	 * <i>propertyName=propertyValue</i> with one property per array element.
-	 */
-	String[] properties() default {};
+    /**
+     * Client id to use for connection.
+     *
+     * @return The client id to use for connection.
+     */
+    String clientId() default "";
 
-	/**
-	 * Set to {@code false} if connections should not participate in
-	 * transactions.
-	 * <p>
-	 * Default is to enlist in a transaction when one is active or becomes
-	 * active.
-	 */
-	boolean transactional() default true;
+    /**
+     * JMS connection factory property. This may be a vendor-specific property or a less commonly used
+     * {@code ConnectionFactory} property.
+     *
+     * <p>
+     * Properties are specified using the format: <i>propertyName=propertyValue</i> with one property per array element.
+     *
+     * @return The JMS connection factory property.
+     */
+    String[] properties() default {};
 
-	/**
-	 * Maximum number of connections that should be concurrently allocated for a
-	 * connection pool.
-	 * <p>
-	 * Default is vendor-specific.
-	 */
-	int maxPoolSize() default -1;
+    /**
+     * Set to {@code false} if connections should not participate in transactions.
+     *
+     * <p>
+     * Default is to enlist in a transaction when one is active or becomes active.
+     *
+     * @return Whether connections should participate in transactions.
+     */
+    boolean transactional() default true;
 
-	/**
-	 * Minimum number of connections that should be concurrently allocated for a
-	 * connection pool.
-	 * <p>
-	 * Default is vendor-specific.
-	 */ 
-	int minPoolSize() default -1;
+    /**
+     * Maximum number of connections that should be concurrently allocated for a connection pool.
+     *
+     * <p>
+     * Default is vendor-specific.
+     *
+     * @return The maximum number of connections that should be concurrently allocated for a connection pool.
+     */
+    int maxPoolSize() default -1;
+
+    /**
+     * Minimum number of connections that should be concurrently allocated for a connection pool.
+     *
+     * <p>
+     * Default is vendor-specific.
+     *
+     * @return The minimum number of connections that should be concurrently allocated for a connection pool.
+     */
+    int minPoolSize() default -1;
 
 }

--- a/src/main/java/javax/jms/JMSConnectionFactoryDefinitions.java
+++ b/src/main/java/javax/jms/JMSConnectionFactoryDefinitions.java
@@ -16,24 +16,23 @@
 
 package javax.jms;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- *  Specifies one or more {@code JMSConnectionFactoryDefinition}
- *  annotations.
- *  
+ * Specifies one or more {@code JMSConnectionFactoryDefinition} annotations.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
  *
- *  @see JMSConnectionFactoryDefinition
+ * @see JMSConnectionFactoryDefinition
  */
-@Target({ElementType.TYPE})
-@Retention(RetentionPolicy.RUNTIME)
+@Target(TYPE)
+@Retention(RUNTIME)
 public @interface JMSConnectionFactoryDefinitions {
 
-	JMSConnectionFactoryDefinition[] value();
+    JMSConnectionFactoryDefinition[] value();
 }
-

--- a/src/main/java/javax/jms/JMSConsumer.java
+++ b/src/main/java/javax/jms/JMSConsumer.java
@@ -15,465 +15,380 @@
  */
 
 package javax.jms;
- 
+
 /**
- * A client using the simplified JMS API introduced for JMS 2.0 uses a
- * {@code JMSConsumer} object to receive messages from a queue or topic. A
- * {@code JMSConsumer} object may be created either created by passing a
- * {@code Queue} or {@code Topic} object to one of the {@code createConsumer}
- * methods on a {@code JMSContext}. or by passing a {@code Topic} object to one
- * of the {@code createSharedConsumer} or {@code createDurableConsumer} methods
- * on a {@code JMSContext}.
- * <P>
- * A {@code JMSConsumer} can be created with a message selector. A message
- * selector allows the client to restrict the messages delivered to the
- * {@code JMSConsumer} to those that match the selector.
+ * A client using the simplified JMS API introduced for JMS 2.0 uses a {@code JMSConsumer} object to receive messages
+ * from a queue or topic. A {@code JMSConsumer} object may be created either created by passing a {@code Queue} or
+ * {@code Topic} object to one of the {@code createConsumer} methods on a {@code JMSContext}. or by passing a
+ * {@code Topic} object to one of the {@code createSharedConsumer} or {@code createDurableConsumer} methods on a
+ * {@code JMSContext}.
+ *
  * <p>
- * A client may either synchronously receive a {@code JMSConsumer}'s messages or
- * have the {@code JMSConsumer} asynchronously deliver them as they arrive.
+ * A {@code JMSConsumer} can be created with a message selector. A message selector allows the client to restrict the
+ * messages delivered to the {@code JMSConsumer} to those that match the selector.
+ *
  * <p>
- * For synchronous receipt, a client can request the next message from a
- * {@code JMSConsumer} using one of its {@code receive} methods. There are
- * several variations of {@code receive} that allow a client to poll or wait for
- * the next message.
+ * A client may either synchronously receive a {@code JMSConsumer}'s messages or have the {@code JMSConsumer}
+ * asynchronously deliver them as they arrive.
+ *
  * <p>
- * For asynchronous delivery, a client can register a {@code MessageListener}
- * object with a {@code JMSConsumer}. As messages arrive at the
- * {@code JMSConsumer}, it delivers them by calling the {@code MessageListener}
- * 's {@code onMessage} method.
+ * For synchronous receipt, a client can request the next message from a {@code JMSConsumer} using one of its
+ * {@code receive} methods. There are several variations of {@code receive} that allow a client to poll or wait for the
+ * next message.
+ *
  * <p>
- * It is a client programming error for a {@code MessageListener} to throw an
- * exception.
- * 
+ * For asynchronous delivery, a client can register a {@code MessageListener} object with a {@code JMSConsumer}. As
+ * messages arrive at the {@code JMSConsumer}, it delivers them by calling the {@code MessageListener} 's
+ * {@code onMessage} method.
+ *
+ * <p>
+ * It is a client programming error for a {@code MessageListener} to throw an exception.
+ *
  * @see javax.jms.JMSContext
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  */
-
 public interface JMSConsumer extends AutoCloseable {
 
-    /** Gets this {@code JMSConsumer}'s message selector expression.
-      *  
-      * @return this {@code JMSConsumer}'s message selector, or null if no
-      *         message selector exists for the {@code JMSConsumer} (that is, if 
-      *         the message selector was not set or was set to null or the 
-      *         empty string)
-      *  
-      * @exception JMSRuntimeException if the JMS provider fails to get the message
-      *            selector due to some internal error.
-      */ 
-
+    /**
+     * Gets this {@code JMSConsumer}'s message selector expression.
+     *
+     * @return this {@code JMSConsumer}'s message selector, or null if no message selector exists for the
+     * {@code JMSConsumer} (that is, if the message selector was not set or was set to null or the empty string)
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to get the message selector due to some internal error.
+     */
     String getMessageSelector();
-    
-    /** Gets the {@code JMSConsumer}'s {@code MessageListener}. 
-     * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSRuntimeException} to be thrown though this is not guaranteed.
-     * 
-      * @return the {@code JMSConsumer}'s {@code MessageListener}, or null if one was not set
-      *  
-      * @exception JMSRuntimeException if the JMS provider fails to get the {@code MessageListener}
-      *                         for one of the following reasons:
-      *                         <ul>
-      *                         <li>an internal error has occurred or
-      *                         <li>this method has been called in a Java EE web or EJB application 
-      *                         (though it is not guaranteed that an exception is thrown in this case)
-      *                         </ul>                      
-      *                         
-      * @see javax.jms.JMSConsumer#setMessageListener(javax.jms.MessageListener)
-      */ 
-    MessageListener getMessageListener() throws JMSRuntimeException;
-    
-    /** Sets the {@code JMSConsumer}'s {@code MessageListener}.
-      * <p>
-      * Setting the {@code MessageListener} to null is the equivalent of 
-      * unsetting the {@code MessageListener} for the {@code JMSConsumer}. 
-      * <p>
-      * The effect of calling this method
-      * while messages are being consumed by an existing listener
-      * or the {@code JMSConsumer} is being used to consume messages synchronously
-      * is undefined.
-      * <p>
-      * This method must not be used in a Java EE web or EJB application. 
-      * Doing so may cause a {@code JMSRuntimeException} to be thrown though this is not guaranteed.
-      * 
-      * @param listener the listener to which the messages are to be 
-      *                 delivered
-      *  
-      * @exception JMSRuntimeException if the JMS provider fails to set the {@code JMSConsumer}'s {@code MessageListener}
-      *                         for one of the following reasons:
-      *                         <ul>
-      *                         <li>an internal error has occurred or  
-      *                         <li>this method has been called in a Java EE web or EJB application 
-      *                         (though it is not guaranteed that an exception is thrown in this case)
-      *                         </ul>    
-      *                         
-      * @see javax.jms.JMSConsumer#getMessageListener()
-      */ 
-    void setMessageListener(MessageListener listener) throws JMSRuntimeException;
-    
 
-    /** Receives the next message produced for this {@code JMSConsumer}.
-      *  
-      * <P>This call blocks indefinitely until a message is produced
-      * or until this {@code JMSConsumer} is closed.
-      *
-      * <P>If this {@code receive} is done within a transaction, the 
-      * JMSConsumer retains the message until the transaction commits.
-      *  
-      * @return the next message produced for this {@code JMSConsumer}, or 
-      * null if this {@code JMSConsumer} is concurrently closed
-      *  
-      * @exception JMSRuntimeException if the JMS provider fails to receive the next
-      *            message due to some internal error.
-      * 
-      */ 
- 
+    /**
+     * Gets the {@code JMSConsumer}'s {@code MessageListener}.
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSRuntimeException} to
+     * be thrown though this is not guaranteed.
+     *
+     * @return the {@code JMSConsumer}'s {@code MessageListener}, or null if one was not set
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to get the {@code MessageListener} for one of the following
+     * reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @see javax.jms.JMSConsumer#setMessageListener(javax.jms.MessageListener)
+     */
+    MessageListener getMessageListener() throws JMSRuntimeException;
+
+    /**
+     * Sets the {@code JMSConsumer}'s {@code MessageListener}.
+     * <p>
+     * Setting the {@code MessageListener} to null is the equivalent of unsetting the {@code MessageListener} for the
+     * {@code JMSConsumer}.
+     * <p>
+     * The effect of calling this method while messages are being consumed by an existing listener or the
+     * {@code JMSConsumer} is being used to consume messages synchronously is undefined.
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSRuntimeException} to
+     * be thrown though this is not guaranteed.
+     *
+     * @param listener the listener to which the messages are to be delivered
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to set the {@code JMSConsumer}'s {@code MessageListener} for
+     * one of the following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @see javax.jms.JMSConsumer#getMessageListener()
+     */
+    void setMessageListener(MessageListener listener) throws JMSRuntimeException;
+
+    /**
+     * Receives the next message produced for this {@code JMSConsumer}.
+     *
+     * <p>
+     * This call blocks indefinitely until a message is produced or until this {@code JMSConsumer} is closed.
+     *
+     * <p>
+     * If this {@code receive} is done within a transaction, the JMSConsumer retains the message until the transaction
+     * commits.
+     *
+     * @return the next message produced for this {@code JMSConsumer}, or null if this {@code JMSConsumer} is concurrently
+     * closed
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to receive the next message due to some internal error.
+     *
+     */
     Message receive();
 
-
-    /** Receives the next message that arrives within the specified
-      * timeout interval.
-      *  
-      * <P>This call blocks until a message arrives, the
-      * timeout expires, or this {@code JMSConsumer} is closed.
-      * A {@code timeout} of zero never expires, and the call blocks 
-      * indefinitely.
-      *
-      * @param timeout the timeout value (in milliseconds)
-      *
-      * @return the next message produced for this {@code JMSConsumer}, or 
-      * null if the timeout expires or this {@code JMSConsumer} is concurrently 
-      * closed
-      *
-      * @exception JMSRuntimeException if the JMS provider fails to receive the next
-      *            message due to some internal error.
-      */ 
-
+    /**
+     * Receives the next message that arrives within the specified timeout interval.
+     *
+     * <p>
+     * This call blocks until a message arrives, the timeout expires, or this {@code JMSConsumer} is closed. A
+     * {@code timeout} of zero never expires, and the call blocks indefinitely.
+     *
+     * @param timeout the timeout value (in milliseconds)
+     *
+     * @return the next message produced for this {@code JMSConsumer}, or null if the timeout expires or this
+     * {@code JMSConsumer} is concurrently closed
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to receive the next message due to some internal error.
+     */
     Message receive(long timeout);
 
-
-    /** Receives the next message if one is immediately available.
-      *
-      * @return the next message produced for this {@code JMSConsumer}, or 
-      * null if one is not available
-      *  
-      * @exception JMSRuntimeException if the JMS provider fails to receive the next
-      *            message due to some internal error.
-      */ 
-
+    /**
+     * Receives the next message if one is immediately available.
+     *
+     * @return the next message produced for this {@code JMSConsumer}, or null if one is not available
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to receive the next message due to some internal error.
+     */
     Message receiveNoWait();
 
+    /**
+     * Closes the {@code JMSConsumer}.
+     * <p>
+     * Since a provider may allocate some resources on behalf of a {@code JMSConsumer} outside the Java virtual machine,
+     * clients should close them when they are not needed. Relying on garbage collection to eventually reclaim these
+     * resources may not be timely enough.
+     * <p>
+     * This call will block until a {@code receive} call in progress on this consumer has completed. A blocked
+     * {@code receive} call returns null when this consumer is closed.
+     * <p>
+     * If this method is called whilst a message listener is in progress in another thread then it will block until the
+     * message listener has completed.
+     * <p>
+     * This method may be called from a message listener's {@code onMessage} method on its own consumer. After this method
+     * returns the {@code onMessage} method will be allowed to complete normally.
+     * <p>
+     * This method is the only {@code JMSConsumer} method that can be called concurrently.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to close the consumer due to some internal error.
+     */
+    @Override
+    void close();
 
-	/**
-	 * Closes the {@code JMSConsumer}.
-	 * <p>
-	 * Since a provider may allocate some resources on behalf of a
-	 * {@code JMSConsumer} outside the Java virtual machine, clients should
-	 * close them when they are not needed. Relying on garbage collection to
-	 * eventually reclaim these resources may not be timely enough.
-	 * <P>
-	 * This call will block until a {@code receive} call in progress on this
-	 * consumer has completed. A blocked {@code receive} call returns null when
-	 * this consumer is closed.
-	 * <p>
-	 * If this method is called whilst a message listener is in progress in
-	 * another thread then it will block until the message listener has
-	 * completed.
-	 * <p>
-	 * This method may be called from a message listener's {@code onMessage}
-	 * method on its own consumer. After this method returns the
-	 * {@code onMessage} method will be allowed to complete normally.
-	 * <p>
-	 * This method is the only {@code JMSConsumer} method that can be called
-	 * concurrently.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to close the consumer due to
-	 *                some internal error.
-	 */
+    /**
+     * Receives the next message produced for this {@code JMSConsumer} and returns its body as an object of the specified
+     * type. This method may be used to receive any type of message except for {@code StreamMessage} and {@code Message}, so
+     * long as the message has a body which is capable of being assigned to the specified type. This means that the
+     * specified class or interface must either be the same as, or a superclass or superinterface of, the class of the
+     * message body. If the message is not one of the supported types, or its body cannot be assigned to the specified type,
+     * or it has no body, then a {@code MessageFormatRuntimeException} is thrown.
+     *
+     * <p>
+     * This method does not give access to the message headers or properties (such as the {@code JMSRedelivered} message
+     * header field or the {@code JMSXDeliveryCount} message property) and should only be used if the application has no
+     * need to access them.
+     *
+     * <p>
+     * This call blocks indefinitely until a message is produced or until this {@code JMSConsumer} is closed.
+     *
+     * <p>
+     * If this method is called within a transaction, the {@code JMSConsumer} retains the message until the transaction
+     * commits.
+     *
+     * <p>
+     * The result of this method throwing a {@code MessageFormatRuntimeException} depends on the session mode:
+     *
+     * <ul>
+     * <li>{@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}: The JMS provider will behave as if the unsuccessful call
+     * to {@code receiveBody} had not occurred. The message will be delivered again before any subsequent messages.
+     *
+     * This is not considered to be redelivery and does not cause the {@code JMSRedelivered} message header field to be set
+     * or the {@code JMSXDeliveryCount} message property to be incremented.</li>
+     * <li>{@code CLIENT_ACKNOWLEDGE}: The JMS provider will behave as if the call to {@code receiveBody} had been
+     * successful and will not deliver the message again.
+     *
+     * As with any message that is delivered with a session mode of {@code CLIENT_ACKNOWLEDGE}, the message will not be
+     * acknowledged until {@code acknowledge} is called on the {@code JMSContext}. If an application wishes to have the
+     * failed message redelivered, it must call {@code recover} on the {@code JMSContext}. The redelivered message's
+     * {@code JMSRedelivered} message header field will be set and its {@code JMSXDeliveryCount} message property will be
+     * incremented.</li>
+     *
+     * <li>Transacted session: The JMS provider will behave as if the call to {@code receiveBody} had been successful and
+     * will not deliver the message again.
+     *
+     * As with any message that is delivered in a transacted session, the transaction will remain uncommitted until the
+     * transaction is committed or rolled back by the application. If an application wishes to have the failed message
+     * redelivered, it must roll back the transaction. The redelivered message's {@code JMSRedelivered} message header field
+     * will be set and its {@code JMSXDeliveryCount} message property will be incremented.</li>
+     * </ul>
+     *
+     * @param <T> The type of the message body
+     * @param c The type to which the body of the next message should be assigned.<br>
+     * If the next message is expected to be a {@code TextMessage} then this should be set to {@code String.class} or
+     * another class to which a {@code String} is assignable.<br>
+     * If the next message is expected to be a {@code ObjectMessage} then this should be set to
+     * {@code java.io.Serializable.class} or another class to which the body is assignable. <br>
+     * If the next message is expected to be a {@code MapMessage} then this should be set to {@code java.util.Map.class} (or
+     * {@code java.lang.Object.class}).<br>
+     * If the next message is expected to be a {@code BytesMessage} then this should be set to {@code byte[].class} (or
+     * {@code java.lang.Object.class}).<br>
+     *
+     * @return the body of the next message produced for this {@code JMSConsumer}, or null if this {@code JMSConsumer} is
+     * concurrently closed
+     *
+     * @throws MessageFormatRuntimeException
+     * <ul>
+     * <li>if the message is not one of the supported types listed above
+     * <li>if the message body cannot be assigned to the specified type
+     * <li>if the message has no body
+     * <li>if the message is an {@code ObjectMessage} and object deserialization fails.
+     * </ul>
+     * @throws JMSRuntimeException if the JMS provider fails to receive the next message due to some internal error
+     */
+    <T> T receiveBody(Class<T> c);
 
-	void close();
-    
-	/**
-	 * Receives the next message produced for this {@code JMSConsumer} and
-	 * returns its body as an object of the specified type. 
-	 * This method may be used to receive any type of message except 
-	 * for {@code StreamMessage} and {@code Message}, so long as the message
-	 * has a body which is capable of being assigned to the specified type.
-	 * This means that the specified class or interface must either be the same
-	 * as, or a superclass or superinterface of, the class of the message body. 
-	 * If the message is not one of the supported types, 
-	 * or its body cannot be assigned to the specified type, or it has no body, 
-	 * then a {@code MessageFormatRuntimeException} is thrown.
-	 * <p>
-	 * This method does not give access to the message headers or properties
-	 * (such as the {@code JMSRedelivered} message header field or the
-	 * {@code JMSXDeliveryCount} message property) and should only be used if
-	 * the application has no need to access them.
-	 * <P>
-	 * This call blocks indefinitely until a message is produced or until this
-	 * {@code JMSConsumer} is closed.
-	 * <p>
-	 * If this method is called within a transaction, the
-	 * {@code JMSConsumer} retains the message until the transaction commits.
-	 * <p>
-	 * The result of this method throwing a
-	 * {@code MessageFormatRuntimeException} depends on the session mode:
-	 * <ul>
-	 * <li>{@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}: The JMS
-	 * provider will behave as if the unsuccessful call to {@code receiveBody} had
-	 * not occurred. The message will be delivered again before any subsequent
-	 * messages.
-	 * <p>
-	 * This is not considered to be redelivery and does not cause the
-	 * {@code JMSRedelivered} message header field to be set or the
-	 * {@code JMSXDeliveryCount} message property to be incremented.</li>
-	 * <li>{@code CLIENT_ACKNOWLEDGE}: The JMS provider will behave as if the
-	 * call to {@code receiveBody} had been successful and will not deliver the
-	 * message again.
-	 * <p>
-	 * As with any message that is delivered with a session mode of
-	 * {@code CLIENT_ACKNOWLEDGE}, the message will not be acknowledged until
-	 * {@code acknowledge} is called on the {@code JMSContext}. If an
-	 * application wishes to have the failed message redelivered, it must call
-	 * {@code recover} on the {@code JMSContext}. The redelivered message's
-	 * {@code JMSRedelivered} message header field will be set and its
-	 * {@code JMSXDeliveryCount} message property will be incremented.</li>
-	 * 
-	 * <li>Transacted session: The JMS provider will behave as if the call to
-	 * {@code receiveBody} had been successful and will not deliver the message
-	 * again.
-	 * <p>
-	 * As with any message that is delivered in a transacted session, the
-	 * transaction will remain uncommitted until the transaction is committed or
-	 * rolled back by the application. If an application wishes to have the
-	 * failed message redelivered, it must roll back the transaction. The
-	 * redelivered message's {@code JMSRedelivered} message header field will be
-	 * set and its {@code JMSXDeliveryCount} message property will be
-	 * incremented.</li>
-	 * </ul>
-	 * 
-	 * @param c
-	 *            The type to which the body of the next message should be
-	 *            assigned.<br>
-	 *            If the next message is expected to be a {@code TextMessage}
-	 *            then this should be set to {@code String.class} or another
-	 *            class to which a {@code String} is assignable.<br>
-	 *            If the next message is expected to be a {@code ObjectMessage}
-	 *            then this should be set to {@code java.io.Serializable.class}
-	 *            or another class to which the body is assignable. <br>
-	 *            If the next message is expected to be a {@code MapMessage}
-	 *            then this should be set to {@code java.util.Map.class}
-	 *            (or {@code java.lang.Object.class}).<br>
-	 *            If the next message is expected to be a {@code BytesMessage}
-	 *            then this should be set to {@code byte[].class}
-	 *            (or {@code java.lang.Object.class}).<br>
-	 * 
-	 * @return the body of the next message produced for this
-	 *         {@code JMSConsumer}, or null if this {@code JMSConsumer} is
-	 *         concurrently closed
-	 * 
-	 * @throws MessageFormatRuntimeException
-	 *             <ul>
-	 *             <li>if the message is not one of the supported types listed above
-	 *             <li>if the message body cannot be assigned to the specified type
-	 *             <li>if the message has no body
-	 *             <li>if the message is an {@code ObjectMessage} and object deserialization fails.
-	 *             </ul>
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to receive the next message due to
-	 *             some internal error
-	 */
-	<T> T receiveBody(Class<T> c);
-	
-	/**
-	 * Receives the next message produced for this {@code JMSConsumer} 
-	 * that arrives within the specified timeout period and
-	 * returns its body as an object of the specified type. 
-	 * This method may be used to receive any type of message except 
-	 * for {@code StreamMessage} and {@code Message}, so long as the message
-	 * has a body which is capable of being assigned to the specified type.
-	 * This means that the specified class or interface must either be the same
-	 * as, or a superclass or superinterface of, the class of the message body. 
-	 * If the message is not one of the supported types, 
-	 * or its body cannot be assigned to the specified type, or it has no body, 
-	 * then a {@code MessageFormatRuntimeException} is thrown.
-	 * <p>
-	 * This method does not give access to the message headers or properties
-	 * (such as the {@code JMSRedelivered} message header field or the
-	 * {@code JMSXDeliveryCount} message property) and should only be used if
-	 * the application has no need to access them.
-	 * <P>
-	 * This call blocks until a message arrives, the timeout expires, or this
-	 * {@code JMSConsumer} is closed. A timeout of zero never expires, and the
-	 * call blocks indefinitely.
-	 * <p>
-	 * If this method is called within a transaction, the
-	 * {@code JMSConsumer} retains the message until the transaction commits.
-	 * <p>
-	 * The result of this method throwing a
-	 * {@code MessageFormatRuntimeException} depends on the session mode:
-	 * <ul>
-	 * <li>{@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}: The JMS
-	 * provider will behave as if the unsuccessful call to {@code receiveBody} had
-	 * not occurred. The message will be delivered again before any subsequent
-	 * messages.
-	 * <p>
-	 * This is not considered to be redelivery and does not cause the
-	 * {@code JMSRedelivered} message header field to be set or the
-	 * {@code JMSXDeliveryCount} message property to be incremented.</li>
-	 * <li>{@code CLIENT_ACKNOWLEDGE}: The JMS provider will behave as if the
-	 * call to {@code receiveBody} had been successful and will not deliver the
-	 * message again.
-	 * <p>
-	 * As with any message that is delivered with a session mode of
-	 * {@code CLIENT_ACKNOWLEDGE}, the message will not be acknowledged until
-	 * {@code acknowledge} is called on the {@code JMSContext}. If an
-	 * application wishes to have the failed message redelivered, it must call
-	 * {@code recover} on the {@code JMSContext}. The redelivered message's
-	 * {@code JMSRedelivered} message header field will be set and its
-	 * {@code JMSXDeliveryCount} message property will be incremented.</li>
-	 * 
-	 * <li>Transacted session: The JMS provider will behave as if the call to
-	 * {@code receiveBody} had been successful and will not deliver the message
-	 * again.
-	 * <p>
-	 * As with any message that is delivered in a transacted session, the
-	 * transaction will remain uncommitted until the transaction is committed or
-	 * rolled back by the application. If an application wishes to have the
-	 * failed message redelivered, it must roll back the transaction. The
-	 * redelivered message's {@code JMSRedelivered} message header field will be
-	 * set and its {@code JMSXDeliveryCount} message property will be
-	 * incremented.</li>
-	 * </ul>
-	 * 
-	 * @param c
-	 *            The type to which the body of the next message should be
-	 *            assigned.<br>
-	 *            If the next message is expected to be a {@code TextMessage}
-	 *            then this should be set to {@code String.class} or another
-	 *            class to which a {@code String} is assignable.<br>
-	 *            If the next message is expected to be a {@code ObjectMessage}
-	 *            then this should be set to {@code java.io.Serializable.class}
-	 *            or another class to which the body is assignable. <br>
-	 *            If the next message is expected to be a {@code MapMessage}
-	 *            then this should be set to {@code java.util.Map.class}
-	 *            (or {@code java.lang.Object.class}).<br>
-	 *            If the next message is expected to be a {@code BytesMessage}
-	 *            then this should be set to {@code byte[].class}
-	 *            (or {@code java.lang.Object.class}).<br>
-	 * 
-	 * @return the body of the next message produced for this {@code JMSConsumer},
-	 *         or null if the timeout expires or this {@code JMSConsumer} is concurrently closed
-	 * 
-	 * @throws MessageFormatRuntimeException
-	 *             <ul>
-	 *             <li>if the message is not one of the supported types listed above
-	 *             <li>if the message body cannot be assigned to the specified type
-	 *             <li>if the message has no body
-	 *             <li>if the message is an {@code ObjectMessage} and object deserialization fails.
-	 *             </ul>
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to receive the next message due
-	 *             to some internal error
-	 */
+    /**
+     * Receives the next message produced for this {@code JMSConsumer} that arrives within the specified timeout period and
+     * returns its body as an object of the specified type. This method may be used to receive any type of message except
+     * for {@code StreamMessage} and {@code Message}, so long as the message has a body which is capable of being assigned
+     * to the specified type. This means that the specified class or interface must either be the same as, or a superclass
+     * or superinterface of, the class of the message body. If the message is not one of the supported types, or its body
+     * cannot be assigned to the specified type, or it has no body, then a {@code MessageFormatRuntimeException} is thrown.
+     *
+     * <p>
+     * This method does not give access to the message headers or properties (such as the {@code JMSRedelivered} message
+     * header field or the {@code JMSXDeliveryCount} message property) and should only be used if the application has no
+     * need to access them.
+     *
+     * <p>
+     * This call blocks until a message arrives, the timeout expires, or this {@code JMSConsumer} is closed. A timeout of
+     * zero never expires, and the call blocks indefinitely.
+     *
+     * <p>
+     * If this method is called within a transaction, the {@code JMSConsumer} retains the message until the transaction
+     * commits.
+     *
+     * <p>
+     * The result of this method throwing a {@code MessageFormatRuntimeException} depends on the session mode:
+     * <ul>
+     * <li>{@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}: The JMS provider will behave as if the unsuccessful call
+     * to {@code receiveBody} had not occurred. The message will be delivered again before any subsequent messages.
+     *
+     * This is not considered to be redelivery and does not cause the {@code JMSRedelivered} message header field to be set
+     * or the {@code JMSXDeliveryCount} message property to be incremented.</li>
+     * <li>{@code CLIENT_ACKNOWLEDGE}: The JMS provider will behave as if the call to {@code receiveBody} had been
+     * successful and will not deliver the message again.
+     *
+     * As with any message that is delivered with a session mode of {@code CLIENT_ACKNOWLEDGE}, the message will not be
+     * acknowledged until {@code acknowledge} is called on the {@code JMSContext}. If an application wishes to have the
+     * failed message redelivered, it must call {@code recover} on the {@code JMSContext}. The redelivered message's
+     * {@code JMSRedelivered} message header field will be set and its {@code JMSXDeliveryCount} message property will be
+     * incremented.</li>
+     *
+     * <li>Transacted session: The JMS provider will behave as if the call to {@code receiveBody} had been successful and
+     * will not deliver the message again.
+     *
+     * As with any message that is delivered in a transacted session, the transaction will remain uncommitted until the
+     * transaction is committed or rolled back by the application. If an application wishes to have the failed message
+     * redelivered, it must roll back the transaction. The redelivered message's {@code JMSRedelivered} message header field
+     * will be set and its {@code JMSXDeliveryCount} message property will be incremented.</li>
+     * </ul>
+     *
+     * @param <T> The message body type
+     * @param c The type to which the body of the next message should be assigned.<br>
+     * If the next message is expected to be a {@code TextMessage} then this should be set to {@code String.class} or
+     * another class to which a {@code String} is assignable.<br>
+     * If the next message is expected to be a {@code ObjectMessage} then this should be set to
+     * {@code java.io.Serializable.class} or another class to which the body is assignable. <br>
+     * If the next message is expected to be a {@code MapMessage} then this should be set to {@code java.util.Map.class} (or
+     * {@code java.lang.Object.class}).<br>
+     * If the next message is expected to be a {@code BytesMessage} then this should be set to {@code byte[].class} (or
+     * {@code java.lang.Object.class}).
+     * @param timeout The maximum amount of time this method blocks. Zero means blocking indefinitely.
+     *
+     * @return the body of the next message produced for this {@code JMSConsumer}, or null if the timeout expires or this
+     * {@code JMSConsumer} is concurrently closed
+     *
+     * @throws MessageFormatRuntimeException
+     * <ul>
+     * <li>if the message is not one of the supported types listed above
+     * <li>if the message body cannot be assigned to the specified type
+     * <li>if the message has no body
+     * <li>if the message is an {@code ObjectMessage} and object deserialization fails.
+     * </ul>
+     * @throws JMSRuntimeException if the JMS provider fails to receive the next message due to some internal error
+     */
     <T> T receiveBody(Class<T> c, long timeout);
-    
-    
-	/**
-	 * Receives the next message produced for this {@code JMSConsumer} 
-	 * if one is immediately available and
-	 * returns its body as an object of the specified type. 
-	 * This method may be used to receive any type of message except 
-	 * for {@code StreamMessage} and {@code Message}, so long as the message
-	 * has a body which is capable of being assigned to the specified type.
-	 * This means that the specified class or interface must either be the same
-	 * as, or a superclass or superinterface of, the class of the message body. 
-	 * If the message is not one of the supported types, 
-	 * or its body cannot be assigned to the specified type, or it has no body, 
-	 * then a {@code MessageFormatRuntimeException} is thrown.
-	 * <p>
-	 * This method does not give access to the message headers or properties
-	 * (such as the {@code JMSRedelivered} message header field or the
-	 * {@code JMSXDeliveryCount} message property) and should only be used if
-	 * the application has no need to access them.
-	 * <P>
-	 * If a message is not immediately available null is returned. 
-	 * <p>
-	 * If this method is called within a transaction, the
-	 * {@code JMSConsumer} retains the message until the transaction commits.
-	 * <p>
-	 * The result of this method throwing a
-	 * {@code MessageFormatRuntimeException} depends on the session mode:
-	 * <ul>
-	 * <li>{@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}: The JMS
-	 * provider will behave as if the unsuccessful call to {@code receiveBodyNoWait} had
-	 * not occurred. The message will be delivered again before any subsequent
-	 * messages.
-	 * <p>
-	 * This is not considered to be redelivery and does not cause the
-	 * {@code JMSRedelivered} message header field to be set or the
-	 * {@code JMSXDeliveryCount} message property to be incremented.</li>
-	 * <li>{@code CLIENT_ACKNOWLEDGE}: The JMS provider will behave as if the
-	 * call to {@code receiveBodyNoWait} had been successful and will not deliver the
-	 * message again.
-	 * <p>
-	 * As with any message that is delivered with a session mode of
-	 * {@code CLIENT_ACKNOWLEDGE}, the message will not be acknowledged until
-	 * {@code acknowledge} is called on the {@code JMSContext}. If an
-	 * application wishes to have the failed message redelivered, it must call
-	 * {@code recover} on the {@code JMSContext}. The redelivered message's
-	 * {@code JMSRedelivered} message header field will be set and its
-	 * {@code JMSXDeliveryCount} message property will be incremented.</li>
-	 * 
-	 * <li>Transacted session: The JMS provider will behave as if the call to
-	 * {@code receiveBodyNoWait} had been successful and will not deliver the message
-	 * again.
-	 * <p>
-	 * As with any message that is delivered in a transacted session, the
-	 * transaction will remain uncommitted until the transaction is committed or
-	 * rolled back by the application. If an application wishes to have the
-	 * failed message redelivered, it must roll back the transaction. The
-	 * redelivered message's {@code JMSRedelivered} message header field will be
-	 * set and its {@code JMSXDeliveryCount} message property will be
-	 * incremented.</li>
-	 * </ul>
-	 * 
-	 * @param c
-	 *            The type to which the body of the next message should be
-	 *            assigned.<br>
-	 *            If the next message is expected to be a {@code TextMessage}
-	 *            then this should be set to {@code String.class} or another
-	 *            class to which a {@code String} is assignable.<br>
-	 *            If the next message is expected to be a {@code ObjectMessage}
-	 *            then this should be set to {@code java.io.Serializable.class}
-	 *            or another class to which the body is assignable. <br>
-	 *            If the next message is expected to be a {@code MapMessage}
-	 *            then this should be set to {@code java.util.Map.class}
-	 *            (or {@code java.lang.Object.class}).<br>
-	 *            If the next message is expected to be a {@code BytesMessage}
-	 *            then this should be set to {@code byte[].class}
-	 *            (or {@code java.lang.Object.class}).<br>
-	 * 
-	 * @return the body of the next message produced for this {@code JMSConsumer},
-	 *         or null if one is not immediately available or this {@code JMSConsumer} is concurrently closed
-	 * 
-	 * @throws MessageFormatRuntimeException
-	 *             <ul>
-	 *             <li>if the message is not one of the supported types listed above
-	 *             <li>if the message body cannot be assigned to the specified type
-	 *             <li>if the message has no body
-	 *             <li>if the message is an {@code ObjectMessage} and object deserialization fails.
-	 *             </ul>
-	 *             
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to receive the next message due
-	 *             to some internal error
 
-	 */
+    /**
+     * Receives the next message produced for this {@code JMSConsumer} if one is immediately available and returns its body
+     * as an object of the specified type. This method may be used to receive any type of message except for
+     * {@code StreamMessage} and {@code Message}, so long as the message has a body which is capable of being assigned to
+     * the specified type. This means that the specified class or interface must either be the same as, or a superclass or
+     * superinterface of, the class of the message body. If the message is not one of the supported types, or its body
+     * cannot be assigned to the specified type, or it has no body, then a {@code MessageFormatRuntimeException} is thrown.
+     * <p>
+     * This method does not give access to the message headers or properties (such as the {@code JMSRedelivered} message
+     * header field or the {@code JMSXDeliveryCount} message property) and should only be used if the application has no
+     * need to access them.
+     *
+     * <p>
+     * If a message is not immediately available null is returned.
+     *
+     * <p>
+     * If this method is called within a transaction, the {@code JMSConsumer} retains the message until the transaction
+     * commits.
+     *
+     * <p>
+     * The result of this method throwing a {@code MessageFormatRuntimeException} depends on the session mode:
+     * <ul>
+     * <li>{@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}: The JMS provider will behave as if the unsuccessful call
+     * to {@code receiveBodyNoWait} had not occurred. The message will be delivered again before any subsequent messages.
+     *
+     * This is not considered to be redelivery and does not cause the {@code JMSRedelivered} message header field to be set
+     * or the {@code JMSXDeliveryCount} message property to be incremented.</li>
+     * <li>{@code CLIENT_ACKNOWLEDGE}: The JMS provider will behave as if the call to {@code receiveBodyNoWait} had been
+     * successful and will not deliver the message again.
+     *
+     * As with any message that is delivered with a session mode of {@code CLIENT_ACKNOWLEDGE}, the message will not be
+     * acknowledged until {@code acknowledge} is called on the {@code JMSContext}. If an application wishes to have the
+     * failed message redelivered, it must call {@code recover} on the {@code JMSContext}. The redelivered message's
+     * {@code JMSRedelivered} message header field will be set and its {@code JMSXDeliveryCount} message property will be
+     * incremented.</li>
+     *
+     * <li>Transacted session: The JMS provider will behave as if the call to {@code receiveBodyNoWait} had been successful
+     * and will not deliver the message again.
+     *
+     * As with any message that is delivered in a transacted session, the transaction will remain uncommitted until the
+     * transaction is committed or rolled back by the application. If an application wishes to have the failed message
+     * redelivered, it must roll back the transaction. The redelivered message's {@code JMSRedelivered} message header field
+     * will be set and its {@code JMSXDeliveryCount} message property will be incremented.</li>
+     * </ul>
+     *
+     * @param <T> The type of the message body
+     * @param c The type to which the body of the next message should be assigned.<br>
+     * If the next message is expected to be a {@code TextMessage} then this should be set to {@code String.class} or
+     * another class to which a {@code String} is assignable.<br>
+     * If the next message is expected to be a {@code ObjectMessage} then this should be set to
+     * {@code java.io.Serializable.class} or another class to which the body is assignable. <br>
+     * If the next message is expected to be a {@code MapMessage} then this should be set to {@code java.util.Map.class} (or
+     * {@code java.lang.Object.class}).<br>
+     * If the next message is expected to be a {@code BytesMessage} then this should be set to {@code byte[].class} (or
+     * {@code java.lang.Object.class}).<br>
+     *
+     * @return the body of the next message produced for this {@code JMSConsumer}, or null if one is not immediately
+     * available or this {@code JMSConsumer} is concurrently closed
+     *
+     * @throws MessageFormatRuntimeException
+     * <ul>
+     * <li>if the message is not one of the supported types listed above
+     * <li>if the message body cannot be assigned to the specified type
+     * <li>if the message has no body
+     * <li>if the message is an {@code ObjectMessage} and object deserialization fails.
+     * </ul>
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to receive the next message due to some internal error
+     *
+     */
     <T> T receiveBodyNoWait(Class<T> c);
-    
+
 }

--- a/src/main/java/javax/jms/JMSContext.java
+++ b/src/main/java/javax/jms/JMSContext.java
@@ -19,1610 +19,1328 @@ package javax.jms;
 import java.io.Serializable;
 
 /**
- * A {@code JMSContext} is the main interface in the simplified JMS API
- * introduced for JMS 2.0. This combines in a single object the functionality of
- * two separate objects from the JMS 1.1 API: a {@code Connection} and a
+ * A {@code JMSContext} is the main interface in the simplified JMS API introduced for JMS 2.0. This combines in a
+ * single object the functionality of two separate objects from the JMS 1.1 API: a {@code Connection} and a
  * {@code Session}.
+ *
  * <p>
- * When an application needs to send messages it use the
- * {@code createProducer} method to create a {@code JMSProducer} which
- * provides methods to configure and send messages. Messages may be sent either
- * synchronously or asynchronously.
+ * When an application needs to send messages it use the {@code createProducer} method to create a {@code JMSProducer}
+ * which provides methods to configure and send messages. Messages may be sent either synchronously or asynchronously.
+ *
  * <p>
- * When an application needs to receive messages it uses one of several
- * {@code createConsumer} or {@code createDurableConsumer} methods to
- * create a {@code JMSConsumer} . A {@code JMSConsumer} provides
- * methods to receive messages either synchronously or asynchronously.
+ * When an application needs to receive messages it uses one of several {@code createConsumer} or
+ * {@code createDurableConsumer} methods to create a {@code JMSConsumer} . A {@code JMSConsumer} provides methods to
+ * receive messages either synchronously or asynchronously.
+ *
  * <p>
- * In terms of the JMS 1.1 API a {@code JMSContext} should be thought of as
- * representing both a {@code Connection} and a {@code Session}.
- * Although the simplified API removes the need for applications to use those
- * objects, the concepts of connection and session remain important. A
- * connection represents a physical link to the JMS server and a session
+ * In terms of the JMS 1.1 API a {@code JMSContext} should be thought of as representing both a {@code Connection} and a
+ * {@code Session}. Although the simplified API removes the need for applications to use those objects, the concepts of
+ * connection and session remain important. A connection represents a physical link to the JMS server and a session
  * represents a single-threaded context for sending and receiving messages.
+ *
  * <p>
- * A {@code JMSContext} may be created by calling one of several
- * {@code createContext} methods on a {@code ConnectionFactory}. A
- * {@code JMSContext} that is created in this way is described as being
- * <i>application-managed</i>. An application-managed {@code JMSContext}
- * must be closed when no longer needed by calling its {@code close}
- * method.
+ * A {@code JMSContext} may be created by calling one of several {@code createContext} methods on a
+ * {@code ConnectionFactory}. A {@code JMSContext} that is created in this way is described as being
+ * <i>application-managed</i>. An application-managed {@code JMSContext} must be closed when no longer needed by calling
+ * its {@code close} method.
+ *
  * <p>
- * Applications running in the Java EE web and EJB containers may alternatively
- * inject a {@code JMSContext} into their application using the
- * {@code @Inject} annotation. A {@code JMSContext} that is created in
- * this way is described as being <i>container-managed</i>. A 
- * container-managed {@code JMSContext} will be closed automatically by
- * the container. 
+ * Applications running in the Java EE web and EJB containers may alternatively inject a {@code JMSContext} into their
+ * application using the {@code @Inject} annotation. A {@code JMSContext} that is created in this way is described as
+ * being <i>container-managed</i>. A container-managed {@code JMSContext} will be closed automatically by the container.
+ *
  * <p>
- * Applications running in the Java EE web and EJB containers are not permitted
- * to create more than one active session on a connection so combining them in a
- * single object takes advantage of this restriction to offer a simpler API.
+ * Applications running in the Java EE web and EJB containers are not permitted to create more than one active session
+ * on a connection so combining them in a single object takes advantage of this restriction to offer a simpler API.
+ *
  * <p>
- * However applications running in a Java SE environment or in the Java EE
- * application client container are permitted to create multiple active sessions
- * on the same connection. This allows the same physical connection to be used
- * in multiple threads simultaneously. Such applications which require multiple
- * sessions to be created on the same connection should use one of the
- * {@code createContext} methods on the {@code ConnectionFactory} to
- * create the first {@code JMSContext} and then use the
- * {@code createContext} method on {@code JMSContext} to create
- * additional {@code JMSContext} objects that use the same connection. All
- * these {@code JMSContext} objects are application-managed and must be
- * closed when no longer needed by calling their {@code close} method.
- * 
+ * However applications running in a Java SE environment or in the Java EE application client container are permitted to
+ * create multiple active sessions on the same connection. This allows the same physical connection to be used in
+ * multiple threads simultaneously. Such applications which require multiple sessions to be created on the same
+ * connection should use one of the {@code createContext} methods on the {@code ConnectionFactory} to create the first
+ * {@code JMSContext} and then use the {@code createContext} method on {@code JMSContext} to create additional
+ * {@code JMSContext} objects that use the same connection. All these {@code JMSContext} objects are application-managed
+ * and must be closed when no longer needed by calling their {@code close} method.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  */
 public interface JMSContext extends AutoCloseable {
 
-	/**
-	 * Creates a new {@code JMSContext} with the specified session mode
-	 * using the same connection as this {@code JMSContext} and creating a
-	 * new session.
-	 * <p>
-	 * This method does not start the connection. If the connection has not
-	 * already been started then it will be automatically started when a
-	 * {@code JMSConsumer} is created on any of the {@code JMSContext}
-	 * objects for that connection.
-	 * <p>
-	 * <ul>
-	 * <li>If {@code sessionMode} is set to
-	 * {@code JMSContext.SESSION_TRANSACTED} then the session will use a
-	 * local transaction which may subsequently be committed or rolled back by
-	 * calling the {@code JMSContext}'s {@code commit} or
-	 * {@code rollback} methods.
-	 * <li>If {@code sessionMode} is set to any of
-	 * {@code JMSContext.CLIENT_ACKNOWLEDGE},
-	 * {@code JMSContext.AUTO_ACKNOWLEDGE} or
-	 * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. then the session will be
-	 * non-transacted and messages received by this session will be acknowledged
-	 * according to the value of {@code sessionMode}. For a definition of
-	 * the meaning of these acknowledgement modes see the links below.
-	 * </ul>
-	 * <p>
-	 * This method must not be used by applications running in the Java EE web
-	 * or EJB containers because doing so would violate the restriction that
-	 * such an application must not attempt to create more than one active (not
-	 * closed) {@code Session} object per connection. If this method is
-	 * called in a Java EE web or EJB container then a
-	 * {@code JMSRuntimeException} will be thrown.
-	 * 
-	 * @param sessionMode
-	 *            indicates which of four possible session modes will be used.
-	 *            The permitted values are
-	 *            {@code JMSContext.SESSION_TRANSACTED},
-	 *            {@code JMSContext.CLIENT_ACKNOWLEDGE},
-	 *            {@code JMSContext.AUTO_ACKNOWLEDGE} and
-	 *            {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
-	 * 
-	 * @return a newly created JMSContext
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create the JMSContext due to
-	 *                <ul>
-	 *                <li>some internal error or <li>because this method is
-	 *                being called in a Java EE web or EJB application.
-	 *                </ul>
-	 * @since JMS 2.0
-	 * 
-	 * @see JMSContext#SESSION_TRANSACTED
-	 * @see JMSContext#CLIENT_ACKNOWLEDGE
-	 * @see JMSContext#AUTO_ACKNOWLEDGE
-	 * @see JMSContext#DUPS_OK_ACKNOWLEDGE
-	 * 
-	 * @see javax.jms.ConnectionFactory#createContext()
-	 * @see javax.jms.ConnectionFactory#createContext(int)
-	 * @see javax.jms.ConnectionFactory#createContext(java.lang.String,
-	 *      java.lang.String)
-	 * @see javax.jms.ConnectionFactory#createContext(java.lang.String,
-	 *      java.lang.String, int)
-	 * @see javax.jms.JMSContext#createContext(int)
-	 */
-	JMSContext createContext(int sessionMode);
-
-	/**
-	 * Creates a new {@code JMSProducer} object which can be used to
-	 * configure and send messages
-	 * 
-	 * @return A new {@code JMSProducer} object
-	 * 
-	 * @see javax.jms.JMSProducer
-	 */
-	JMSProducer createProducer();
-
-	/**
-	 * Gets the client identifier for the JMSContext's connection.
-	 * 
-	 * <P>
-	 * This value is specific to the JMS provider. It is either preconfigured by
-	 * an administrator in a {@code ConnectionFactory} object or assigned
-	 * dynamically by the application by calling the {@code setClientID}
-	 * method.
-	 * 
-	 * @return the unique client identifier
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to return the client ID for the
-	 *                JMSContext's connection due to some internal error.
-	 * 
-	 **/
-	String getClientID();
-
-	/**
-	 * Sets the client identifier for the JMSContext's connection.
-	 * 
-	 * <P>
-	 * The preferred way to assign a JMS client's client identifier is for it to
-	 * be configured in a client-specific {@code ConnectionFactory} object
-	 * and transparently assigned to the {@code Connection} object it
-	 * creates.
-	 * 
-	 * <P>
-	 * Alternatively, a client can set the client identifier for the
-	 * JMSContext's connection using a provider-specific value. The facility
-	 * to set its client identifier explicitly is not a mechanism for overriding
-	 * the identifier that has been administratively configured. It is provided
-	 * for the case where no administratively specified identifier exists. If
-	 * one does exist, an attempt to change it by setting it must throw an
-	 * {@code IllegalStateRuntimeException}. If a client sets the client
-	 * identifier explicitly, it must do so immediately after it creates the
-	 * JMSContext and before any other action on the JMSContext is taken. After
-	 * this point, setting the client identifier is a programming error that
-	 * should throw an {@code IllegalStateRuntimeException}.
-	 * 
-	 * <P>
-	 * The purpose of the client identifier is to associate the JMSContext's
-	 * connection and its objects with a state maintained on behalf of the
-	 * client by a provider. The only such state identified by the JMS API is
-	 * that required to support durable subscriptions.
-	 * 
-	 * <P>
-	 * If another connection with the same {@code clientID} is already
-	 * running when this method is called, the JMS provider should detect the
-	 * duplicate ID and throw an {@code InvalidClientIDException}.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSRuntimeException} to be thrown though this
-	 * is not guaranteed.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @param clientID
-	 *            the unique client identifier
-	 * 
-	 * 
-	 * @throws InvalidClientIDRuntimeException
-	 *             if the JMS client specifies an invalid or duplicate client
-	 *             ID.
-	 * @throws IllegalStateRuntimeException
-	 *             <ul>
-	 *             <li>if the JMS client attempts to set the client ID for the
-	 *             JMSContext's connection at the wrong time or 
-	 *             <li>if the client ID has been administratively configured or
-	 *             <li>if the {@code JMSContext} is container-managed (injected).
-	 *             </ul>
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to set the client ID for the the
-	 *                JMSContext's connection for one of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred or <li>this method has
-	 *                been called in a Java EE web or EJB application (though it
-	 *                is not guaranteed that an exception is thrown in this
-	 *                case) 
-	 *                </ul>
-	 */
-
-	void setClientID(String clientID);
-
-	/**
-	 * Gets the connection metadata for the JMSContext's connection.
-	 * 
-	 * @return the connection metadata
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the connection metadata
-	 * 
-	 * @see javax.jms.ConnectionMetaData
-	 */
-
-	ConnectionMetaData getMetaData();
-
-	/**
-	 * Gets the {@code ExceptionListener} object for the JMSContext's
-	 * connection. Not every {@code Connection} has an
-	 * {@code ExceptionListener} associated with it.
-	 * 
-	 * @return the {@code ExceptionListener} for the JMSContext's
-	 *         connection, or null if no {@code ExceptionListener} is
-	 *         associated with that connection.
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the
-	 *             {@code ExceptionListener} for the JMSContext's
-	 *             connection.
-	 * @see javax.jms.Connection#setExceptionListener
-	 */
-
-	ExceptionListener getExceptionListener();
-
-	/**
-	 * Sets an exception listener for the JMSContext's connection.
-	 * 
-	 * <P>
-	 * If a JMS provider detects a serious problem with a connection, it informs
-	 * the connection's {@code ExceptionListener}, if one has been
-	 * registered. It does this by calling the listener's
-	 * {@code onException} method, passing it a {@code JMSRuntimeException}
-	 * object describing the problem.
-	 * 
-	 * <P>
-	 * An exception listener allows a client to be notified of a problem
-	 * asynchronously. Some connections only consume messages, so they would
-	 * have no other way to learn their connection has failed.
-	 * 
-	 * <P>
-	 * A connection serializes execution of its {@code ExceptionListener}.
-	 * 
-	 * <P>
-	 * A JMS provider should attempt to resolve connection problems itself
-	 * before it notifies the client of them.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSRuntimeException} to be thrown though this
-	 * is not guaranteed.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @param listener
-	 *            the exception listener
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                if the {@code JMSContext} is container-managed (injected).
-	 *                
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to set the exception listener
-	 *                for one of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred or <li>this method has
-	 *                been called in a Java EE web or EJB application (though it
-	 *                is not guaranteed that an exception is thrown in this
-	 *                case) 
-	 *                </ul>
-	 */
-	void setExceptionListener(ExceptionListener listener);
-
-	/**
-	 * Starts (or restarts) delivery of incoming messages by the JMSContext's
-	 * connection. A call to {@code start} on a connection that has already
-	 * been started is ignored.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                if the {@code JMSContext} is container-managed (injected).
-	 *                
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to start message delivery due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.JMSContext#stop
-	 */
-	void start();
-
-	/**
-	 * Temporarily stops the delivery of incoming messages by the JMSContext's
-	 * connection. Delivery can be restarted using the {@code start}
-	 * method. When the connection is stopped, delivery to all the connection's
-	 * message consumers is inhibited: synchronous receives block, and messages
-	 * are not delivered to message listeners.
-	 * 
-	 * <P>
-	 * Stopping a connection has no effect on its ability to send messages. A
-	 * call to {@code stop} on a connection that has already been stopped
-	 * is ignored.
-	 * 
-	 * <P>
-	 * A call to {@code stop} must not return until delivery of messages
-	 * has paused. This means that a client can rely on the fact that none of
-	 * its message listeners will be called and that all threads of control
-	 * waiting for {@code receive} calls to return will not return with a
-	 * message until the connection is restarted. The receive timers for a
-	 * stopped connection continue to advance, so receives may time out while
-	 * the connection is stopped.
-	 * 
-	 * <P>
-	 * If message listeners are running when {@code stop} is invoked, the
-	 * {@code stop} call must wait until all of them have returned before
-	 * it may return. While these message listeners are completing, they must
-	 * have the full services of the connection available to them.
-	 * <p>
-	 * However if the stop method is called from a message listener on its own
-	 * {@code JMSContext}, or any other {@code JMSContext} that uses the same connection,
-	 * then it will either fail and throw a {@code javax.jms.IllegalStateRuntimeException},
-	 * or it will succeed and stop the connection, blocking until all other message
-	 * listeners that may have been running have returned.
-	 * <p>
-	 * Since two alternative behaviors are permitted in this case, applications
-	 * should avoid calling {@code stop} from a message listener on its own {@code JMSContext}, or
-	 * any other {@code JMSContext} that uses the same connection, because this is not
-	 * portable.
-	 * <p>
-	 * For the avoidance of doubt, if an exception listener for the JMSContext's
-	 * connection is running when {@code stop} is invoked, there is no
-	 * requirement for the {@code stop} call to wait until the exception
-	 * listener has returned before it may return.
-	 * <p>
-	 * This method must not be used in a Java EE web or EJB application. Doing
-	 * so may cause a {@code JMSRuntimeException} to be thrown though this
-	 * is not guaranteed.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                <ul>
-	 *                <li>if this method has been called by a <tt>MessageListener</tt>
-	 *                on its own <tt>JMSContext</tt>
-	 *                <li>if the {@code JMSContext} is container-managed (injected).
-	 *                </ul>
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to stop message delivery for one
-	 *                of the following reasons:
-	 *                <ul>
-	 *                <li>an internal error has occurred or <li>this method has
-	 *                been called in a Java EE web or EJB application (though it
-	 *                is not guaranteed that an exception is thrown in this
-	 *                case) 
-	 *                </ul>
-	 *                
-	 * @see javax.jms.JMSContext#start
-	 */
-	void stop();
-
-	/**
-	 * Specifies whether the underlying connection used by this
-	 * {@code JMSContext} will be started automatically when a consumer is
-	 * created. This is the default behaviour, and it may be disabled by calling
-	 * this method with a value of {@code false}.
-	 * <p>
-	 * This method does not itself either start or stop the connection.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @param autoStart
-	 *            Whether the underlying connection used by this
-	 *            {@code JMSContext} will be automatically started when a
-	 *            consumer is created.
-	 * @exception IllegalStateRuntimeException
-	 *                if the {@code JMSContext} is container-managed (injected)
-	 * 
-	 * @see javax.jms.JMSContext#getAutoStart
-	 */
-	public void setAutoStart(boolean autoStart);
-
-	/**
-	 * Returns whether the underlying connection used by this
-	 * {@code JMSContext} will be started automatically when a consumer is
-	 * created.
-	 * 
-	 * @return whether the underlying connection used by this
-	 *         {@code JMSContext} will be started automatically when a
-	 *         consumer is created.
-	 * 
-	 * @see javax.jms.JMSContext#setAutoStart
-	 */
-	public boolean getAutoStart();
-
-	/**
-	 * Closes the JMSContext
-	 * <p>
-	 * This closes the underlying session and any underlying producers and
-	 * consumers. If there are no other active (not closed) JMSContext objects
-	 * using the underlying connection then this method also closes the
-	 * underlying connection.
-	 * 
-	 * <P>
-	 * Since a provider typically allocates significant resources outside the
-	 * JVM on behalf of a connection, clients should close these resources when
-	 * they are not needed. Relying on garbage collection to eventually reclaim
-	 * these resources may not be timely enough.
-	 * 
-	 * <P>
-	 * Closing a connection causes all temporary destinations to be deleted.
-	 * 
-	 * <P>
-	 * When this method is invoked, it should not return until message
-	 * processing has been shut down in an orderly fashion. This means that all
-	 * message listeners that may have been running have returned, and that all
-	 * pending receives have returned. A close terminates all pending message
-	 * receives on the connection's sessions' consumers. The receives may return
-	 * with a message or with null, depending on whether there was a message
-	 * available at the time of the close. If one or more of the connection's
-	 * sessions' message listeners is processing a message at the time when
-	 * connection {@code close} is invoked, all the facilities of the
-	 * connection and its sessions must remain available to those listeners
-	 * until they return control to the JMS provider.
-	 * <p>
-	 * However if the close method is called from a message listener on its own
-	 * {@code JMSContext}, then it will either fail and throw a
-	 * {@code javax.jms.IllegalStateRuntimeException}, or it will succeed and close the
-	 * {@code JMSContext}. If {@code close} succeeds and the session mode of the 
-	 * {@code JMSContext} is set to {@code AUTO_ACKNOWLEDGE}, the current message
-	 * will still be acknowledged automatically when the onMessage call completes.
-	 * <p>
-	 * Since two alternative behaviors are permitted in this case, applications
-	 * should avoid calling close from a message listener on its own
-	 * {@code JMSContext} because this is not portable.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>JMSContext</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	 * For the avoidance of doubt, if an exception listener for the JMSContext's
-	 * connection is running when {@code close} is invoked, there is no
-	 * requirement for the {@code close} call to wait until the exception
-	 * listener has returned before it may return.
-	 * <P>
-	 * Closing a connection causes any of its sessions' transactions in progress
-	 * to be rolled back. In the case where a session's work is coordinated by
-	 * an external transaction manager, a session's {@code commit} and
-	 * {@code rollback} methods are not used and the result of a closed
-	 * session's work is determined later by the transaction manager.
-	 * <p>
-	 * Closing a connection does NOT force an acknowledgment of
-	 * client-acknowledged sessions.
-	 * <P>
-	 * Invoking the {@code acknowledge} method of a received message from a
-	 * closed connection's session must throw an
-	 * {@code IllegalStateRuntimeException}. Closing a closed connection must NOT
-	 * throw an exception.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>JMSContext</tt>. Doing so will cause an
-	 * <tt>IllegalStateRuntimeException</tt> to be thrown.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                <ul>
-	 *                <li>if this method has been called by a <tt>MessageListener
-	 *                </tt> on its own <tt>JMSContext</tt></li> <li>if this method
-	 *                has been called by a <tt>CompletionListener</tt> callback
-	 *                method on its own <tt>JMSContext</tt></li>
-	 *                <li>if the {@code JMSContext} is container-managed (injected)</li>
-	 *                </ul>
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to close the
-	 *                {@code JMSContext} due to some internal error. For example, a
-	 *                failure to release resources or to close a socket
-	 *                connection can cause this exception to be thrown. 
-	 */
-	void close();
-
-	/**
-	 * With this session mode, the JMSContext's session automatically
-	 * acknowledges a client's receipt of a message either when the session has
-	 * successfully returned from a call to {@code receive} or when the
-	 * message listener the session has called to process the message
-	 * successfully returns.
-	 */
-
-	static final int AUTO_ACKNOWLEDGE = Session.AUTO_ACKNOWLEDGE;
-
-	/**
-	 * With this session mode, the client acknowledges a consumed message by
-	 * calling the message's {@code acknowledge} method. Acknowledging a
-	 * consumed message acknowledges all messages that the session has consumed.
-	 * 
-	 * <P>
-	 * When this session mode is used, a client may build up a large number of
-	 * unacknowledged messages while attempting to process them. A JMS provider
-	 * should provide administrators with a way to limit client overrun so that
-	 * clients are not driven to resource exhaustion and ensuing failure when
-	 * some resource they are using is temporarily blocked.
-	 * 
-	 * @see javax.jms.Message#acknowledge()
-	 */
-
-	static final int CLIENT_ACKNOWLEDGE = Session.CLIENT_ACKNOWLEDGE;
-
-	/**
-	 * This session mode instructs the JMSContext's session to lazily
-	 * acknowledge the delivery of messages. This is likely to result in the
-	 * delivery of some duplicate messages if the JMS provider fails, so it
-	 * should only be used by consumers that can tolerate duplicate messages.
-	 * Use of this mode can reduce session overhead by minimizing the work the
-	 * session does to prevent duplicates.
-	 */
-
-	static final int DUPS_OK_ACKNOWLEDGE = Session.DUPS_OK_ACKNOWLEDGE;
-
-	/**
-	 * This session mode instructs the JMSContext's session to deliver and
-	 * consume messages in a local transaction which will be subsequently
-	 * committed by calling {@code commit} or rolled back by calling
-	 * {@code rollback}.
-	 */
-	static final int SESSION_TRANSACTED = Session.SESSION_TRANSACTED;
-
-	/**
-	 * Creates a {@code BytesMessage} object. A {@code BytesMessage}
-	 * object is used to send a message containing a stream of uninterpreted
-	 * bytes.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	BytesMessage createBytesMessage();
-
-	/**
-	 * Creates a {@code MapMessage} object. A {@code MapMessage}
-	 * object is used to send a self-defining set of name-value pairs, where
-	 * names are {@code String} objects and values are primitive values in
-	 * the Java programming language.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	MapMessage createMapMessage();
-
-	/**
-	 * Creates a {@code Message} object. The {@code Message} interface
-	 * is the root interface of all JMS messages. A {@code Message} object
-	 * holds all the standard message header information. It can be sent when a
-	 * message containing only header information is sufficient.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	Message createMessage();
-
-	/**
-	 * Creates an {@code ObjectMessage} object. An
-	 * {@code ObjectMessage} object is used to send a message that contains
-	 * a serializable Java object.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	ObjectMessage createObjectMessage();
-
-	/**
-	 * Creates an initialized {@code ObjectMessage} object. An
-	 * {@code ObjectMessage} object is used to send a message that contains
-	 * a serializable Java object.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @param object
-	 *            the object to use to initialize this message
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	ObjectMessage createObjectMessage(Serializable object);
-
-	/**
-	 * Creates a {@code StreamMessage} object. A {@code StreamMessage}
-	 * object is used to send a self-defining stream of primitive values in the
-	 * Java programming language.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	StreamMessage createStreamMessage();
-
-	/**
-	 * Creates a {@code TextMessage} object. A {@code TextMessage}
-	 * object is used to send a message containing a {@code String} object.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	TextMessage createTextMessage();
-
-	/**
-	 * Creates an initialized {@code TextMessage} object. A
-	 * {@code TextMessage} object is used to send a message containing a
-	 * {@code String}.
-	 * <p>
-	 * The message object returned may be sent using any {@code Session} or
-	 * {@code JMSContext}. It is not restricted to being sent using the
-	 * {@code JMSContext} used to create it.
-	 * <p>
-	 * The message object returned may be optimised for use with the JMS
-	 * provider used to create it. However it can be sent using any JMS
-	 * provider, not just the JMS provider used to create it.
-	 * 
-	 * @param text
-	 *            the string used to initialize this message
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create this message due to
-	 *                some internal error.
-	 */
-
-	TextMessage createTextMessage(String text);
-
-	/**
-	 * Indicates whether the JMSContext's session is in transacted mode.
-	 * 
-	 * @return true if the session is in transacted mode
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to return the transaction mode
-	 *                due to some internal error.
-	 */
-
-	boolean getTransacted();
-
-	/**
-	 * Returns the session mode of the JMSContext's session. This can be set at
-	 * the time that the JMSContext is created. Possible values are
-	 * JMSContext.SESSION_TRANSACTED, JMSContext.AUTO_ACKNOWLEDGE,
-	 * JMSContext.CLIENT_ACKNOWLEDGE and JMSContext.DUPS_OK_ACKNOWLEDGE
-	 * <p>
-	 * If a session mode was not specified when the JMSContext was created a
-	 * value of JMSContext.AUTO_ACKNOWLEDGE will be returned.
-	 * 
-	 * @return the session mode of the JMSContext's session
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to return the acknowledgment
-	 *                mode due to some internal error.
-	 * 
-	 * @see Connection#createSession
-	 * @since JMS 2.0
-	 */
-	int getSessionMode();
-
-	/**
-	 * Commits all messages done in this transaction and releases any locks
-	 * currently held.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>JMSContext</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>commit</tt> on its own <tt>JMSContext</tt>. Doing so will cause an
-	 * <tt>IllegalStateRuntimeException</tt> to be thrown.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                <ul>
-	 *                <li>if the <tt>JMSContext</tt>'s session is not using a local
-	 *                transaction 
-	 *                <li>if this method has been called by a <tt>
-	 *                CompletionListener</tt> callback method on its own <tt>
-	 *                JMSContext</tt></li>
-	 *                <li>if the {@code JMSContext} is container-managed (injected)
-	 *                </ul>
-	 * @exception TransactionRolledBackRuntimeException
-	 *                if the transaction is rolled back due to some internal
-	 *                error during commit.
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to commit the transaction due to some internal error                
-	 * 
-	 */
-
-	void commit();
-
-	/**
-	 * Rolls back any messages done in this transaction and releases any locks
-	 * currently held.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>JMSContext</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>rollback</tt> on its own <tt>JMSContext</tt>. Doing so will cause an
-	 * <tt>IllegalStateRuntimeException</tt> to be thrown.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                <ul>
-	 *                <li>if the <tt>JMSContext</tt>'s session is not using a local transaction
-	 *                <li>if this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>JMSContext</tt></li>
-	 *                <li>if the {@code JMSContext} is container-managed (injected)
-	 *                </ul>
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to roll back the transaction due to some internal error 
-	 * 
-	 */
-	void rollback();
-
-	/**
-	 * Stops message delivery in the JMSContext's session, and restarts message
-	 * delivery with the oldest unacknowledged message.
-	 * 
-	 * <P>
-	 * All consumers deliver messages in a serial order. Acknowledging a
-	 * received message automatically acknowledges all messages that have been
-	 * delivered to the client.
-	 * 
-	 * <P>
-	 * Restarting a session causes it to take the following actions:
-	 * 
-	 * <UL>
-	 * <LI>Stop message delivery
-	 * <LI>Mark all messages that might have been delivered but not acknowledged
-	 * as "redelivered"
-	 * <LI>Restart the delivery sequence including all unacknowledged messages
-	 * that had been previously delivered. Redelivered messages do not have to
-	 * be delivered in exactly their original delivery order.
-	 * </UL>
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                <ul>
-	 *                <li>if the <tt>JMSContext</tt>'s session is using a transaction
-	 *                <li>if the {@code JMSContext} is container-managed (injected)
-	 *                </ul>
-	 * @exception JMSRuntimeException
-	 *                 if the JMS provider fails to stop and restart message delivery due to some internal error
-	 */
-
-	void recover();
-
-	/**
-	 * Creates a {@code JMSConsumer} for the specified destination.
-	 * 
-	 * <P>
-	 * A client uses a {@code JMSConsumer} object to receive messages that
-	 * have been sent to a destination.
-	 * 
-	 * @param destination
-	 *            the {@code Destination} to access.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the session fails to create a {@code JMSConsumer}
-	 *                due to some internal error.
-	 * @exception InvalidDestinationRuntimeException
-	 *                if an invalid destination is specified.
-	 */
-	JMSConsumer createConsumer(Destination destination);
-
-	/**
-	 * Creates a {@code JMSConsumer} for the specified destination, using a
-	 * message selector.
-	 * <P>
-	 * A client uses a {@code JMSConsumer} object to receive messages that
-	 * have been sent to a destination.
-	 * 
-	 * @param destination
-	 *            the {@code Destination} to access
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the
-	 *            {@code JMSConsumer}.
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the session fails to create a {@code JMSConsumer} due
-	 *             to some internal error.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if an invalid destination is specified.
-	 * @throws InvalidSelectorRuntimeException
-	 *             if the message selector is invalid.
-	 */
-	JMSConsumer createConsumer(Destination destination, java.lang.String messageSelector);
-
-	/**
-	 * Creates a {@code JMSConsumer} for the specified destination,
-	 * specifying a message selector and the {@code noLocal} parameter.
-	 * <P>
-	 * A client uses a {@code JMSConsumer} object to receive messages that
-	 * have been sent to a destination.
-	 * <P>
-	 * The {@code noLocal} argument is for use when the destination is a
-	 * topic and the JMSContext's connection is also being used to publish
-	 * messages to that topic. If {@code noLocal} is set to true then the
-	 * {@code JMSConsumer} will not receive messages published to the topic
-	 * by its own connection. The default value of this argument is false. If
-	 * the destination is a queue then the effect of setting
-	 * {@code noLocal} to true is not specified.
-	 * 
-	 * @param destination
-	 *            the {@code Destination} to access
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the
-	 *            {@code JMSConsumer}.
-	 * @param noLocal
-	 *            if true, and the destination is a topic, then the
-	 *            {@code JMSConsumer} will not receive messages published
-	 *            to the topic by its own connection
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the session fails to create a {@code JMSConsumer} due
-	 *             to some internal error.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if an invalid destination is specified.
-	 * @throws InvalidSelectorRuntimeException
-	 *             if the message selector is invalid.
-	 */
-	JMSConsumer createConsumer(Destination destination, java.lang.String messageSelector, boolean noLocal);
-
-	/**
-	 * Creates a {@code Queue} object which encapsulates a specified
-	 * provider-specific queue name.
-	 * <p>
-	 * The use of provider-specific queue names in an application may render the
-	 * application non-portable. Portable applications are recommended to not
-	 * use this method but instead look up an administratively-defined
-	 * {@code Queue} object using JNDI.
-	 * <p>
-	 * Note that this method simply creates an object that encapsulates the name
-	 * of a queue. It does not create the physical queue in the JMS provider.
-	 * JMS does not provide a method to create the physical queue, since this
-	 * would be specific to a given JMS provider. Creating a physical queue is
-	 * provider-specific and is typically an administrative task performed by an
-	 * administrator, though some providers may create them automatically when
-	 * needed. The one exception to this is the creation of a temporary queue,
-	 * which is done using the {@code createTemporaryQueue} method.
-	 * 
-	 * @param queueName
-	 *            A provider-specific queue name
-	 * @return a Queue object which encapsulates the specified name
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if a Queue object cannot be created due to some internal
-	 *             error
-	 */
-	Queue createQueue(String queueName);
-
-	/**
-	 * Creates a {@code Topic} object which encapsulates a specified
-	 * provider-specific topic name.
-	 * <p>
-	 * The use of provider-specific topic names in an application may render the
-	 * application non-portable. Portable applications are recommended to not
-	 * use this method but instead look up an administratively-defined
-	 * {@code Topic} object using JNDI.
-	 * <p>
-	 * Note that this method simply creates an object that encapsulates the name
-	 * of a topic. It does not create the physical topic in the JMS provider.
-	 * JMS does not provide a method to create the physical topic, since this
-	 * would be specific to a given JMS provider. Creating a physical topic is
-	 * provider-specific and is typically an administrative task performed by an
-	 * administrator, though some providers may create them automatically when
-	 * needed. The one exception to this is the creation of a temporary topic,
-	 * which is done using the {@code createTemporaryTopic} method.
-	 * 
-	 * @param topicName
-	 *            A provider-specific topic name
-	 * @return a Topic object which encapsulates the specified name
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if a Topic object cannot be created due to some internal
-	 *             error
-	 */
-	Topic createTopic(String topicName);
-
-	/**
-	 * Creates an unshared durable subscription on the specified topic (if one
-	 * does not already exist) and creates a consumer on that durable
-	 * subscription. This method creates the durable subscription without a
-	 * message selector and with a {@code noLocal} value of {@code false}.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with unshared durable subscriptions. Any
-	 * durable subscription created using this method will be unshared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by the
-	 * client and by the client identifier, which must be set. An application
-	 * which subsequently wishes to create a consumer on that unshared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and the same topic, message selector and
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then
-	 * this method creates a {@code JMSConsumer} on the existing durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, then a {@code JMSRuntimeException} will be
-	 * thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier but a different topic, message selector or
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSRuntimeException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId. Such subscriptions would
-	 * be completely separate.
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @exception InvalidDestinationRuntimeException
-	 *                if an invalid topic is specified.
-	 * @exception IllegalStateRuntimeException
-	 *                if the client identifier is unset 
-	 * @exception JMSRuntimeException
-	 *                <ul>
-	 *                <li>if the session fails to create the non-shared durable
-	 *                subscription and {@code JMSConsumer} due to some
-	 *                internal error 
-	 *                <li>
-	 *                if an unshared durable subscription already exists with
-	 *                the same name and client identifier, and there is a
-	 *                consumer already active 
-	 *                <li>if a shared durable subscription already exists 
-	 *                with the same name and client identifier
-	 *                </ul>
-	 *
- 	 * @since JMS 2.0
-	 */
-     JMSConsumer createDurableConsumer(Topic topic, String name);
-
-  	/**
-  	 * Creates an unshared durable subscription on the specified topic (if one
-  	 * does not already exist), specifying a message selector and the
-  	 * {@code noLocal} parameter, and creates a consumer on that durable
-  	 * subscription.
- 	 * <p>
- 	 * A durable subscription is used by an application which needs to receive
- 	 * all the messages published on a topic, including the ones published when
- 	 * there is no active consumer associated with it. The JMS provider retains
- 	 * a record of this durable subscription and ensures that all messages from
- 	 * the topic's publishers are retained until they are delivered to, and
- 	 * acknowledged by, a consumer on this durable subscription or until they
- 	 * have expired.
- 	 * <p>
- 	 * A durable subscription will continue to accumulate messages until it is
- 	 * deleted using the {@code unsubscribe} method.
- 	 * <p>
- 	 * This method may only be used with unshared durable subscriptions. Any
- 	 * durable subscription created using this method will be unshared. This
- 	 * means that only one active (i.e. not closed) consumer on the subscription
- 	 * may exist at a time. The term "consumer" here means a
- 	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
- 	 * object in any client.
- 	 * <p>
- 	 * An unshared durable subscription is identified by a name specified by the
- 	 * client and by the client identifier, which must be set. An application
- 	 * which subsequently wishes to create a consumer on that unshared durable
- 	 * subscription must use the same client identifier.
- 	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and the same topic, message selector and
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then
-	 * this method creates a {@code JMSConsumer} on the existing durable subscription.
- 	 * <p>
- 	 * If an unshared durable subscription already exists with the same name and
- 	 * client identifier, and there is a consumer already active (i.e. not
- 	 * closed) on the durable subscription, then a {@code JMSRuntimeException} will be
- 	 * thrown.
- 	 * <p>
- 	 * If an unshared durable subscription already exists with the same name and
- 	 * client identifier but a different topic, message selector or
- 	 * {@code noLocal} value has been specified, and there is no consumer
- 	 * already active (i.e. not closed) on the durable subscription then this is
- 	 * equivalent to unsubscribing (deleting) the old one and creating a new
- 	 * one.
-	 * <p>
-	 * If {@code noLocal} is set to true then any messages published to the topic
-	 * using this {@code JMSContext}'s connection, or any other connection with the same client
-	 * identifier, will not be added to the durable subscription. 
- 	 * <p>
- 	 * A shared durable subscription and an unshared durable subscription may
- 	 * not have the same name and client identifier. If a shared durable
- 	 * subscription already exists with the same name and client identifier then
- 	 * a {@code JMSRuntimeException} is thrown.
-	 * <p>
- 	 * There is no restriction on durable subscriptions and shared non-durable
- 	 * subscriptions having the same name and clientId. Such subscriptions would
- 	 * be completely separate.
- 	 * <p>
- 	 * This method is identical to the corresponding
- 	 * {@code createDurableSubscriber} method except that it returns a
- 	 * {@code MessageConsumer} rather than a {@code TopicSubscriber} to
- 	 * represent the consumer.
- 	 * 
- 	 * @param topic
- 	 *            the non-temporary {@code Topic} to subscribe to
- 	 * @param name
- 	 *            the name used to identify this subscription
- 	 * @param messageSelector
- 	 *            only messages with properties matching the message selector
- 	 *            expression are added to the durable subscription. A value of
- 	 *            null or an empty string indicates that there is no message
- 	 *            selector for the durable subscription.
- 	 * @param noLocal
- 	 *            if true then any messages published to the topic using this
- 	 *            session's connection, or any other connection with the same
- 	 *            client identifier, will not be added to the durable
- 	 *            subscription.
- 	 *            
- 	 * @exception InvalidDestinationRuntimeException
- 	 *                if an invalid topic is specified.
- 	 * @exception InvalidSelectorRuntimeException
- 	 *                if the message selector is invalid.
-	 * @exception IllegalStateRuntimeException
-	 *                if the client identifier is unset 
- 	 * @exception JMSRuntimeException
- 	 *                <ul>
- 	 *                <li>if the session fails to create the non-shared durable
- 	 *                subscription and {@code JMSConsumer} due to some
- 	 *                internal error 
- 	 *                <li>
- 	 *                if an unshared durable subscription already exists with
- 	 *                the same name and client identifier, and there is a
- 	 *                consumer already active 
- 	 *                <li>if a shared durable
- 	 *                subscription already exists with the same name and client
- 	 *                identifier
- 	 *                </ul>
- 	 * 
-	 * @since JMS 2.0
-	 */ 
-      JMSConsumer createDurableConsumer(Topic topic, String name, String messageSelector, boolean noLocal);     
-
-   	/**
-   	 * Creates a shared durable subscription on the specified topic (if one
-   	 * does not already exist), specifying a message selector,
-   	 * and creates a consumer on that durable subscription.
-   	 * This method creates the durable subscription without a message selector. 
-   	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with shared durable subscriptions. Any
-	 * durable subscription created using this method will be shared. This means
-	 * that multiple active (i.e. not closed) consumers on the subscription may
-	 * exist at the same time. The term "consumer" here means a
-	 * {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
-	 * <p>
-	 * A shared durable subscription is identified by a name specified by the
-	 * client and by the client identifier (which may be unset). An application
-	 * which subsequently wishes to create a consumer on that shared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set), and the same topic and message selector 
-	 * has been specified, then this method creates a
-	 * {@code JMSConsumer} on the existing shared durable subscription.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the durable subscription, then a
-	 * {@code JMSRuntimeException} will be thrown.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier (if set). If an unshared
-	 * durable subscription already exists with the same name and client
-	 * identifier (if set) then a {@code JMSRuntimeException} is thrown.
-	 * <p>
-	 * If a message selector is specified then only messages with properties 
-	 * matching the message selector expression will be added to the subscription.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * <p>
-   	 * 
-   	 * @param topic
-   	 *            the non-temporary {@code Topic} to subscribe to
-   	 * @param name
-   	 *            the name used to identify this subscription
-   	 * @exception InvalidDestinationRuntimeException
-   	 *                if an invalid topic is specified.
-   	 * @exception JMSRuntimeException
-   	 *                <ul>
-   	 *                <li>if the session fails to create the shared durable
-   	 *                subscription and {@code MessageConsumer} due to some
-   	 *                internal error 
-   	 *                <li>
-   	 *                if a shared durable subscription already exists with
-   	 *                the same name and client identifier, but a different topic,
-   	 *                or message selector,
-   	 *                and there is a consumer already active 
-   	 *                <li>if an unshared durable
-   	 *                subscription already exists with the same name and client
-   	 *                identifier
-   	 *                </ul>
-   	 *
+    /**
+     * Creates a new {@code JMSContext} with the specified session mode using the same connection as this {@code JMSContext}
+     * and creating a new session.
+     *
+     * <p>
+     * This method does not start the connection. If the connection has not already been started then it will be
+     * automatically started when a {@code JMSConsumer} is created on any of the {@code JMSContext} objects for that
+     * connection.
+     *
+     * <ul>
+     * <li>If {@code sessionMode} is set to {@code JMSContext.SESSION_TRANSACTED} then the session will use a local
+     * transaction which may subsequently be committed or rolled back by calling the {@code JMSContext}'s {@code commit} or
+     * {@code rollback} methods.
+     * <li>If {@code sessionMode} is set to any of {@code JMSContext.CLIENT_ACKNOWLEDGE},
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code JMSContext.DUPS_OK_ACKNOWLEDGE}. then the session will be
+     * non-transacted and messages received by this session will be acknowledged according to the value of
+     * {@code sessionMode}. For a definition of the meaning of these acknowledgement modes see the links below.
+     * </ul>
+     *
+     * <p>
+     * This method must not be used by applications running in the Java EE web or EJB containers because doing so would
+     * violate the restriction that such an application must not attempt to create more than one active (not closed)
+     * {@code Session} object per connection. If this method is called in a Java EE web or EJB container then a
+     * {@code JMSRuntimeException} will be thrown.
+     *
+     * @param sessionMode indicates which of four possible session modes will be used. The permitted values are
+     * {@code JMSContext.SESSION_TRANSACTED}, {@code JMSContext.CLIENT_ACKNOWLEDGE}, {@code JMSContext.AUTO_ACKNOWLEDGE} and
+     * {@code JMSContext.DUPS_OK_ACKNOWLEDGE}.
+     *
+     * @return a newly created JMSContext
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create the JMSContext due to
+     * <ul>
+     * <li>some internal error or
+     * <li>because this method is being called in a Java EE web or EJB application.
+     * </ul>
      * @since JMS 2.0
-   	 */
-     JMSConsumer createSharedDurableConsumer(Topic topic, String name);
+     *
+     * @see JMSContext#SESSION_TRANSACTED
+     * @see JMSContext#CLIENT_ACKNOWLEDGE
+     * @see JMSContext#AUTO_ACKNOWLEDGE
+     * @see JMSContext#DUPS_OK_ACKNOWLEDGE
+     *
+     * @see javax.jms.ConnectionFactory#createContext()
+     * @see javax.jms.ConnectionFactory#createContext(int)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String)
+     * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String, int)
+     * @see javax.jms.JMSContext#createContext(int)
+     */
+    JMSContext createContext(int sessionMode);
 
- 	/**
- 	 * Creates a shared durable subscription on the specified topic (if one
- 	 * does not already exist), specifying a message selector,
- 	 * and creates a consumer on that durable subscription.
-   	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with shared durable subscriptions. Any
-	 * durable subscription created using this method will be shared. This means
-	 * that multiple active (i.e. not closed) consumers on the subscription may
-	 * exist at the same time. The term "consumer" here means a
-	 * {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
-	 * <p>
-	 * A shared durable subscription is identified by a name specified by the
-	 * client and by the client identifier (which may be unset). An application
-	 * which subsequently wishes to create a consumer on that shared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set), and the same topic and message selector have
-	 * been specified, then this method creates a
-	 * {@code JMSConsumer} on the existing shared durable subscription.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set), but a different topic or message selector 
-	 * has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the durable subscription, then a
-	 * {@code JMSRuntimeException} will be thrown.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier (if set). If an unshared
-	 * durable subscription already exists with the same name and client
-	 * identifier (if set) then a {@code JMSRuntimeException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * <p>
- 	 * 
- 	 * @param topic
- 	 *            the non-temporary {@code Topic} to subscribe to
- 	 * @param name
- 	 *            the name used to identify this subscription
- 	 * @param messageSelector
- 	 *            only messages with properties matching the message selector
- 	 *            expression are added to the durable subscription. A value of
- 	 *            null or an empty string indicates that there is no message
- 	 *            selector for the durable subscription.
- 	 * @exception InvalidDestinationRuntimeException
- 	 *                if an invalid topic is specified.
- 	 * @exception InvalidSelectorRuntimeException
- 	 *                if the message selector is invalid.
- 	 * @exception JMSRuntimeException
- 	 *                <ul>
- 	 *                <li>if the session fails to create the shared durable
- 	 *                subscription and {@code JMSConsumer} due to some
- 	 *                internal error 
- 	 *                <li>
- 	 *                if a shared durable subscription already exists with
- 	 *                the same name and client identifier, but a different topic,
- 	 *                or message selector,
- 	 *                and there is a consumer already active 
- 	 *                <li>if an unshared durable
- 	 *                subscription already exists with the same name and client
- 	 *                identifier
- 	 *                </ul>
+    /**
+     * Creates a new {@code JMSProducer} object which can be used to configure and send messages
+     *
+     * @return A new {@code JMSProducer} object
+     *
+     * @see javax.jms.JMSProducer
+     */
+    JMSProducer createProducer();
 
- 	 *
-   * @since JMS 2.0
- 	 */
-      JMSConsumer createSharedDurableConsumer(Topic topic, String name, String messageSelector);         
-      
-  	/**
-  	 * Creates a shared non-durable subscription with the specified name on the
-  	 * specified topic (if one does not already exist) and creates a consumer on
-  	 * that subscription. This method creates the non-durable subscription
-  	 * without a message selector.
-  	 * <p>
-  	 * If a shared non-durable subscription already exists with the same name
-  	 * and client identifier (if set), and the same topic and message selector 
-  	 * has been specified, then this method creates a
-  	 * {@code JMSConsumer} on the existing subscription.
-  	 * <p>
-  	 * A non-durable shared subscription is used by a client which needs to be
-  	 * able to share the work of receiving messages from a topic subscription
-  	 * amongst multiple consumers. A non-durable shared subscription may
-  	 * therefore have more than one consumer. Each message from the subscription
-  	 * will be delivered to only one of the consumers on that subscription. Such
-  	 * a subscription is not persisted and will be deleted (together with any
-  	 * undelivered messages associated with it) when there are no consumers on
-  	 * it. The term "consumer" here means a {@code MessageConsumer} or
-  	 * {@code  JMSConsumer} object in any client.
-  	 * <p>
-  	 * A shared non-durable subscription is identified by a name specified by
-  	 * the client and by the client identifier (which may be unset). An
-  	 * application which subsequently wishes to create a consumer on that shared
-  	 * non-durable subscription must use the same client identifier.
-  	 * <p>
-  	 * If a shared non-durable subscription already exists with the same name
-  	 * and client identifier (if set) but a different topic or message selector 
-  	 * value has been specified, and there is a consumer already
-  	 * active (i.e. not closed) on the subscription, then a {@code JMSRuntimeException}
-  	 * will be thrown.
-  	 * <p>
-  	 * There is no restriction on durable subscriptions and shared non-durable
-  	 * subscriptions having the same name and clientId (which may be unset).
-  	 * Such subscriptions would be completely separate.
-	 * 
-	 * @param topic
-	 *            the {@code Topic} to subscribe to
-	 * @param sharedSubscriptionName
-	 *            the name used to identify the shared non-durable subscription
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the session fails to create the shared non-durable
-	 *             subscription and {@code JMSContext} due to some internal
-	 *             error.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if an invalid topic is specified.
-	 * @throws InvalidSelectorRuntimeException
-	 *             if the message selector is invalid.
-	 */
-	JMSConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName);
+    /**
+     * Gets the client identifier for the JMSContext's connection.
+     *
+     * <p>
+     * This value is specific to the JMS provider. It is either preconfigured by an administrator in a
+     * {@code ConnectionFactory} object or assigned dynamically by the application by calling the {@code setClientID}
+     * method.
+     *
+     * @return the unique client identifier
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to return the client ID for the JMSContext's connection due
+     * to some internal error.
+     *
+     **/
+    String getClientID();
 
-	/**
-	 * Creates a shared non-durable subscription with the specified name on the
-	 * specified topic (if one does not already exist) specifying a message selector,
-	 * and creates a consumer on that subscription. 
-	 * <p>
-	 * If a shared non-durable subscription already exists with the same name
-	 * and client identifier (if set), and the same topic and message selector 
-	 * has been specified, then this method creates a
-	 * {@code JMSConsumer} on the existing subscription.
-	 * <p>
-	 * A non-durable shared subscription is used by a client which needs to be
-	 * able to share the work of receiving messages from a topic subscription
-	 * amongst multiple consumers. A non-durable shared subscription may
-	 * therefore have more than one consumer. Each message from the subscription
-	 * will be delivered to only one of the consumers on that subscription. Such
-	 * a subscription is not persisted and will be deleted (together with any
-	 * undelivered messages associated with it) when there are no consumers on
-	 * it. The term "consumer" here means a {@code MessageConsumer} or
-	 * {@code  JMSConsumer} object in any client.
-	 * <p>
-	 * A shared non-durable subscription is identified by a name specified by
-	 * the client and by the client identifier (which may be unset). An
-	 * application which subsequently wishes to create a consumer on that shared
-	 * non-durable subscription must use the same client identifier.
-	 * <p>
-	 * If a shared non-durable subscription already exists with the same name
-	 * and client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the subscription, then a {@code JMSRuntimeException}
-	 * will be thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * 
-	 * @param topic
-	 *            the {@code Topic} to subscribe to
-	 * @param sharedSubscriptionName
-	 *            the name used to identify the shared non-durable subscription
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are added to the shared non-durable subscription. A
-	 *            value of null or an empty string indicates that there is no
-	 *            message selector for the shared non-durable subscription.
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the session fails to create the shared non-durable
-	 *             subscription and {@code JMSConsumer} due to some
-	 *             internal error.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if an invalid topic is specified.
-	 * @throws InvalidSelectorRuntimeException
-	 *             if the message selector is invalid.
-	 */
-	JMSConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName, java.lang.String messageSelector);
+    /**
+     * Sets the client identifier for the JMSContext's connection.
+     *
+     * <p>
+     * The preferred way to assign a JMS client's client identifier is for it to be configured in a client-specific
+     * {@code ConnectionFactory} object and transparently assigned to the {@code Connection} object it creates.
+     *
+     * <p>
+     * Alternatively, a client can set the client identifier for the JMSContext's connection using a provider-specific
+     * value. The facility to set its client identifier explicitly is not a mechanism for overriding the identifier that has
+     * been administratively configured. It is provided for the case where no administratively specified identifier exists.
+     * If one does exist, an attempt to change it by setting it must throw an {@code IllegalStateRuntimeException}. If a
+     * client sets the client identifier explicitly, it must do so immediately after it creates the JMSContext and before
+     * any other action on the JMSContext is taken. After this point, setting the client identifier is a programming error
+     * that should throw an {@code IllegalStateRuntimeException}.
+     *
+     * <p>
+     * The purpose of the client identifier is to associate the JMSContext's connection and its objects with a state
+     * maintained on behalf of the client by a provider. The only such state identified by the JMS API is that required to
+     * support durable subscriptions.
+     *
+     * <p>
+     * If another connection with the same {@code clientID} is already running when this method is called, the JMS provider
+     * should detect the duplicate ID and throw an {@code InvalidClientIDException}.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSRuntimeException} to
+     * be thrown though this is not guaranteed.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @param clientID the unique client identifier
+     *
+     * @throws InvalidClientIDRuntimeException if the JMS client specifies an invalid or duplicate client ID.
+     * @throws IllegalStateRuntimeException
+     * <ul>
+     * <li>if the JMS client attempts to set the client ID for the JMSContext's connection at the wrong time or
+     * <li>if the client ID has been administratively configured or
+     * <li>if the {@code JMSContext} is container-managed (injected).
+     * </ul>
+     * @exception JMSRuntimeException if the JMS provider fails to set the client ID for the the JMSContext's connection for
+     * one of the following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     */
+    void setClientID(String clientID);
 
-	/**
-	 * Creates a {@code QueueBrowser} object to peek at the messages on the
-	 * specified queue.
-	 * 
-	 * @param queue
-	 *            the {@code queue} to access
-	 * 
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the session fails to create a browser due to some
-	 *                internal error.
-	 * @exception InvalidRuntimeDestinationException
-	 *                if an invalid destination is specified
-	 * 
-	 */
-	QueueBrowser createBrowser(Queue queue);
+    /**
+     * Gets the connection metadata for the JMSContext's connection.
+     *
+     * @return the connection metadata
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the connection metadata
+     *
+     * @see javax.jms.ConnectionMetaData
+     */
+    ConnectionMetaData getMetaData();
 
-	/**
-	 * Creates a {@code QueueBrowser} object to peek at the messages on the
-	 * specified queue using a message selector.
-	 * 
-	 * @param queue
-	 *            the {@code queue} to access
-	 * 
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the message
-	 *            consumer.
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the session fails to create a browser due to some
-	 *                internal error.
-	 * @exception InvalidRuntimeDestinationException
-	 *                if an invalid destination is specified
-	 * @exception InvalidRuntimeSelectorException
-	 *                if the message selector is invalid.
-	 * 
-	 */
+    /**
+     * Gets the {@code ExceptionListener} object for the JMSContext's connection. Not every {@code Connection} has an
+     * {@code ExceptionListener} associated with it.
+     *
+     * @return the {@code ExceptionListener} for the JMSContext's connection, or null if no {@code ExceptionListener} is
+     * associated with that connection.
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the {@code ExceptionListener} for the JMSContext's
+     * connection.
+     * @see javax.jms.Connection#setExceptionListener
+     */
+    ExceptionListener getExceptionListener();
 
-	QueueBrowser createBrowser(Queue queue, String messageSelector);
+    /**
+     * Sets an exception listener for the JMSContext's connection.
+     *
+     * <p>
+     * If a JMS provider detects a serious problem with a connection, it informs the connection's {@code ExceptionListener},
+     * if one has been registered. It does this by calling the listener's {@code onException} method, passing it a
+     * {@code JMSRuntimeException} object describing the problem.
+     *
+     * <p>
+     * An exception listener allows a client to be notified of a problem asynchronously. Some connections only consume
+     * messages, so they would have no other way to learn their connection has failed.
+     *
+     * <p>
+     * A connection serializes execution of its {@code ExceptionListener}.
+     *
+     * <p>
+     * A JMS provider should attempt to resolve connection problems itself before it notifies the client of them.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSRuntimeException} to
+     * be thrown though this is not guaranteed.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @param listener the exception listener
+     *
+     * @exception IllegalStateRuntimeException if the {@code JMSContext} is container-managed (injected).
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to set the exception listener for one of the following
+     * reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     */
+    void setExceptionListener(ExceptionListener listener);
 
-	/**
-	 * Creates a {@code TemporaryQueue} object. Its lifetime will be that
-	 * of the JMSContext's {@code Connection} unless it is deleted earlier.
-	 * 
-	 * @return a temporary queue identity
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the session fails to create a temporary queue due to
-	 *                some internal error.
-	 */
+    /**
+     * Starts (or restarts) delivery of incoming messages by the JMSContext's connection. A call to {@code start} on a
+     * connection that has already been started is ignored.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException if the {@code JMSContext} is container-managed (injected).
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to start message delivery due to some internal error.
+     *
+     * @see javax.jms.JMSContext#stop
+     */
+    void start();
 
-	TemporaryQueue createTemporaryQueue();
+    /**
+     * Temporarily stops the delivery of incoming messages by the JMSContext's connection. Delivery can be restarted using
+     * the {@code start} method. When the connection is stopped, delivery to all the connection's message consumers is
+     * inhibited: synchronous receives block, and messages are not delivered to message listeners.
+     *
+     * <p>
+     * Stopping a connection has no effect on its ability to send messages. A call to {@code stop} on a connection that has
+     * already been stopped is ignored.
+     *
+     * <p>
+     * A call to {@code stop} must not return until delivery of messages has paused. This means that a client can rely on
+     * the fact that none of its message listeners will be called and that all threads of control waiting for
+     * {@code receive} calls to return will not return with a message until the connection is restarted. The receive timers
+     * for a stopped connection continue to advance, so receives may time out while the connection is stopped.
+     *
+     * <p>
+     * If message listeners are running when {@code stop} is invoked, the {@code stop} call must wait until all of them have
+     * returned before it may return. While these message listeners are completing, they must have the full services of the
+     * connection available to them.
+     *
+     * <p>
+     * However if the stop method is called from a message listener on its own {@code JMSContext}, or any other
+     * {@code JMSContext} that uses the same connection, then it will either fail and throw a
+     * {@code javax.jms.IllegalStateRuntimeException}, or it will succeed and stop the connection, blocking until all other
+     * message listeners that may have been running have returned.
+     *
+     * <p>
+     * Since two alternative behaviors are permitted in this case, applications should avoid calling {@code stop} from a
+     * message listener on its own {@code JMSContext}, or any other {@code JMSContext} that uses the same connection,
+     * because this is not portable.
+     *
+     * <p>
+     * For the avoidance of doubt, if an exception listener for the JMSContext's connection is running when {@code stop} is
+     * invoked, there is no requirement for the {@code stop} call to wait until the exception listener has returned before
+     * it may return.
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSRuntimeException} to
+     * be thrown though this is not guaranteed.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException
+     * <ul>
+     * <li>if this method has been called by a <tt>MessageListener</tt> on its own <tt>JMSContext</tt>
+     * <li>if the {@code JMSContext} is container-managed (injected).
+     * </ul>
+     * @exception JMSRuntimeException if the JMS provider fails to stop message delivery for one of the following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @see javax.jms.JMSContext#start
+     */
+    void stop();
 
-	/**
-	 * Creates a {@code TemporaryTopic} object. Its lifetime will be that
-	 * of the JMSContext's {@code Connection} unless it is deleted earlier.
-	 * 
-	 * @return a temporary topic identity
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the session fails to create a temporary topic due to
-	 *                some internal error.
-	 * 
-	 */
+    /**
+     * Specifies whether the underlying connection used by this {@code JMSContext} will be started automatically when a
+     * consumer is created. This is the default behaviour, and it may be disabled by calling this method with a value of
+     * {@code false}.
+     *
+     * <p>
+     * This method does not itself either start or stop the connection.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @param autoStart Whether the underlying connection used by this {@code JMSContext} will be automatically started when
+     * a consumer is created.
+     * @exception IllegalStateRuntimeException if the {@code JMSContext} is container-managed (injected)
+     *
+     * @see javax.jms.JMSContext#getAutoStart
+     */
+    void setAutoStart(boolean autoStart);
 
-	TemporaryTopic createTemporaryTopic();
+    /**
+     * Returns whether the underlying connection used by this {@code JMSContext} will be started automatically when a
+     * consumer is created.
+     *
+     * @return whether the underlying connection used by this {@code JMSContext} will be started automatically when a
+     * consumer is created.
+     *
+     * @see javax.jms.JMSContext#setAutoStart
+     */
+    boolean getAutoStart();
 
-	/**
-	 * Unsubscribes a durable subscription that has been created by a client.
-	 * 
-	 * <P>
-	 * This method deletes the state being maintained on behalf of the
-	 * subscriber by its provider.
-	 * <p>
-	 * A durable subscription is identified by a name specified by the client
-	 * and by the client identifier if set. If the client identifier was set
-	 * when the durable subscription was created then a client which
-	 * subsequently wishes to use this method to delete a durable subscription
-	 * must use the same client identifier.
-	 * 
-	 * <P>
-	 * It is erroneous for a client to delete a durable subscription while there
-	 * is an active (not closed) consumer on that subscription, or while a consumed message
-	 * is part of a pending transaction or has not been acknowledged in the
-	 * session.
-	 * <P>
-	 * If the active consumer is represented by a {@code JMSConsumer} then
-	 * calling {@code close} on either that object or the
-	 * {@code JMSContext} used to create it will render the consumer
-	 * inactive and allow the subscription to be deleted.
-	 * <P>
-	 * If the active consumer was created by calling
-	 * {@code setMessageListener} on the {@code JMSContext} then
-	 * calling {@code close} on the {@code JMSContext} will render the
-	 * consumer inactive and allow the subscription to be deleted.
-	 * <p>
-	 * If the active consumer is represented by a {@code MessageConsumer}
-	 * or {@code TopicSubscriber} then calling {@code close} on that
-	 * object or on the {@code Session} or {@code Connection} used to
-	 * create it will render the consumer inactive and allow the subscription to
-	 * be deleted.
-	 * 
-	 * @param name
-	 *            the name used to identify this subscription
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the session fails to unsubscribe to the durable
-	 *                subscription due to some internal error.
-	 * @exception InvalidDestinationRuntimeException
-	 *                if an invalid subscription name is specified.
-	 * 
-	 * 
-	 * 
-	 */
-	void unsubscribe(String name);
+    /**
+     * Closes the JMSContext
+     * <p>
+     * This closes the underlying session and any underlying producers and consumers. If there are no other active (not
+     * closed) JMSContext objects using the underlying connection then this method also closes the underlying connection.
+     *
+     * <p>
+     * Since a provider typically allocates significant resources outside the JVM on behalf of a connection, clients should
+     * close these resources when they are not needed. Relying on garbage collection to eventually reclaim these resources
+     * may not be timely enough.
+     *
+     * <p>
+     * Closing a connection causes all temporary destinations to be deleted.
+     *
+     * <p>
+     * When this method is invoked, it should not return until message processing has been shut down in an orderly fashion.
+     * This means that all message listeners that may have been running have returned, and that all pending receives have
+     * returned. A close terminates all pending message receives on the connection's sessions' consumers. The receives may
+     * return with a message or with null, depending on whether there was a message available at the time of the close. If
+     * one or more of the connection's sessions' message listeners is processing a message at the time when connection
+     * {@code close} is invoked, all the facilities of the connection and its sessions must remain available to those
+     * listeners until they return control to the JMS provider.
+     *
+     * <p>
+     * However if the close method is called from a message listener on its own {@code JMSContext}, then it will either fail
+     * and throw a {@code javax.jms.IllegalStateRuntimeException}, or it will succeed and close the {@code JMSContext}. If
+     * {@code close} succeeds and the session mode of the {@code JMSContext} is set to {@code AUTO_ACKNOWLEDGE}, the current
+     * message will still be acknowledged automatically when the onMessage call completes.
+     *
+     * <p>
+     * Since two alternative behaviors are permitted in this case, applications should avoid calling close from a message
+     * listener on its own {@code JMSContext} because this is not portable.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>JMSContext</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * For the avoidance of doubt, if an exception listener for the JMSContext's connection is running when {@code close} is
+     * invoked, there is no requirement for the {@code close} call to wait until the exception listener has returned before
+     * it may return.
+     *
+     * <p>
+     * Closing a connection causes any of its sessions' transactions in progress to be rolled back. In the case where a
+     * session's work is coordinated by an external transaction manager, a session's {@code commit} and {@code rollback}
+     * methods are not used and the result of a closed session's work is determined later by the transaction manager.
+     *
+     * <p>
+     * Closing a connection does NOT force an acknowledgment of client-acknowledged sessions.
+     *
+     * <p>
+     * Invoking the {@code acknowledge} method of a received message from a closed connection's session must throw an
+     * {@code IllegalStateRuntimeException}. Closing a closed connection must NOT throw an exception.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>JMSContext</tt>. Doing so
+     * will cause an <tt>IllegalStateRuntimeException</tt> to be thrown.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException
+     * <ul>
+     * <li>if this method has been called by a <tt>MessageListener
+     *                </tt> on its own <tt>JMSContext</tt></li>
+     * <li>if this method has been called by a <tt>CompletionListener</tt> callback method on its own
+     * <tt>JMSContext</tt></li>
+     * <li>if the {@code JMSContext} is container-managed (injected)</li>
+     * </ul>
+     * @exception JMSRuntimeException if the JMS provider fails to close the {@code JMSContext} due to some internal error.
+     * For example, a failure to release resources or to close a socket connection can cause this exception to be thrown.
+     */
+    @Override
+    void close();
 
-	/**
-	 * Acknowledges all messages consumed by the JMSContext's session.
-	 * <p>
-	 * This method is for use when the session has an acknowledgement mode of
-	 * CLIENT_ACKNOWLEDGE. If the session is transacted or has an
-	 * acknowledgement mode of AUTO_ACKNOWLEDGE or DUPS_OK_ACKNOWLEDGE calling
-	 * this method has no effect.
-	 * <p>
-	 * This method has identical behaviour to the {@code acknowledge}
-	 * method on {@code Message}. A client may individually acknowledge
-	 * each message as it is consumed, or it may choose to acknowledge messages
-	 * as an application-defined group. In both cases it makes no difference
-	 * which of these two methods is used.
-	 * <p>
-	 * Messages that have been received but not acknowledged may be redelivered.
-	 * <p>
-	 * This method must not be used if the {@code JMSContext} is
-	 * container-managed (injected). Doing so will cause a
-	 * {@code IllegalStateRuntimeException} to be thrown.
-	 * 
-	 * @exception IllegalStateRuntimeException
-	 *                <ul>
-	 *                <li>if the {@code JMSContext} is closed.
-	 *                <li>if the {@code JMSContext} is container-managed (injected)
-	 *                </ul>
-	 *                
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to acknowledge the messages due to some internal error 
-	 * 
-	 * @see javax.jms.Session#CLIENT_ACKNOWLEDGE
-	 * @see javax.jms.Message#acknowledge
-	 */
+    /**
+     * With this session mode, the JMSContext's session automatically acknowledges a client's receipt of a message either
+     * when the session has successfully returned from a call to {@code receive} or when the message listener the session
+     * has called to process the message successfully returns.
+     */
+    int AUTO_ACKNOWLEDGE = Session.AUTO_ACKNOWLEDGE;
 
-	void acknowledge();
+    /**
+     * With this session mode, the client acknowledges a consumed message by calling the message's {@code acknowledge}
+     * method. Acknowledging a consumed message acknowledges all messages that the session has consumed.
+     *
+     * <p>
+     * When this session mode is used, a client may build up a large number of unacknowledged messages while attempting to
+     * process them. A JMS provider should provide administrators with a way to limit client overrun so that clients are not
+     * driven to resource exhaustion and ensuing failure when some resource they are using is temporarily blocked.
+     *
+     * @see javax.jms.Message#acknowledge()
+     */
+    int CLIENT_ACKNOWLEDGE = Session.CLIENT_ACKNOWLEDGE;
+
+    /**
+     * This session mode instructs the JMSContext's session to lazily acknowledge the delivery of messages. This is likely
+     * to result in the delivery of some duplicate messages if the JMS provider fails, so it should only be used by
+     * consumers that can tolerate duplicate messages. Use of this mode can reduce session overhead by minimizing the work
+     * the session does to prevent duplicates.
+     */
+    int DUPS_OK_ACKNOWLEDGE = Session.DUPS_OK_ACKNOWLEDGE;
+
+    /**
+     * This session mode instructs the JMSContext's session to deliver and consume messages in a local transaction which
+     * will be subsequently committed by calling {@code commit} or rolled back by calling {@code rollback}.
+     */
+    int SESSION_TRANSACTED = Session.SESSION_TRANSACTED;
+
+    /**
+     * Creates a {@code BytesMessage} object. A {@code BytesMessage} object is used to send a message containing a stream of
+     * uninterpreted bytes.
+     *
+     * @return The created {@code BytesMessage} object
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    BytesMessage createBytesMessage();
+
+    /**
+     * Creates a {@code MapMessage} object. A {@code MapMessage} object is used to send a self-defining set of name-value
+     * pairs, where names are {@code String} objects and values are primitive values in the Java programming language.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return The created {@code MapMessage} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    MapMessage createMapMessage();
+
+    /**
+     * Creates a {@code Message} object. The {@code Message} interface is the root interface of all JMS messages. A
+     * {@code Message} object holds all the standard message header information. It can be sent when a message containing
+     * only header information is sufficient.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return The created {@code Message} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    Message createMessage();
+
+    /**
+     * Creates an {@code ObjectMessage} object. An {@code ObjectMessage} object is used to send a message that contains a
+     * serializable Java object.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return The created {@code ObjectMessage} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    ObjectMessage createObjectMessage();
+
+    /**
+     * Creates an initialized {@code ObjectMessage} object. An {@code ObjectMessage} object is used to send a message that
+     * contains a serializable Java object.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @param object the object to use to initialize this message
+     *
+     * @return The created {@code ObjectMessage} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    ObjectMessage createObjectMessage(Serializable object);
+
+    /**
+     * Creates a {@code StreamMessage} object. A {@code StreamMessage} object is used to send a self-defining stream of
+     * primitive values in the Java programming language.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return The created {@code StreamMessage} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    StreamMessage createStreamMessage();
+
+    /**
+     * Creates a {@code TextMessage} object. A {@code TextMessage} object is used to send a message containing a
+     * {@code String} object.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return The created {@code TextMessage} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    TextMessage createTextMessage();
+
+    /**
+     * Creates an initialized {@code TextMessage} object. A {@code TextMessage} object is used to send a message containing
+     * a {@code String}.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @param text the string used to initialize this message
+     *
+     * @return The created {@code TextMessage} object.
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create this message due to some internal error.
+     */
+    TextMessage createTextMessage(String text);
+
+    /**
+     * Indicates whether the JMSContext's session is in transacted mode.
+     *
+     * @return true if the session is in transacted mode
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to return the transaction mode due to some internal error.
+     */
+    boolean getTransacted();
+
+    /**
+     * Returns the session mode of the JMSContext's session. This can be set at the time that the JMSContext is created.
+     * Possible values are JMSContext.SESSION_TRANSACTED, JMSContext.AUTO_ACKNOWLEDGE, JMSContext.CLIENT_ACKNOWLEDGE and
+     * JMSContext.DUPS_OK_ACKNOWLEDGE
+     *
+     * <p>
+     * If a session mode was not specified when the JMSContext was created a value of JMSContext.AUTO_ACKNOWLEDGE will be
+     * returned.
+     *
+     * @return the session mode of the JMSContext's session
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to return the acknowledgment mode due to some internal
+     * error.
+     *
+     * @see Connection#createSession
+     * @since JMS 2.0
+     */
+    int getSessionMode();
+
+    /**
+     * Commits all messages done in this transaction and releases any locks currently held.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>JMSContext</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>commit</tt> on its own <tt>JMSContext</tt>. Doing so
+     * will cause an <tt>IllegalStateRuntimeException</tt> to be thrown.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException
+     * <ul>
+     * <li>if the <tt>JMSContext</tt>'s session is not using a local transaction
+     * <li>if this method has been called by a <tt>
+     *                CompletionListener</tt> callback method on its own <tt>
+     *                JMSContext</tt></li>
+     * <li>if the {@code JMSContext} is container-managed (injected)
+     * </ul>
+     * @exception TransactionRolledBackRuntimeException if the transaction is rolled back due to some internal error during
+     * commit.
+     * @exception JMSRuntimeException if the JMS provider fails to commit the transaction due to some internal error
+     *
+     */
+    void commit();
+
+    /**
+     * Rolls back any messages done in this transaction and releases any locks currently held.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>JMSContext</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>rollback</tt> on its own <tt>JMSContext</tt>. Doing
+     * so will cause an <tt>IllegalStateRuntimeException</tt> to be thrown.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException
+     * <ul>
+     * <li>if the <tt>JMSContext</tt>'s session is not using a local transaction
+     * <li>if this method has been called by a <tt>CompletionListener</tt> callback method on its own
+     * <tt>JMSContext</tt></li>
+     * <li>if the {@code JMSContext} is container-managed (injected)
+     * </ul>
+     * @exception JMSRuntimeException if the JMS provider fails to roll back the transaction due to some internal error
+     *
+     */
+    void rollback();
+
+    /**
+     * Stops message delivery in the JMSContext's session, and restarts message delivery with the oldest unacknowledged
+     * message.
+     *
+     * <p>
+     * All consumers deliver messages in a serial order. Acknowledging a received message automatically acknowledges all
+     * messages that have been delivered to the client.
+     *
+     * <p>
+     * Restarting a session causes it to take the following actions:
+     *
+     * <ul>
+     * <li>Stop message delivery
+     * <li>Mark all messages that might have been delivered but not acknowledged as "redelivered"
+     * <li>Restart the delivery sequence including all unacknowledged messages that had been previously delivered.
+     * Redelivered messages do not have to be delivered in exactly their original delivery order.
+     * </ul>
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException
+     * <ul>
+     * <li>if the <tt>JMSContext</tt>'s session is using a transaction
+     * <li>if the {@code JMSContext} is container-managed (injected)
+     * </ul>
+     * @exception JMSRuntimeException if the JMS provider fails to stop and restart message delivery due to some internal
+     * error
+     */
+    void recover();
+
+    /**
+     * Creates a {@code JMSConsumer} for the specified destination.
+     *
+     * <p>
+     * A client uses a {@code JMSConsumer} object to receive messages that have been sent to a destination.
+     *
+     * @param destination the {@code Destination} to access.
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @exception JMSRuntimeException if the session fails to create a {@code JMSConsumer} due to some internal error.
+     * @exception InvalidDestinationRuntimeException if an invalid destination is specified.
+     */
+    JMSConsumer createConsumer(Destination destination);
+
+    /**
+     * Creates a {@code JMSConsumer} for the specified destination, using a message selector.
+     *
+     * <p>
+     * A client uses a {@code JMSConsumer} object to receive messages that have been sent to a destination.
+     *
+     * @param destination the {@code Destination} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the {@code JMSConsumer}.
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @throws JMSRuntimeException if the session fails to create a {@code JMSConsumer} due to some internal error.
+     * @throws InvalidDestinationRuntimeException if an invalid destination is specified.
+     * @throws InvalidSelectorRuntimeException if the message selector is invalid.
+     */
+    JMSConsumer createConsumer(Destination destination, java.lang.String messageSelector);
+
+    /**
+     * Creates a {@code JMSConsumer} for the specified destination, specifying a message selector and the {@code noLocal}
+     * parameter.
+     *
+     * <p>
+     * A client uses a {@code JMSConsumer} object to receive messages that have been sent to a destination.
+     *
+     * <p>
+     * The {@code noLocal} argument is for use when the destination is a topic and the JMSContext's connection is also being
+     * used to publish messages to that topic. If {@code noLocal} is set to true then the {@code JMSConsumer} will not
+     * receive messages published to the topic by its own connection. The default value of this argument is false. If the
+     * destination is a queue then the effect of setting {@code noLocal} to true is not specified.
+     *
+     * @param destination the {@code Destination} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the {@code JMSConsumer}.
+     * @param noLocal if true, and the destination is a topic, then the {@code JMSConsumer} will not receive messages
+     * published to the topic by its own connection
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @throws JMSRuntimeException if the session fails to create a {@code JMSConsumer} due to some internal error.
+     * @throws InvalidDestinationRuntimeException if an invalid destination is specified.
+     * @throws InvalidSelectorRuntimeException if the message selector is invalid.
+     */
+    JMSConsumer createConsumer(Destination destination, java.lang.String messageSelector, boolean noLocal);
+
+    /**
+     * Creates a {@code Queue} object which encapsulates a specified provider-specific queue name.
+     *
+     * <p>
+     * The use of provider-specific queue names in an application may render the application non-portable. Portable
+     * applications are recommended to not use this method but instead look up an administratively-defined {@code Queue}
+     * object using JNDI.
+     *
+     * <p>
+     * Note that this method simply creates an object that encapsulates the name of a queue. It does not create the physical
+     * queue in the JMS provider. JMS does not provide a method to create the physical queue, since this would be specific
+     * to a given JMS provider. Creating a physical queue is provider-specific and is typically an administrative task
+     * performed by an administrator, though some providers may create them automatically when needed. The one exception to
+     * this is the creation of a temporary queue, which is done using the {@code createTemporaryQueue} method.
+     *
+     * @param queueName A provider-specific queue name
+     * @return a Queue object which encapsulates the specified name
+     *
+     * @throws JMSRuntimeException if a Queue object cannot be created due to some internal error
+     */
+    Queue createQueue(String queueName);
+
+    /**
+     * Creates a {@code Topic} object which encapsulates a specified provider-specific topic name.
+     *
+     * <p>
+     * The use of provider-specific topic names in an application may render the application non-portable. Portable
+     * applications are recommended to not use this method but instead look up an administratively-defined {@code Topic}
+     * object using JNDI.
+     *
+     * <p>
+     * Note that this method simply creates an object that encapsulates the name of a topic. It does not create the physical
+     * topic in the JMS provider. JMS does not provide a method to create the physical topic, since this would be specific
+     * to a given JMS provider. Creating a physical topic is provider-specific and is typically an administrative task
+     * performed by an administrator, though some providers may create them automatically when needed. The one exception to
+     * this is the creation of a temporary topic, which is done using the {@code createTemporaryTopic} method.
+     *
+     * @param topicName A provider-specific topic name
+     * @return a Topic object which encapsulates the specified name
+     *
+     * @throws JMSRuntimeException if a Topic object cannot be created due to some internal error
+     */
+    Topic createTopic(String topicName);
+
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist) and creates a
+     * consumer on that durable subscription. This method creates the durable subscription without a message selector and
+     * with a {@code noLocal} value of {@code false}.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with unshared durable subscriptions. Any durable subscription created using this method
+     * will be unshared. This means that only one active (i.e. not closed) consumer on the subscription may exist at a time.
+     * The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer} object in
+     * any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that unshared durable subscription must
+     * use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and the same topic,
+     * message selector and {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this method creates a {@code JMSConsumer} on the existing durable
+     * subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, then a {@code JMSRuntimeException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a
+     * new one.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a
+     * {@code JMSRuntimeException} is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @exception InvalidDestinationRuntimeException if an invalid topic is specified.
+     * @exception IllegalStateRuntimeException if the client identifier is unset
+     * @exception JMSRuntimeException
+     * <ul>
+     * <li>if the session fails to create the non-shared durable subscription and {@code JMSConsumer} due to some internal
+     * error
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 2.0
+     */
+    JMSConsumer createDurableConsumer(Topic topic, String name);
+
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector and the {@code noLocal} parameter, and creates a consumer on that durable subscription.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with unshared durable subscriptions. Any durable subscription created using this method
+     * will be unshared. This means that only one active (i.e. not closed) consumer on the subscription may exist at a time.
+     * The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer} object in
+     * any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that unshared durable subscription must
+     * use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and the same topic,
+     * message selector and {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this method creates a {@code JMSConsumer} on the existing durable
+     * subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, then a {@code JMSRuntimeException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a
+     * new one.
+     *
+     * <p>
+     * If {@code noLocal} is set to true then any messages published to the topic using this {@code JMSContext}'s
+     * connection, or any other connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a
+     * {@code JMSRuntimeException} is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableSubscriber} method except that it returns a
+     * {@code MessageConsumer} rather than a {@code TopicSubscriber} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the
+     * durable subscription. A value of null or an empty string indicates that there is no message selector for the durable
+     * subscription.
+     * @param noLocal if true then any messages published to the topic using this session's connection, or any other
+     * connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @exception InvalidDestinationRuntimeException if an invalid topic is specified.
+     * @exception InvalidSelectorRuntimeException if the message selector is invalid.
+     * @exception IllegalStateRuntimeException if the client identifier is unset
+     * @exception JMSRuntimeException
+     * <ul>
+     * <li>if the session fails to create the non-shared durable subscription and {@code JMSConsumer} due to some internal
+     * error
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 2.0
+     */
+    JMSConsumer createDurableConsumer(Topic topic, String name, String messageSelector, boolean noLocal);
+
+    /**
+     * Creates a shared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector, and creates a consumer on that durable subscription. This method creates the durable subscription without a
+     * message selector.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with shared durable subscriptions. Any durable subscription created using this method
+     * will be shared. This means that multiple active (i.e. not closed) consumers on the subscription may exist at the same
+     * time. The term "consumer" here means a {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
+     *
+     * <p>
+     * A shared durable subscription is identified by a name specified by the client and by the client identifier (which may
+     * be unset). An application which subsequently wishes to create a consumer on that shared durable subscription must use
+     * the same client identifier.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set), and the same topic
+     * and message selector has been specified, then this method creates a {@code JMSConsumer} on the existing shared
+     * durable subscription.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is no consumer already active (i.e. not closed) on the
+     * durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a new one.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the durable
+     * subscription, then a {@code JMSRuntimeException} will be thrown.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier
+     * (if set). If an unshared durable subscription already exists with the same name and client identifier (if set) then a
+     * {@code JMSRuntimeException} is thrown.
+     *
+     * <p>
+     * If a message selector is specified then only messages with properties matching the message selector expression will
+     * be added to the subscription.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @exception InvalidDestinationRuntimeException if an invalid topic is specified.
+     * @exception JMSRuntimeException
+     * <ul>
+     * <li>if the session fails to create the shared durable subscription and {@code MessageConsumer} due to some internal
+     * error
+     * <li>if a shared durable subscription already exists with the same name and client identifier, but a different topic,
+     * or message selector, and there is a consumer already active
+     * <li>if an unshared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 2.0
+     */
+    JMSConsumer createSharedDurableConsumer(Topic topic, String name);
+
+    /**
+     * Creates a shared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector, and creates a consumer on that durable subscription.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with shared durable subscriptions. Any durable subscription created using this method
+     * will be shared. This means that multiple active (i.e. not closed) consumers on the subscription may exist at the same
+     * time. The term "consumer" here means a {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
+     *
+     * <p>
+     * A shared durable subscription is identified by a name specified by the client and by the client identifier (which may
+     * be unset). An application which subsequently wishes to create a consumer on that shared durable subscription must use
+     * the same client identifier.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set), and the same topic
+     * and message selector have been specified, then this method creates a {@code JMSConsumer} on the existing shared
+     * durable subscription.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set), but a different
+     * topic or message selector has been specified, and there is no consumer already active (i.e. not closed) on the
+     * durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a new one.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the durable
+     * subscription, then a {@code JMSRuntimeException} will be thrown.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier
+     * (if set). If an unshared durable subscription already exists with the same name and client identifier (if set) then a
+     * {@code JMSRuntimeException} is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the
+     * durable subscription. A value of null or an empty string indicates that there is no message selector for the durable
+     * subscription.
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @exception InvalidDestinationRuntimeException if an invalid topic is specified.
+     * @exception InvalidSelectorRuntimeException if the message selector is invalid.
+     * @exception JMSRuntimeException
+     * <ul>
+     * <li>if the session fails to create the shared durable subscription and {@code JMSConsumer} due to some internal error
+     * <li>if a shared durable subscription already exists with the same name and client identifier, but a different topic,
+     * or message selector, and there is a consumer already active
+     * <li>if an unshared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 2.0
+     */
+    JMSConsumer createSharedDurableConsumer(Topic topic, String name, String messageSelector);
+
+    /**
+     * Creates a shared non-durable subscription with the specified name on the specified topic (if one does not already
+     * exist) and creates a consumer on that subscription. This method creates the non-durable subscription without a
+     * message selector.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set), and the same
+     * topic and message selector has been specified, then this method creates a {@code JMSConsumer} on the existing
+     * subscription.
+     *
+     * <p>
+     * A non-durable shared subscription is used by a client which needs to be able to share the work of receiving messages
+     * from a topic subscription amongst multiple consumers. A non-durable shared subscription may therefore have more than
+     * one consumer. Each message from the subscription will be delivered to only one of the consumers on that subscription.
+     * Such a subscription is not persisted and will be deleted (together with any undelivered messages associated with it)
+     * when there are no consumers on it. The term "consumer" here means a {@code MessageConsumer} or {@code  JMSConsumer}
+     * object in any client.
+     *
+     * <p>
+     * A shared non-durable subscription is identified by a name specified by the client and by the client identifier (which
+     * may be unset). An application which subsequently wishes to create a consumer on that shared non-durable subscription
+     * must use the same client identifier.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector value has been specified, and there is a consumer already active (i.e. not closed) on the
+     * subscription, then a {@code JMSRuntimeException} will be thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the {@code Topic} to subscribe to
+     * @param sharedSubscriptionName the name used to identify the shared non-durable subscription
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @throws JMSRuntimeException if the session fails to create the shared non-durable subscription and {@code JMSContext}
+     * due to some internal error.
+     * @throws InvalidDestinationRuntimeException if an invalid topic is specified.
+     * @throws InvalidSelectorRuntimeException if the message selector is invalid.
+     */
+    JMSConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName);
+
+    /**
+     * Creates a shared non-durable subscription with the specified name on the specified topic (if one does not already
+     * exist) specifying a message selector, and creates a consumer on that subscription.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set), and the same
+     * topic and message selector has been specified, then this method creates a {@code JMSConsumer} on the existing
+     * subscription.
+     *
+     * <p>
+     * A non-durable shared subscription is used by a client which needs to be able to share the work of receiving messages
+     * from a topic subscription amongst multiple consumers. A non-durable shared subscription may therefore have more than
+     * one consumer. Each message from the subscription will be delivered to only one of the consumers on that subscription.
+     * Such a subscription is not persisted and will be deleted (together with any undelivered messages associated with it)
+     * when there are no consumers on it. The term "consumer" here means a {@code MessageConsumer} or {@code  JMSConsumer}
+     * object in any client.
+     *
+     * <p>
+     * A shared non-durable subscription is identified by a name specified by the client and by the client identifier (which
+     * may be unset). An application which subsequently wishes to create a consumer on that shared non-durable subscription
+     * must use the same client identifier.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the
+     * subscription, then a {@code JMSRuntimeException} will be thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the {@code Topic} to subscribe to
+     * @param sharedSubscriptionName the name used to identify the shared non-durable subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the shared
+     * non-durable subscription. A value of null or an empty string indicates that there is no message selector for the
+     * shared non-durable subscription.
+     *
+     * @return The created {@code JMSConsumer} object.
+     *
+     * @throws JMSRuntimeException if the session fails to create the shared non-durable subscription and
+     * {@code JMSConsumer} due to some internal error.
+     * @throws InvalidDestinationRuntimeException if an invalid topic is specified.
+     * @throws InvalidSelectorRuntimeException if the message selector is invalid.
+     */
+    JMSConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName, java.lang.String messageSelector);
+
+    /**
+     * Creates a {@code QueueBrowser} object to peek at the messages on the specified queue.
+     *
+     * @param queue the {@code queue} to access
+     *
+     * @return The created {@code QueueBrowser} object.
+     *
+     * @exception JMSRuntimeException if the session fails to create a browser due to some internal error.
+     * @exception InvalidDestinationRuntimeException if an invalid destination is specified
+     */
+    QueueBrowser createBrowser(Queue queue);
+
+    /**
+     * Creates a {@code QueueBrowser} object to peek at the messages on the specified queue using a message selector.
+     *
+     * @param queue the {@code queue} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     *
+     * @return The created {@code QueueBrowser} object.
+     *
+     * @exception JMSRuntimeException if the session fails to create a browser due to some internal error.
+     * @exception InvalidDestinationRuntimeException if an invalid destination is specified
+     * @exception InvalidSelectorRuntimeException if the message selector is invalid.
+     */
+    QueueBrowser createBrowser(Queue queue, String messageSelector);
+
+    /**
+     * Creates a {@code TemporaryQueue} object. Its lifetime will be that of the JMSContext's {@code Connection} unless it
+     * is deleted earlier.
+     *
+     * @return a temporary queue identity
+     *
+     * @exception JMSRuntimeException if the session fails to create a temporary queue due to some internal error.
+     */
+    TemporaryQueue createTemporaryQueue();
+
+    /**
+     * Creates a {@code TemporaryTopic} object. Its lifetime will be that of the JMSContext's {@code Connection} unless it
+     * is deleted earlier.
+     *
+     * @return a temporary topic identity
+     *
+     * @exception JMSRuntimeException if the session fails to create a temporary topic due to some internal error.
+     *
+     */
+    TemporaryTopic createTemporaryTopic();
+
+    /**
+     * Unsubscribes a durable subscription that has been created by a client.
+     *
+     * <p>
+     * This method deletes the state being maintained on behalf of the subscriber by its provider.
+     *
+     * <p>
+     * A durable subscription is identified by a name specified by the client and by the client identifier if set. If the
+     * client identifier was set when the durable subscription was created then a client which subsequently wishes to use
+     * this method to delete a durable subscription must use the same client identifier.
+     *
+     * <p>
+     * It is erroneous for a client to delete a durable subscription while there is an active (not closed) consumer on that
+     * subscription, or while a consumed message is part of a pending transaction or has not been acknowledged in the
+     * session.
+     *
+     * <p>
+     * If the active consumer is represented by a {@code JMSConsumer} then calling {@code close} on either that object or
+     * the {@code JMSContext} used to create it will render the consumer inactive and allow the subscription to be deleted.
+     *
+     * <p>
+     * If the active consumer was created by calling {@code setMessageListener} on the {@code JMSContext} then calling
+     * {@code close} on the {@code JMSContext} will render the consumer inactive and allow the subscription to be deleted.
+     *
+     * <p>
+     * If the active consumer is represented by a {@code MessageConsumer} or {@code TopicSubscriber} then calling
+     * {@code close} on that object or on the {@code Session} or {@code Connection} used to create it will render the
+     * consumer inactive and allow the subscription to be deleted.
+     *
+     * @param name the name used to identify this subscription
+     *
+     * @exception JMSRuntimeException if the session fails to unsubscribe to the durable subscription due to some internal
+     * error.
+     * @exception InvalidDestinationRuntimeException if an invalid subscription name is specified.
+     */
+    void unsubscribe(String name);
+
+    /**
+     * Acknowledges all messages consumed by the JMSContext's session.
+     *
+     * <p>
+     * This method is for use when the session has an acknowledgement mode of CLIENT_ACKNOWLEDGE. If the session is
+     * transacted or has an acknowledgement mode of AUTO_ACKNOWLEDGE or DUPS_OK_ACKNOWLEDGE calling this method has no
+     * effect.
+     *
+     * <p>
+     * This method has identical behaviour to the {@code acknowledge} method on {@code Message}. A client may individually
+     * acknowledge each message as it is consumed, or it may choose to acknowledge messages as an application-defined group.
+     * In both cases it makes no difference which of these two methods is used.
+     *
+     * <p>
+     * Messages that have been received but not acknowledged may be redelivered.
+     *
+     * <p>
+     * This method must not be used if the {@code JMSContext} is container-managed (injected). Doing so will cause a
+     * {@code IllegalStateRuntimeException} to be thrown.
+     *
+     * @exception IllegalStateRuntimeException
+     * <ul>
+     * <li>if the {@code JMSContext} is closed.
+     * <li>if the {@code JMSContext} is container-managed (injected)
+     * </ul>
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to acknowledge the messages due to some internal error
+     *
+     * @see javax.jms.Session#CLIENT_ACKNOWLEDGE
+     * @see javax.jms.Message#acknowledge
+     */
+    void acknowledge();
 
 }

--- a/src/main/java/javax/jms/JMSDestinationDefinition.java
+++ b/src/main/java/javax/jms/JMSDestinationDefinition.java
@@ -22,76 +22,80 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An application may use this annotation to specify a JMS {@code 
- * Destination} resource that it requires in its operational 
- * environment. This provides information that can be used at the 
- * application's deployment to provision the required resource
- * and allows an application to be deployed into a Java EE environment 
- * with more minimal administrative configuration.
+ * An application may use this annotation to specify a JMS {@code
+ * Destination} resource that it requires in its operational environment. This provides information that can be used at
+ * the application's deployment to provision the required resource and allows an application to be deployed into a Java
+ * EE environment with more minimal administrative configuration.
+ *
  * <p>
- * The {@code Destination} resource may be configured by 
- * setting the annotation elements for commonly used properties. 
- * Additional properties may be specified using the {@code properties}
- * element. Once defined, a {@code Destination} resource may be referenced by a
- * component in the same way as any other {@code Destination} resource,
- * for example by using the {@code lookup} element of the {@code Resource}
- * annotation.
- * 
+ * The {@code Destination} resource may be configured by setting the annotation elements for commonly used properties.
+ * Additional properties may be specified using the {@code properties} element. Once defined, a {@code Destination}
+ * resource may be referenced by a component in the same way as any other {@code Destination} resource, for example by
+ * using the {@code lookup} element of the {@code Resource} annotation.
+ *
  * @see javax.annotation.Resource
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  */
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JMSDestinationDefinition {
 
     /**
-     *  Description of this JMS destination.
+     * Description of this JMS destination.
+     *
+     * @return The description of this JMS destination.
      */
     String description() default "";
 
     /**
-     *  JNDI name of the destination resource being defined.
+     * JNDI name of the destination resource being defined.
+     *
+     * @return The JNDI name of the destination resource being defined.
      */
     String name();
 
-	/**
-	 * Fully qualified name of the JMS destination interface.
-	 * Permitted values are
-	 * {@code javax.jms.Queue} or
-	 * {@code javax.jms.Topic}.
-	 */
-	String interfaceName();
-	
-	/**
-	 * Fully-qualified name of the JMS destination implementation class.
-	 * Ignored if a resource adapter is used unless the resource adapter 
-	 * defines more than one JMS destination implementation class for the specified interface
-	 */
-	String className() default "";
-
-	/**
-	 * Resource adapter name.
-	 * If not specified then the application server will define the default behaviour,
-	 * which may or may not involve the use of a resource adapter.
-	 */
-	String resourceAdapter() default "";
+    /**
+     * Fully qualified name of the JMS destination interface. Permitted values are {@code javax.jms.Queue} or
+     * {@code javax.jms.Topic}.
+     *
+     * @return The fully qualified name of the JMS destination interface.
+     */
+    String interfaceName();
 
     /**
-     *  Name of the queue or topic.
+     * Fully-qualified name of the JMS destination implementation class. Ignored if a resource adapter is used unless the
+     * resource adapter defines more than one JMS destination implementation class for the specified interface.
+     *
+     * @return The fully-qualified name of the JMS destination implementation class.
+     */
+    String className() default "";
+
+    /**
+     * Resource adapter name. If not specified then the application server will define the default behaviour, which may or
+     * may not involve the use of a resource adapter.
+     *
+     * @return The resource adapter name.
+     */
+    String resourceAdapter() default "";
+
+    /**
+     * Name of the queue or topic.
+     *
+     * @return The name of the queue or topic.
      */
     String destinationName() default "";
 
     /**
-     *  JMS destination property.  This may be a vendor-specific property
-     *  or a less commonly used {@code ConnectionFactory} property.
-     *  <p>
-     *  Properties are specified using the format:
-     *  <i>propertyName=propertyValue</i> with one property per array element.
+     * JMS destination property. This may be a vendor-specific property or a less commonly used {@code ConnectionFactory}
+     * property.
+     *
+     * <p>
+     * Properties are specified using the format: <i>propertyName=propertyValue</i> with one property per array element.
+     *
+     * @return The JMS destination properties.
      */
     String[] properties() default {};
 }
-
-

--- a/src/main/java/javax/jms/JMSDestinationDefinitions.java
+++ b/src/main/java/javax/jms/JMSDestinationDefinitions.java
@@ -16,23 +16,24 @@
 
 package javax.jms;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
  * Specifies one or more {@code JMSDestinationDefinition} annotations.
- * 
+ *
  * @see JMSDestinationDefinition
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  */
-@Target({ ElementType.TYPE })
-@Retention(RetentionPolicy.RUNTIME)
+@Target(TYPE)
+@Retention(RUNTIME)
 public @interface JMSDestinationDefinitions {
 
-	JMSDestinationDefinition[] value();
+    JMSDestinationDefinition[] value();
 }

--- a/src/main/java/javax/jms/JMSException.java
+++ b/src/main/java/javax/jms/JMSException.java
@@ -17,91 +17,87 @@
 package javax.jms;
 
 /**
- * <P>This is the root class of all checked exceptions in the JMS API.
+ * <p>
+ * This is the root class of all checked exceptions in the JMS API.
  *
- * <P>It provides the following information:
- * <UL>
- *   <LI> A provider-specific string describing the error. This string is 
- *        the standard exception message and is available via the
- *        {@code getMessage} method.
- *   <LI> A provider-specific string error code 
- *   <LI> A reference to another exception. Often a JMS API exception will 
- *        be the result of a lower-level problem. If appropriate, this 
- *        lower-level exception can be linked to the JMS API exception.
- * </UL>
- * 
+ * <p>
+ * It provides the following information:
+ * <ul>
+ * <li>A provider-specific string describing the error. This string is the standard exception message and is available
+ * via the {@code getMessage} method.
+ * <li>A provider-specific string error code
+ * <li>A reference to another exception. Often a JMS API exception will be the result of a lower-level problem. If
+ * appropriate, this lower-level exception can be linked to the JMS API exception.
+ * </ul>
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class JMSException extends Exception {
 
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = 8951994251593378324L;
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = 8951994251593378324L;
 
-  /** Vendor-specific error code.
-  **/
-  private String errorCode;
+    /**
+     * Vendor-specific error code.
+     **/
+    private String errorCode;
 
-  /** {@code Exception} reference.
-  **/
-  private Exception linkedException;
+    /**
+     * {@code Exception} reference.
+     **/
+    private Exception linkedException;
 
+    /**
+     * Constructs a {@code JMSException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     **/
+    public JMSException(String reason, String errorCode) {
+        super(reason);
+        this.errorCode = errorCode;
+        linkedException = null;
+    }
 
-  /** Constructs a {@code JMSException} with the specified reason and 
-   *  error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   **/
-  public 
-  JMSException(String reason, String errorCode) {
-    super(reason);
-    this.errorCode = errorCode;
-    linkedException = null;
-  }
+    /**
+     * Constructs a {@code JMSException} with the specified reason and with the error code defaulting to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public JMSException(String reason) {
+        super(reason);
+        this.errorCode = null;
+        linkedException = null;
+    }
 
-  /** Constructs a {@code JMSException} with the specified reason and with
-   *  the error code defaulting to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  JMSException(String reason) {
-    super(reason);
-    this.errorCode = null;
-    linkedException = null;
-  }
+    /**
+     * Gets the vendor-specific error code.
+     *
+     * @return a string specifying the vendor-specific error code
+     **/
+    public String getErrorCode() {
+        return this.errorCode;
+    }
 
-  /** Gets the vendor-specific error code.
-   *  @return   a string specifying the vendor-specific
-   *                        error code
-  **/
-  public 
-  String getErrorCode() {
-    return this.errorCode;
-  }
+    /**
+     * Gets the exception linked to this one.
+     *
+     * @return the linked {@code Exception}, null if none
+     **/
+    public Exception getLinkedException() {
+        return (linkedException);
+    }
 
-  /**
-   * Gets the exception linked to this one.
-   *
-   * @return the linked {@code Exception}, null if none
-  **/
-  public 
-  Exception getLinkedException() {
-    return (linkedException);
-  }
-
-  /**
-   * Adds a linked {@code Exception}.
-   *
-   * @param ex       the linked {@code Exception}
-  **/
-  public void setLinkedException(Exception ex) {
-      linkedException = ex;
-  } 
+    /**
+     * Adds a linked {@code Exception}.
+     *
+     * @param ex the linked {@code Exception}
+     **/
+    public void setLinkedException(Exception ex) {
+        linkedException = ex;
+    }
 }

--- a/src/main/java/javax/jms/JMSMessageDrivenBean.java
+++ b/src/main/java/javax/jms/JMSMessageDrivenBean.java
@@ -17,29 +17,26 @@
 package javax.jms;
 
 /**
- * This is a marker interface that may be implemented by a message-driven bean
- * class to specify that it is used to consume JMS messages. It is an
- * alternative to implementing the MessageListener interface.
+ * This is a marker interface that may be implemented by a message-driven bean class to specify that it is used to
+ * consume JMS messages. It is an alternative to implementing the MessageListener interface.
+ *
  * <p>
- * A JMS message-driven bean that implements the {@code JMSMessageDrivenBean}
- * marker interface must not also implement the {@code MessageListener}
- * interface.
+ * A JMS message-driven bean that implements the {@code JMSMessageDrivenBean} marker interface must not also implement
+ * the {@code MessageListener} interface.
+ *
  * <p>
- * If the MDB implements this interface then each callback method must be
- * annotated with one of {@code JMSQueueListener},
- * {@code JMSNonDurableTopicListener} or {@code JMSDurableTopicListener}.
- * <p>
- * 
+ * If the MDB implements this interface then each callback method must be annotated with one of
+ * {@code JMSQueueListener}, {@code JMSNonDurableTopicListener} or {@code JMSDurableTopicListener}.
+ *
  * @see JMSMessageDrivenBean
  * @see TopicListener
  * @see DurableSubscription
  * @see QueueListener
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
+ *
  */
-
 public interface JMSMessageDrivenBean {
 
 }

--- a/src/main/java/javax/jms/JMSPasswordCredential.java
+++ b/src/main/java/javax/jms/JMSPasswordCredential.java
@@ -26,27 +26,30 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation may be used to specify the userName and password
- * to be used when injecting a {@code javax.jms.JMSContext} object.
- * 
+ * This annotation may be used to specify the userName and password to be used when injecting a
+ * {@code javax.jms.JMSContext} object.
+ *
  * @see javax.jms.ConnectionFactory#createContext(java.lang.String, java.lang.String)
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
  */
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, PARAMETER, TYPE})
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
 public @interface JMSPasswordCredential {
 
     /**
      * Specifies the userName to be used when injecting a {@code javax.jms.JMSContext} object
+     *
+     * @return The userName to be used when injecting a {@code javax.jms.JMSContext} object
      */
     String userName();
-    
+
     /**
      * Specifies the password to be used when injecting a {@code javax.jms.JMSContext} object
+     *
+     * @return the password to be used when injecting a {@code javax.jms.JMSContext} object
      */
     String password();
-    
+
 }

--- a/src/main/java/javax/jms/JMSProducer.java
+++ b/src/main/java/javax/jms/JMSProducer.java
@@ -21,1250 +21,1009 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * A {@code JMSProducer} is a simple object used to send messages on behalf
- * of a {@code JMSContext}. An instance of {@code JMSProducer} is
- * created by calling the {@code createProducer} method on a
- * {@code JMSContext}. It provides various {@code send} methods to
- * send a message to a specified destination. It also provides methods to allow
- * message send options, message properties and message headers to be specified
- * prior to sending a message or set of messages.
+ * A {@code JMSProducer} is a simple object used to send messages on behalf of a {@code JMSContext}. An instance of
+ * {@code JMSProducer} is created by calling the {@code createProducer} method on a {@code JMSContext}. It provides
+ * various {@code send} methods to send a message to a specified destination. It also provides methods to allow message
+ * send options, message properties and message headers to be specified prior to sending a message or set of messages.
+ *
  * <p>
- * Message send options may be specified using one or more of the following
- * methods: {@code setDeliveryMode}, {@code setPriority},
- * {@code setTimeToLive}, {@code setDeliveryDelay},
- * {@code setDisableMessageTimestamp}, {@code setDisableMessageID} and
- * {@code setAsync}.
+ * Message send options may be specified using one or more of the following methods: {@code setDeliveryMode},
+ * {@code setPriority}, {@code setTimeToLive}, {@code setDeliveryDelay}, {@code setDisableMessageTimestamp},
+ * {@code setDisableMessageID} and {@code setAsync}.
+ *
  * <p>
- * Message properties may be may be specified using one or more of nine
- * {@code setProperty} methods. Any message properties set using these
- * methods will override any message properties that have been set directly on
- * the message.
+ * Message properties may be may be specified using one or more of nine {@code setProperty} methods. Any message
+ * properties set using these methods will override any message properties that have been set directly on the message.
+ *
  * <p>
- * Message headers may be specified using one or more of the following methods:
- * {@code setJMSCorrelationID}, {@code setJMSCorrelationIDAsBytes},
- * {@code setJMSType} or {@code setJMSReplyTo}. Any message headers
- * set using these methods will override any message headers that have been set
- * directly on the message.
+ * Message headers may be specified using one or more of the following methods: {@code setJMSCorrelationID},
+ * {@code setJMSCorrelationIDAsBytes}, {@code setJMSType} or {@code setJMSReplyTo}. Any message headers set using these
+ * methods will override any message headers that have been set directly on the message.
+ *
  * <p>
- * All the above methods return the {@code JMSProducer} to allow method
- * calls to be chained together, allowing a fluid programming style. For
- * example:
+ * All the above methods return the {@code JMSProducer} to allow method calls to be chained together, allowing a fluid
+ * programming style. For example:
+ *
  * <p>
  * <tt>context.createProducer().setDeliveryMode(DeliveryMode.NON_PERSISTENT).setTimeToLive(1000).send(destination, message);</tt>
+ *
  * <p>
- * Instances of {@code JMSProducer} are intended to be lightweight objects
- * which can be created freely and which do not consume significant resources.
- * This interface therefore does not provide a {@code close} method.
- * 
+ * Instances of {@code JMSProducer} are intended to be lightweight objects which can be created freely and which do not
+ * consume significant resources. This interface therefore does not provide a {@code close} method.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  */
-
 public interface JMSProducer {
-	
-	/**
-	 * Sends a message to the specified destination, using any send options,
-	 * message properties and message headers that have been defined on this
-	 * {@code JMSProducer}.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param message
-	 *            the message to send
-	 * @return this {@code JMSProducer}
-	 * @throws MessageFormatRuntimeException
-	 *             if an invalid message is specified.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if a client uses this method with an invalid destination.
-	 * @throws MessageNotWriteableRuntimeException
-	 *             if this {@code JMSProducer} has been configured to set a
-	 *             message property, but the message's properties are read-only
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to send the message due to some
-	 *             internal error.
-	 */
-	JMSProducer send(Destination destination, Message message);
 
-	/**
-	 * Send a {@code TextMessage} with the specified body to the
-	 * specified destination, using any send options, message properties and
-	 * message headers that have been defined on this {@code JMSProducer}.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param body
-	 *            the body of the {@code TextMessage} that will be sent. 
-	 *            If a null value is specified then a {@code TextMessage} 
-	 *            with no body will be sent.
-	 * @return this {@code JMSProducer}
-	 * @throws MessageFormatRuntimeException
-	 *             if an invalid message is specified.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if a client uses this method with an invalid destination.
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to send the message due to some
-	 *             internal error.
-	 */
-	JMSProducer send(Destination destination, String body);
+    /**
+     * Sends a message to the specified destination, using any send options, message properties and message headers that
+     * have been defined on this {@code JMSProducer}.
+     *
+     * @param destination the destination to send this message to
+     * @param message the message to send
+     * @return this {@code JMSProducer}
+     * @throws MessageFormatRuntimeException if an invalid message is specified.
+     * @throws InvalidDestinationRuntimeException if a client uses this method with an invalid destination.
+     * @throws MessageNotWriteableRuntimeException if this {@code JMSProducer} has been configured to set a message
+     * property, but the message's properties are read-only
+     * @throws JMSRuntimeException if the JMS provider fails to send the message due to some internal error.
+     */
+    JMSProducer send(Destination destination, Message message);
 
-	/**
-	 * Send a {@code MapMessage} with the specified body to the
-	 * specified destination, using any send options, message properties and
-	 * message headers that have been defined on this {@code JMSProducer}.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param body
-	 *            the body of the {@code MapMessage} that will be sent.
-	 *            If a null value is specified then a {@code MapMessage} 
-	 *            with no map entries will be sent.
-	 * @return this {@code JMSProducer}
-	 * @throws MessageFormatRuntimeException
-	 *             if an invalid message is specified.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if a client uses this method with an invalid destination.
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to send the message due to some
-	 *             internal error.
-	 */
-	JMSProducer send(Destination destination, Map<String, Object> body);
+    /**
+     * Send a {@code TextMessage} with the specified body to the specified destination, using any send options, message
+     * properties and message headers that have been defined on this {@code JMSProducer}.
+     *
+     * @param destination the destination to send this message to
+     * @param body the body of the {@code TextMessage} that will be sent. If a null value is specified then a
+     * {@code TextMessage} with no body will be sent.
+     * @return this {@code JMSProducer}
+     * @throws MessageFormatRuntimeException if an invalid message is specified.
+     * @throws InvalidDestinationRuntimeException if a client uses this method with an invalid destination.
+     * @throws JMSRuntimeException if the JMS provider fails to send the message due to some internal error.
+     */
+    JMSProducer send(Destination destination, String body);
 
-	/**
-	 * Send a {@code BytesMessage} with the specified body to the
-	 * specified destination, using any send options, message properties and
-	 * message headers that have been defined on this {@code JMSProducer}.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param body
-	 *            the body of the {@code BytesMessage} that will be
-	 *            sent.
-	 *            If a null value is specified then a {@code BytesMessage} 
-	 *            with no body will be sent.
-	 * @return this {@code JMSProducer}
-	 * @throws MessageFormatRuntimeException
-	 *             if an invalid message is specified.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if a client uses this method with an invalid destination.
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to send the message due to some
-	 *             internal error.
-	 */
-	JMSProducer send(Destination destination, byte[] body);
+    /**
+     * Send a {@code MapMessage} with the specified body to the specified destination, using any send options, message
+     * properties and message headers that have been defined on this {@code JMSProducer}.
+     *
+     * @param destination the destination to send this message to
+     * @param body the body of the {@code MapMessage} that will be sent. If a null value is specified then a
+     * {@code MapMessage} with no map entries will be sent.
+     * @return this {@code JMSProducer}
+     * @throws MessageFormatRuntimeException if an invalid message is specified.
+     * @throws InvalidDestinationRuntimeException if a client uses this method with an invalid destination.
+     * @throws JMSRuntimeException if the JMS provider fails to send the message due to some internal error.
+     */
+    JMSProducer send(Destination destination, Map<String, Object> body);
 
-	/**
-	 * Send an {@code ObjectMessage} with the specified body to the
-	 * specified destination, using any send options, message properties and
-	 * message headers that have been defined on this {@code JMSProducer}.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param body
-	 *            the body of the ObjectMessage that will be sent.
-	 *            If a null value is specified then an {@code ObjectMessage} 
-	 *            with no body will be sent.
-	 * @return this {@code JMSProducer}
-	 * @throws MessageFormatRuntimeException
-	 *             if an invalid message is specified.
-	 * @throws InvalidDestinationRuntimeException
-	 *             if a client uses this method with an invalid destination.
-	 * @throws JMSRuntimeException
-	 *             if JMS provider fails to send the message due to some
-	 *             internal error.
-	 */
-	JMSProducer send(Destination destination, Serializable body);
+    /**
+     * Send a {@code BytesMessage} with the specified body to the specified destination, using any send options, message
+     * properties and message headers that have been defined on this {@code JMSProducer}.
+     *
+     * @param destination the destination to send this message to
+     * @param body the body of the {@code BytesMessage} that will be sent. If a null value is specified then a
+     * {@code BytesMessage} with no body will be sent.
+     * @return this {@code JMSProducer}
+     * @throws MessageFormatRuntimeException if an invalid message is specified.
+     * @throws InvalidDestinationRuntimeException if a client uses this method with an invalid destination.
+     * @throws JMSRuntimeException if the JMS provider fails to send the message due to some internal error.
+     */
+    JMSProducer send(Destination destination, byte[] body);
 
-	/**
-	 * Specifies whether message IDs may be disabled for messages that are sent
-	 * using this {@code JMSProducer}
-	 * <p>
-	 * Since message IDs take some effort to create and increase a message's
-	 * size, some JMS providers may be able to optimise message overhead if they
-	 * are given a hint that the message ID is not used by an application. By
-	 * calling this method, a JMS application enables this potential
-	 * optimisation for all messages sent using this {@code JMSProducer}.
-	 * If the JMS provider accepts this hint, these messages must have the
-	 * message ID set to null; if the provider ignores the hint, the message ID
-	 * must be set to its normal unique value.
-	 * <p>
-	 * Message IDs are enabled by default.
-	 * <p>
-	 * 
-	 * @param value
-	 *            indicates whether message IDs may be disabled
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set message ID to disabled due
-	 *             to some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getDisableMessageID
-	 */
-	JMSProducer setDisableMessageID(boolean value);
+    /**
+     * Send an {@code ObjectMessage} with the specified body to the specified destination, using any send options, message
+     * properties and message headers that have been defined on this {@code JMSProducer}.
+     *
+     * @param destination the destination to send this message to
+     * @param body the body of the ObjectMessage that will be sent. If a null value is specified then an
+     * {@code ObjectMessage} with no body will be sent.
+     * @return this {@code JMSProducer}
+     * @throws MessageFormatRuntimeException if an invalid message is specified.
+     * @throws InvalidDestinationRuntimeException if a client uses this method with an invalid destination.
+     * @throws JMSRuntimeException if JMS provider fails to send the message due to some internal error.
+     */
+    JMSProducer send(Destination destination, Serializable body);
 
-	/**
-	 * Gets an indication of whether message IDs are disabled.
-	 * 
-	 * @return an indication of whether message IDs are disabled
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to determine if message IDs are
-	 *             disabled due to some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setDisableMessageID
-	 */
+    /**
+     * Specifies whether message IDs may be disabled for messages that are sent using this {@code JMSProducer}
+     *
+     * <p>
+     * Since message IDs take some effort to create and increase a message's size, some JMS providers may be able to
+     * optimise message overhead if they are given a hint that the message ID is not used by an application. By calling this
+     * method, a JMS application enables this potential optimisation for all messages sent using this {@code JMSProducer}.
+     * If the JMS provider accepts this hint, these messages must have the message ID set to null; if the provider ignores
+     * the hint, the message ID must be set to its normal unique value.
+     *
+     * <p>
+     * Message IDs are enabled by default.
+     *
+     * @param value indicates whether message IDs may be disabled
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to set message ID to disabled due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getDisableMessageID
+     */
+    JMSProducer setDisableMessageID(boolean value);
 
-	boolean getDisableMessageID();
+    /**
+     * Gets an indication of whether message IDs are disabled.
+     *
+     * @return an indication of whether message IDs are disabled
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to determine if message IDs are disabled due to some internal
+     * error.
+     *
+     * @see javax.jms.JMSProducer#setDisableMessageID
+     */
+    boolean getDisableMessageID();
 
-	/**
-	 * Specifies whether message timestamps may be disabled for messages that
-	 * are sent using this {@code JMSProducer}. <pP> Since timestamps take
-	 * some effort to create and increase a message's size, some JMS providers
-	 * may be able to optimise message overhead if they are given a hint that
-	 * the timestamp is not used by an application. By calling this method, a
-	 * JMS application enables this potential optimisation for all messages sent
-	 * using this {@code JMSProducer}. If the JMS provider accepts this
-	 * hint, these messages must have the timestamp set to zero; if the provider
-	 * ignores the hint, the timestamp must be set to its normal value.
-	 * <p>
-	 * Message timestamps are enabled by default.
-	 * 
-	 * @param value
-	 *            indicates whether message timestamps may be disabled
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set timestamps to disabled due
-	 *             to some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getDisableMessageTimestamp
-	 */
-	JMSProducer setDisableMessageTimestamp(boolean value);
+    /**
+     * Specifies whether message timestamps may be disabled for messages that are sent using this {@code JMSProducer}.
+     *
+     * <p>
+     * Since timestamps take some effort to create and increase a message's size, some JMS providers may be able to optimise
+     * message overhead if they are given a hint that the timestamp is not used by an application. By calling this method, a
+     * JMS application enables this potential optimisation for all messages sent using this {@code JMSProducer}. If the JMS
+     * provider accepts this hint, these messages must have the timestamp set to zero; if the provider ignores the hint, the
+     * timestamp must be set to its normal value.
+     *
+     * <p>
+     * Message timestamps are enabled by default.
+     *
+     * @param value indicates whether message timestamps may be disabled
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to set timestamps to disabled due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getDisableMessageTimestamp
+     */
+    JMSProducer setDisableMessageTimestamp(boolean value);
 
-	/**
-	 * Gets an indication of whether message timestamps are disabled.
-	 * 
-	 * @return an indication of whether message timestamps are disabled
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to determine if timestamps are
-	 *             disabled due to some internal error.
-	 * @see javax.jms.JMSProducer#setDisableMessageTimestamp
-	 */
-	boolean getDisableMessageTimestamp();
+    /**
+     * Gets an indication of whether message timestamps are disabled.
+     *
+     * @return an indication of whether message timestamps are disabled
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to determine if timestamps are disabled due to some internal
+     * error.
+     * @see javax.jms.JMSProducer#setDisableMessageTimestamp
+     */
+    boolean getDisableMessageTimestamp();
 
-	/**
-	 * Specifies the delivery mode of messages that are sent using this
-	 * {@code JMSProducer}
-	 * <p>
-	 * Delivery mode is set to {@code PERSISTENT} by default.
-	 * 
-	 * @param deliveryMode
-	 *            the message delivery mode to be used; legal values are
-	 *            {@code DeliveryMode.NON_PERSISTENT} and
-	 *            {@code DeliveryMode.PERSISTENT}
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the delivery mode due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getDeliveryMode
-	 * @see javax.jms.DeliveryMode#NON_PERSISTENT
-	 * @see javax.jms.DeliveryMode#PERSISTENT
-	 * @see javax.jms.Message#DEFAULT_DELIVERY_MODE
-	 */
-	JMSProducer setDeliveryMode(int deliveryMode);
+    /**
+     * Specifies the delivery mode of messages that are sent using this {@code JMSProducer}
+     * <p>
+     * Delivery mode is set to {@code PERSISTENT} by default.
+     *
+     * @param deliveryMode the message delivery mode to be used; legal values are {@code DeliveryMode.NON_PERSISTENT} and
+     * {@code DeliveryMode.PERSISTENT}
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to set the delivery mode due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getDeliveryMode
+     * @see javax.jms.DeliveryMode#NON_PERSISTENT
+     * @see javax.jms.DeliveryMode#PERSISTENT
+     * @see javax.jms.Message#DEFAULT_DELIVERY_MODE
+     */
+    JMSProducer setDeliveryMode(int deliveryMode);
 
-	/**
-	 * Returns the delivery mode of messages that are sent using this
-	 * {@code JMSProducer}
-	 * 
-	 * @return the message delivery mode
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the delivery mode due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setDeliveryMode
-	 */
+    /**
+     * Returns the delivery mode of messages that are sent using this {@code JMSProducer}
+     *
+     * @return the message delivery mode
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the delivery mode due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setDeliveryMode
+     */
+    int getDeliveryMode();
 
-	int getDeliveryMode();
+    /**
+     * Specifies the priority of messages that are sent using this {@code JMSProducer}
+     *
+     * <p>
+     * The JMS API defines ten levels of priority value, with 0 as the lowest priority and 9 as the highest. Clients should
+     * consider priorities 0-4 as gradations of normal priority and priorities 5-9 as gradations of expedited priority.
+     * Priority is set to 4 by default.
+     *
+     * @param priority the message priority to be used; must be a value between 0 and 9
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to set the priority due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getPriority
+     * @see javax.jms.Message#DEFAULT_PRIORITY
+     */
+    JMSProducer setPriority(int priority);
 
-	/**
-	 * Specifies the priority of messages that are sent using this
-	 * {@code JMSProducer}
-	 * <p>
-	 * The JMS API defines ten levels of priority value, with 0 as the lowest
-	 * priority and 9 as the highest. Clients should consider priorities 0-4 as
-	 * gradations of normal priority and priorities 5-9 as gradations of
-	 * expedited priority. Priority is set to 4 by default.
-	 * <p>
-	 * 
-	 * @param priority
-	 *            the message priority to be used; must be a value between 0 and
-	 *            9
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the priority due to some
-	 *             internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getPriority
-	 * @see javax.jms.Message#DEFAULT_PRIORITY
-	 */
+    /**
+     * Return the priority of messages that are sent using this {@code JMSProducer}
+     *
+     * @return the message priority
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the priority due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setPriority
+     */
+    int getPriority();
 
-	JMSProducer setPriority(int priority);
+    /**
+     * Specifies the time to live of messages that are sent using this {@code JMSProducer}. This is used to determine the
+     * expiration time of a message.
+     *
+     * <p>
+     * The expiration time of a message is the sum of the message's time to live and the time it is sent. For transacted
+     * sends, this is the time the client sends the message, not the time the transaction is committed.
+     *
+     * <p>
+     * Clients should not receive messages that have expired; however, JMS does not guarantee that this will not happen.
+     *
+     * <p>
+     * A JMS provider should do its best to accurately expire messages; however, JMS does not define the accuracy provided.
+     * It is not acceptable to simply ignore time-to-live.
+     *
+     * <p>
+     * Time to live is set to zero by default, which means a message never expires.
+     *
+     * @param timeToLive the message time to live to be used, in milliseconds; a value of zero means that a message never
+     * expires.
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to set the time to live due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getTimeToLive
+     * @see javax.jms.Message#DEFAULT_TIME_TO_LIVE
+     */
+    JMSProducer setTimeToLive(long timeToLive);
 
-	/**
-	 * Return the priority of messages that are sent using this
-	 * {@code JMSProducer}
-	 * <p>
-	 * 
-	 * @return the message priority
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the priority due to some
-	 *             internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setPriority
-	 */
+    /**
+     * Returns the time to live of messages that are sent using this {@code JMSProducer}.
+     *
+     * @return the message time to live in milliseconds; a value of zero means that a message never expires.
+     * @throws JMSRuntimeException if the JMS provider fails to get the time to live due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setTimeToLive
+     */
+    long getTimeToLive();
 
-	int getPriority();
+    /**
+     * Sets the minimum length of time in milliseconds that must elapse after a message is sent before the JMS provider may
+     * deliver the message to a consumer.
+     *
+     * <p>
+     * For transacted sends, this time starts when the client sends the message, not when the transaction is committed.
+     *
+     * <p>
+     * deliveryDelay is set to zero by default.
+     *
+     * @param deliveryDelay the delivery delay in milliseconds.
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the delivery delay due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getDeliveryDelay
+     * @see javax.jms.Message#DEFAULT_DELIVERY_DELAY
+     */
+    JMSProducer setDeliveryDelay(long deliveryDelay);
 
-	/**
-	 * Specifies the time to live of messages that are sent using this
-	 * {@code JMSProducer}. This is used to determine the expiration time
-	 * of a message.
-	 * <p>
-	 * The expiration time of a message is the sum of the message's time to live
-	 * and the time it is sent. For transacted sends, this is the time the
-	 * client sends the message, not the time the transaction is committed.
-	 * <p>
-	 * Clients should not receive messages that have expired; however, JMS does
-	 * not guarantee that this will not happen.
-	 * <p>
-	 * A JMS provider should do its best to accurately expire messages; however,
-	 * JMS does not define the accuracy provided. It is not acceptable to simply
-	 * ignore time-to-live.
-	 * <p>
-	 * Time to live is set to zero by default, which means a message never
-	 * expires.
-	 * 
-	 * @param timeToLive
-	 *            the message time to live to be used, in milliseconds; a value
-	 *            of zero means that a message never expires.
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the time to live due to some
-	 *             internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getTimeToLive
-	 * @see javax.jms.Message#DEFAULT_TIME_TO_LIVE
-	 */
-	JMSProducer setTimeToLive(long timeToLive);
+    /**
+     * Gets the minimum length of time in milliseconds that must elapse after a message is sent before the JMS provider may
+     * deliver the message to a consumer.
+     *
+     * @return the delivery delay in milliseconds.
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the delivery delay due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setDeliveryDelay
+     */
+    long getDeliveryDelay();
 
-	/**
-	 * Returns the time to live of messages that are sent using this
-	 * {@code JMSProducer}.
-	 * 
-	 * @return the message time to live in milliseconds; a value of zero means
-	 *         that a message never expires.
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the time to live due to some
-	 *             internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setTimeToLive
-	 */
+    /**
+     * Specifies whether subsequent calls to {@code send} on this {@code JMSProducer} object should be synchronous or
+     * asynchronous. If the specified {@code CompletionListener} is not null then subsequent calls to {@code send} will be
+     * asynchronous. If the specified {@code CompletionListener} is null then subsequent calls to {@code send} will be
+     * synchronous. Calls to {@code send} are synchronous by default.
+     *
+     * <p>
+     * If a call to {@code send} is asynchronous then part of the work involved in sending the message will be performed in
+     * a separate thread and the specified <tt>CompletionListener</tt> will be notified when the operation has completed.
+     *
+     * <p>
+     * When the message has been successfully sent the JMS provider invokes the callback method <tt>onCompletion</tt> on the
+     * <tt>CompletionListener</tt> object. Only when that callback has been invoked can the application be sure that the
+     * message has been successfully sent with the same degree of confidence as if the send had been synchronous. An
+     * application which requires this degree of confidence must therefore wait for the callback to be invoked before
+     * continuing.
+     *
+     * <p>
+     * The following information is intended to give an indication of how an asynchronous send would typically be
+     * implemented.
+     *
+     * <p>
+     * In some JMS providers, a normal synchronous send involves sending the message to a remote JMS server and then waiting
+     * for an acknowledgement to be received before returning. It is expected that such a provider would implement an
+     * asynchronous send by sending the message to the remote JMS server and then returning without waiting for an
+     * acknowledgement. When the acknowledgement is received, the JMS provider would notify the application by invoking the
+     * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object. If for some reason the
+     * acknowledgement is not received the JMS provider would notify the application by invoking the
+     * <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+     *
+     * <p>
+     * In those cases where the JMS specification permits a lower level of reliability, a normal synchronous send might not
+     * wait for an acknowledgement. In that case it is expected that an asynchronous send would be similar to a synchronous
+     * send: the JMS provider would send the message to the remote JMS server and then return without waiting for an
+     * acknowledgement. However the JMS provider would still notify the application that the send had completed by invoking
+     * the <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
+     *
+     * <p>
+     * It is up to the JMS provider to decide exactly what is performed in the calling thread and what, if anything, is
+     * performed asynchronously, so long as it satisfies the requirements given below:
+     *
+     * <p>
+     * <b>Quality of service</b>: After the send operation has completed successfully, which means that the message has been
+     * successfully sent with the same degree of confidence as if a normal synchronous send had been performed, the JMS
+     * provider must invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
+     * must not be invoked earlier than this.
+     *
+     * <p>
+     * <b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt> method then an appropriate
+     * exception should be thrown in the thread that is calling the <tt>send</tt> method. In this case the JMS provider must
+     * not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
+     * encountered which cannot be thrown in the thread that is calling the <tt>send</tt> method then the JMS provider must
+     * call the <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases if an exception occurs it is
+     * undefined whether or not the message was successfully sent.
+     *
+     * <p>
+     * <b>Message order</b>: If the same <tt>JMSContext</tt> is used to send multiple messages then JMS message ordering
+     * requirements must be satisfied. This applies even if a combination of synchronous and asynchronous sends has been
+     * performed. The application is not required to wait for an asynchronous send to complete before sending the next
+     * message.
+     *
+     * <p>
+     * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the <tt>JMSContext</tt> then the JMS
+     * provider must block until any incomplete send operations have been completed and all {@code CompletionListener}
+     * callbacks have returned before closing the object and returning. If the session is transacted (uses a local
+     * transaction) then when the <tt>JMSContext</tt>'s <tt>commit</tt> or <tt>rollback</tt> method is called the JMS
+     * provider must block until any incomplete send operations have been completed and all {@code CompletionListener}
+     * callbacks have returned before performing the commit or rollback. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> on
+     * its own <tt>JMSContext</tt>. Doing so will cause the <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> to throw an
+     * <tt>IllegalStateRuntimeException</tt>.
+     *
+     * <p>
+     * <b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web container. Doing so may
+     * cause a {@code JMSRuntimeException} to be thrown though this is not guaranteed.
+     *
+     * <p>
+     * <b>Message headers</b> JMS defines a number of message header fields and message properties which must be set by the
+     * "JMS provider on send". If the send is asynchronous these fields and properties may be accessed on the sending client
+     * only after the <tt>CompletionListener</tt> has been invoked. If the <tt>CompletionListener</tt>'s
+     * <tt>onException</tt> method is called then the state of these message header fields and properties is undefined.
+     *
+     * <p>
+     * <b>Restrictions on threading</b>: Applications that perform an asynchronous send must confirm to the threading
+     * restrictions defined in JMS. This means that the session may be used by only one thread at a time.
+     *
+     * <p>
+     * Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the thread of control which calls
+     * the <tt>CompletionListener</tt>. The application thread may therefore continue to use the session after performing an
+     * asynchronous send. However the <tt>CompletionListener</tt>'s callback methods must not use the session if an
+     * application thread might be using the session at the same time.
+     *
+     * <p>
+     * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only invoke one
+     * <tt>CompletionListener</tt> callback method at a time. For a given <tt>JMSContext</tt>, callbacks (both
+     * {@code onCompletion} and {@code onException}) will be performed in the same order as the corresponding calls to the
+     * <tt>send</tt> method. A JMS provider must not invoke the <tt>CompletionListener</tt> from the thread that is calling
+     * the <tt>send</tt> method.
+     *
+     * <p>
+     * <b>Restrictions on the use of the Message object</b>: Applications which perform an asynchronous send must take
+     * account of the restriction that a <tt>Message</tt> object is designed to be accessed by one logical thread of control
+     * at a time and does not support concurrent use.
+     *
+     * <p>
+     * After the <tt>send</tt> method has returned, the application must not attempt to read the headers, properties or body
+     * of the <tt>Message</tt> object until the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt>
+     * method has been called. This is because the JMS provider may be modifying the <tt>Message</tt> object in another
+     * thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the application attempts to access or
+     * modify the <tt>Message</tt> object after the <tt>send</tt> method has returned and before the
+     * <tt>CompletionListener</tt> has been invoked. If the JMS provider does not throw an exception then the behaviour is
+     * undefined.
+     *
+     * @param completionListener If asynchronous send behaviour is required, this should be set to a
+     * {@code CompletionListener} to be notified when the send has completed. If synchronous send behaviour is required,
+     * this should be set to {@code null}.
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if an internal error occurs
+     *
+     * @see javax.jms.JMSProducer#getAsync
+     * @see javax.jms.CompletionListener
+     */
+    JMSProducer setAsync(CompletionListener completionListener);
 
-	long getTimeToLive();
+    /**
+     * If subsequent calls to {@code send} on this {@code JMSProducer} object have been configured to be asynchronous then
+     * this method returns the {@code CompletionListener} that has previously been configured. If subsequent calls to
+     * {@code send} have been configured to be synchronous then this method returns {@code null}.
+     *
+     * @return the {@code CompletionListener} or {@code null}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the required information due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setAsync
+     */
+    CompletionListener getAsync();
 
-	/**
-	 * Sets the minimum length of time in milliseconds that must elapse after a
-	 * message is sent before the JMS provider may deliver the message to a
-	 * consumer.
-	 * <p>
-	 * For transacted sends, this time starts when the client sends the message,
-	 * not when the transaction is committed.
-	 * <p>
-	 * deliveryDelay is set to zero by default.
-	 * 
-	 * @param deliveryDelay
-	 *            the delivery delay in milliseconds.
-	 * @return this {@code JMSProducer}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the delivery delay due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getDeliveryDelay
-	 * @see javax.jms.Message#DEFAULT_DELIVERY_DELAY
-	 */
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code boolean} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code boolean} value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getBooleanProperty
+     */
+    JMSProducer setProperty(String name, boolean value);
 
-	JMSProducer setDeliveryDelay(long deliveryDelay);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code byte} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code byte} value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getByteProperty
+     */
+    JMSProducer setProperty(String name, byte value);
 
-	/**
-	 * Gets the minimum length of time in milliseconds that must elapse after a
-	 * message is sent before the JMS provider may deliver the message to a
-	 * consumer.
-	 * 
-	 * @return the delivery delay in milliseconds.
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the delivery delay due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setDeliveryDelay
-	 */
-	long getDeliveryDelay();
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code short} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code short} property value to set
+     *
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     *
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getShortProperty
+     */
+    JMSProducer setProperty(String name, short value);
 
-	/**
-	 * Specifies whether subsequent calls to {@code send} on this
-	 * {@code JMSProducer} object should be synchronous or asynchronous. If
-	 * the specified {@code CompletionListener} is not null then subsequent
-	 * calls to {@code send} will be asynchronous. If the specified
-	 * {@code CompletionListener} is null then subsequent calls to
-	 * {@code send} will be synchronous. Calls to {@code send} are
-	 * synchronous by default.
-	 * <p>
-	 * If a call to {@code send} is asynchronous then part of the work
-	 * involved in sending the message will be performed in a separate thread
-	 * and the specified <tt>CompletionListener</tt> will be notified when the
-	 * operation has completed.
-	 * <p>
-	 * When the message has been successfully sent the JMS provider invokes the
-	 * callback method <tt>onCompletion</tt> on the <tt>CompletionListener</tt>
-	 * object. Only when that callback has been invoked can the application be
-	 * sure that the message has been successfully sent with the same degree of
-	 * confidence as if the send had been synchronous. An application which
-	 * requires this degree of confidence must therefore wait for the callback
-	 * to be invoked before continuing.
-	 * <p>
-	 * The following information is intended to give an indication of how an
-	 * asynchronous send would typically be implemented.
-	 * <p>
-	 * In some JMS providers, a normal synchronous send involves sending the
-	 * message to a remote JMS server and then waiting for an acknowledgement to
-	 * be received before returning. It is expected that such a provider would
-	 * implement an asynchronous send by sending the message to the remote JMS
-	 * server and then returning without waiting for an acknowledgement. When
-	 * the acknowledgement is received, the JMS provider would notify the
-	 * application by invoking the <tt>onCompletion</tt> method on the
-	 * application-specified <tt>CompletionListener</tt> object. If for some
-	 * reason the acknowledgement is not received the JMS provider would notify
-	 * the application by invoking the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method.
-	 * <p>
-	 * In those cases where the JMS specification permits a lower level of
-	 * reliability, a normal synchronous send might not wait for an
-	 * acknowledgement. In that case it is expected that an asynchronous send
-	 * would be similar to a synchronous send: the JMS provider would send the
-	 * message to the remote JMS server and then return without waiting for an
-	 * acknowledgement. However the JMS provider would still notify the
-	 * application that the send had completed by invoking the
-	 * <tt>onCompletion</tt> method on the application-specified
-	 * <tt>CompletionListener</tt> object.
-	 * <p>
-	 * It is up to the JMS provider to decide exactly what is performed in the
-	 * calling thread and what, if anything, is performed asynchronously, so
-	 * long as it satisfies the requirements given below:
-	 * <p>
-	 * <b>Quality of service</b>: After the send operation has completed
-	 * successfully, which means that the message has been successfully sent
-	 * with the same degree of confidence as if a normal synchronous send had
-	 * been performed, the JMS provider must invoke the
-	 * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The
-	 * <tt>CompletionListener</tt> must not be invoked earlier than this.
-	 * <p>
-	 * <b>Exceptions</b>: If an exception is encountered during the call to the
-	 * <tt>send</tt> method then an appropriate exception should be thrown in
-	 * the thread that is calling the <tt>send</tt> method. In this case the JMS
-	 * provider must not invoke the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
-	 * encountered which cannot be thrown in the thread that is calling the
-	 * <tt>send</tt> method then the JMS provider must call the
-	 * <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases
-	 * if an exception occurs it is undefined whether or not the message was
-	 * successfully sent.
-	 * <p>
-	 * <b>Message order</b>: If the same <tt>JMSContext</tt> is used to send
-	 * multiple messages then JMS message ordering requirements must be
-	 * satisfied. This applies even if a combination of synchronous and
-	 * asynchronous sends has been performed. The application is not required to
-	 * wait for an asynchronous send to complete before sending the next
-	 * message.
-	 * <p>
-	 * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called
-	 * on the <tt>JMSContext</tt> then the JMS provider must block until any
-	 * incomplete send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before closing
-	 * the object and returning. If the session is transacted (uses a local
-	 * transaction) then when the <tt>JMSContext</tt>'s <tt>commit</tt> or
-	 * <tt>rollback</tt> method is called the JMS provider must block until any
-	 * incomplete send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before performing
-	 * the commit or rollback. Incomplete sends should be allowed to complete
-	 * normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> on its own
-	 * <tt>JMSContext</tt>. Doing so will cause the <tt>close</tt>,
-	 * <tt>commit</tt> or <tt>rollback</tt> to throw an
-	 * <tt>IllegalStateRuntimeException</tt>.
-	 * <p>
-	 * <b>Restrictions on usage in Java EE</b> This method must not be used in a
-	 * Java EE EJB or web container. Doing so may cause a {@code JMSRuntimeException} 
-	 * to be thrown though this is not guaranteed.
-	 * <p>
-	 * <b>Message headers</b> JMS defines a number of message header fields and
-	 * message properties which must be set by the "JMS provider on send". If
-	 * the send is asynchronous these fields and properties may be accessed on
-	 * the sending client only after the <tt>CompletionListener</tt> has been
-	 * invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method
-	 * is called then the state of these message header fields and properties is
-	 * undefined.
-	 * <p>
-	 * <b>Restrictions on threading</b>: Applications that perform an
-	 * asynchronous send must confirm to the threading restrictions defined in
-	 * JMS. This means that the session may be used by only one thread at a
-	 * time.
-	 * <p>
-	 * Setting a <tt>CompletionListener</tt> does not cause the session to be
-	 * dedicated to the thread of control which calls the
-	 * <tt>CompletionListener</tt>. The application thread may therefore
-	 * continue to use the session after performing an asynchronous send.
-	 * However the <tt>CompletionListener</tt>'s callback methods must not use
-	 * the session if an application thread might be using the session at the
-	 * same time.
-	 * <p>
-	 * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A
-	 * session will only invoke one <tt>CompletionListener</tt> callback method
-	 * at a time. For a given <tt>JMSContext</tt>, callbacks (both
-	 * {@code onCompletion} and {@code onException}) will be performed
-	 * in the same order as the corresponding calls to the <tt>send</tt> method.
-	 * A JMS provider must not invoke the <tt>CompletionListener</tt> from the
-	 * thread that is calling the <tt>send</tt> method.
-	 * <p>
-	 * <b>Restrictions on the use of the Message object</b>: Applications which
-	 * perform an asynchronous send must take account of the restriction that a
-	 * <tt>Message</tt> object is designed to be accessed by one logical thread
-	 * of control at a time and does not support concurrent use.
-	 * <p>
-	 * After the <tt>send</tt> method has returned, the application must not
-	 * attempt to read the headers, properties or body of the
-	 * <tt>Message</tt> object until the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method has been called.
-	 * This is because the JMS provider may be modifying the <tt>Message</tt>
-	 * object in another thread during this time. The JMS provider may throw an
-	 * <tt>JMSException</tt> if the application attempts to access or modify the
-	 * <tt>Message</tt> object after the <tt>send</tt> method has returned and
-	 * before the <tt>CompletionListener</tt> has been invoked. If the JMS
-	 * provider does not throw an exception then the behaviour is undefined.
-	 * 
-	 * @param completionListener
-	 *            If asynchronous send behaviour is required, this should be set
-	 *            to a {@code CompletionListener} to be notified when the
-	 *            send has completed. If synchronous send behaviour is required,
-	 *            this should be set to {@code null}.
-	 * @return this {@code JMSProducer}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if an internal error occurs
-	 * 
-	 * @see javax.jms.JMSProducer#getAsync
-	 * @see javax.jms.CompletionListener
-	 * 
-	 */
-	JMSProducer setAsync(CompletionListener completionListener);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code int} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code int} property value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getIntProperty
+     */
+    JMSProducer setProperty(String name, int value);
 
-	/**
-	 * If subsequent calls to {@code send} on this
-	 * {@code JMSProducer} object have been configured to be asynchronous 
-	 * then this method returns the {@code CompletionListener}
-	 * that has previously been configured.
-	 * If subsequent calls to {@code send} have been configured to be synchronous
-	 * then this method returns {@code null}.
-	 * 
-	 * @return the {@code CompletionListener} or {@code null}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the required information due
-	 *             to some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setAsync
-	 */
-	CompletionListener getAsync();
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code long} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code long} property value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getLongProperty
+     */
+    JMSProducer setProperty(String name, long value);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code boolean}
-	 * value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code boolean} value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getBooleanProperty
-	 */
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code float} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code float} property value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getFloatProperty
+     */
+    JMSProducer setProperty(String name, float value);
 
-	JMSProducer setProperty(String name, boolean value);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code double} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code double} property value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getDoubleProperty
+     */
+    JMSProducer setProperty(String name, double value);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code byte} value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code byte} value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getByteProperty
-	 */
-	JMSProducer setProperty(String name, byte value);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * {@code String} value.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the {@code String} property value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     *
+     * @see javax.jms.JMSProducer#getStringProperty
+     */
+    JMSProducer setProperty(String name, String value);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code short}
-	 * value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code short} property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getShortProperty
-	 */
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have the specified property set to the specified
+     * Java object value.
+     *
+     * <p>
+     * Note that this method works only for the objectified primitive object types ({@code Integer}, {@code Double},
+     * {@code Long} ...) and {@code String} objects.
+     *
+     * <p>
+     * This will replace any property of the same name that is already set on the message being sent.
+     *
+     * @param name the name of the property
+     * @param value the Java object property value to set
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the property due to some internal error.
+     * @throws IllegalArgumentException if the name is null or if the name is an empty string.
+     * @throws MessageFormatRuntimeException if the object is invalid
+     *
+     * @see javax.jms.JMSProducer#getObjectProperty
+     */
+    JMSProducer setProperty(String name, Object value);
 
-	JMSProducer setProperty(String name, short value);
+    /**
+     * Clears any message properties set on this {@code JMSProducer}
+     *
+     * @return this {@code JMSProducer}
+     * @throws JMSRuntimeException if the JMS provider fails to clear the message properties due to some internal error.
+     */
+    JMSProducer clearProperties();
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code int} value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code int} property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getIntProperty
-	 */
+    /**
+     * Indicates whether a message property with the specified name has been set on this {@code JMSProducer}
+     *
+     * @param name the name of the property
+     *
+     * @return true whether the property exists
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to determine whether the property exists due to some internal
+     * error.
+     */
+    boolean propertyExists(String name);
 
-	JMSProducer setProperty(String name, int value);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code boolean}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code boolean}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,boolean)
+     */
+    boolean getBooleanProperty(String name);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code long} value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code long} property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getLongProperty
-	 */
-	JMSProducer setProperty(String name, long value);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code String}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code byte}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,byte)
+     */
+    byte getByteProperty(String name);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code float}
-	 * value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code float} property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getFloatProperty
-	 */
-	JMSProducer setProperty(String name, float value);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code short}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code short}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,short)
+     */
+    short getShortProperty(String name);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code double}
-	 * value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code double} property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getDoubleProperty
-	 */
-	JMSProducer setProperty(String name, double value);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code int}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code int}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,int)
+     */
+    int getIntProperty(String name);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified {@code String}
-	 * value.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the {@code String} property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * 
-	 * @see javax.jms.JMSProducer#getStringProperty
-	 */
-	JMSProducer setProperty(String name, String value);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code long}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code long}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,long)
+     */
+    long getLongProperty(String name);
 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have the specified property set to the specified Java object value.
-	 * <p>
-	 * Note that this method works only for the objectified primitive object
-	 * types ({@code Integer}, {@code Double}, {@code Long} ...)
-	 * and {@code String} objects.
-	 * <p>
-	 * This will replace any property of the same name that is already set on
-	 * the message being sent.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * @param value
-	 *            the Java object property value to set
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the property due to some
-	 *             internal error.
-	 * @throws IllegalArgumentException
-	 *             if the name is null or if the name is an empty string.
-	 * @throws MessageFormatRuntimeException
-	 *             if the object is invalid
-	 * 
-	 * @see javax.jms.JMSProducer#getObjectProperty
-	 */
-	JMSProducer setProperty(String name, Object value);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code float}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code float}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,float)
+     */
+    float getFloatProperty(String name);
 
-	/**
-	 * Clears any message properties set on this {@code JMSProducer}
-	 * 
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to clear the message properties due
-	 *             to some internal error.
-	 */
-	JMSProducer clearProperties();
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code double}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code double}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,double)
+     */
+    double getDoubleProperty(String name);
 
-	/**
-	 * Indicates whether a message property with the specified name has been set
-	 * on this {@code JMSProducer}
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return true whether the property exists
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to determine whether the property
-	 *             exists due to some internal error.
-	 */
-	boolean propertyExists(String name);
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to a
+     * {@code String}.
+     *
+     * @param name the name of the property
+     *
+     * @return the property value, converted to a {@code boolean}; if there is no property by this name, a null value is
+     * returned
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     * @throws MessageFormatRuntimeException if this type conversion is invalid.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,String)
+     */
+    String getStringProperty(String name);
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code boolean}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code boolean}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,boolean)
-	 */
+    /**
+     * Returns the message property with the specified name that has been set on this {@code JMSProducer}, converted to
+     * objectified format.
+     *
+     * <p>
+     * This method can be used to return, in objectified format, an object that has been stored as a property in the message
+     * with the equivalent {@code setObjectProperty} method call, or its equivalent primitive
+     * <code>set<I>type</I>Property</code> method.
+     *
+     * @param name the name of the property
+     *
+     * @return the Java object property value with the specified name, in objectified format (for example, if the property
+     * was set as an {@code int}, an {@code Integer} is returned); if there is no property by this name, a null value is
+     * returned
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property value due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setProperty(java.lang.String,java.lang.Object)
+     */
+    Object getObjectProperty(String name);
 
-	boolean getBooleanProperty(String name);
+    /**
+     * Returns an unmodifiable {@code Set} view of the names of all the message properties that have been set on this
+     * JMSProducer.
+     *
+     * <p>
+     * Note that JMS standard header fields are not considered properties and are not returned in this Set.
+     *
+     * <p>
+     * The set is backed by the {@code JMSProducer}, so changes to the map are reflected in the set. However the set may not
+     * be modified. Attempts to modify the returned collection, whether directly or via its iterator, will result in an
+     * {@code java.lang.UnsupportedOperationException}. Its behaviour matches that defined in the
+     * {@code java.util.Collections} method {@code unmodifiableSet}.
+     *
+     * @return a {@code Set} containing the names of all the message properties that have been set on this
+     * {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the property names due to some internal error.
+     *
+     * @see java.util.Collections#unmodifiableSet
+     */
+    Set<String> getPropertyNames();
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code String}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code byte}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,byte)
-	 */
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have their {@code JMSCorrelationID} header value set
+     * to the specified correlation ID, where correlation ID is specified as an array of bytes.
+     *
+     * <p>
+     * This will override any {@code JMSCorrelationID} header value that is already set on the message being sent.
+     *
+     * <p>
+     * The array is copied before the method returns, so future modifications to the array will not alter the value in this
+     * {@code JMSProducer}.
+     *
+     * <p>
+     * If a provider supports the native concept of correlation ID, a JMS client may need to assign specific
+     * {@code JMSCorrelationID} values to match those expected by native messaging clients. JMS providers without native
+     * correlation ID values are not required to support this method and its corresponding get method; their implementation
+     * may throw a {@code java.lang.UnsupportedOperationException}.
+     *
+     * <p>
+     * The use of a {@code byte[]} value for {@code JMSCorrelationID} is non-portable.
+     *
+     * @param correlationID the correlation ID value as an array of bytes
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the correlation ID due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setJMSCorrelationID(String)
+     * @see javax.jms.JMSProducer#getJMSCorrelationID()
+     * @see javax.jms.JMSProducer#getJMSCorrelationIDAsBytes()
+     */
+    JMSProducer setJMSCorrelationIDAsBytes(byte[] correlationID);
 
-	byte getByteProperty(String name);
+    /**
+     * Returns the {@code JMSCorrelationID} header value that has been set on this {@code JMSProducer}, as an array of
+     * bytes.
+     *
+     * <p>
+     * The use of a {@code byte[]} value for {@code JMSCorrelationID} is non-portable.
+     *
+     * @return the correlation ID as an array of bytes
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the correlation ID due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setJMSCorrelationID(String)
+     * @see javax.jms.JMSProducer#getJMSCorrelationID()
+     * @see javax.jms.JMSProducer#setJMSCorrelationIDAsBytes(byte[])
+     */
+    byte[] getJMSCorrelationIDAsBytes();
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code short}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code short}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,short)
-	 */
-	short getShortProperty(String name);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have their {@code JMSCorrelationID} header value set
+     * to the specified correlation ID, where correlation ID is specified as a {@code String}.
+     *
+     * <p>
+     * This will override any {@code JMSCorrelationID} header value that is already set on the message being sent.
+     *
+     * <p>
+     * A client can use the {@code JMSCorrelationID} header field to link one message with another. A typical use is to link
+     * a response message with its request message.
+     *
+     * <p>
+     * {@code JMSCorrelationID} can hold one of the following:
+     * <ul>
+     * <li>A provider-specific message ID
+     * <li>An application-specific {@code String}
+     * <li>A provider-native {@code byte[]} value
+     * </ul>
+     *
+     * <p>
+     * Since each message sent by a JMS provider is assigned a message ID value, it is convenient to link messages via
+     * message ID. All message ID values must start with the {@code 'ID:'} prefix.
+     *
+     * <p>
+     * In some cases, an application (made up of several clients) needs to use an application-specific value for linking
+     * messages. For instance, an application may use {@code JMSCorrelationID} to hold a value referencing some external
+     * information. Application-specified values must not start with the {@code 'ID:'} prefix; this is reserved for
+     * provider-generated message ID values.
+     *
+     * <p>
+     * If a provider supports the native concept of correlation ID, a JMS client may need to assign specific
+     * {@code JMSCorrelationID} values to match those expected by clients that do not use the JMS API. A {@code byte[]}
+     * value is used for this purpose. JMS providers without native correlation ID values are not required to support
+     * {@code byte[]} values. The use of a {@code byte[]} value for {@code JMSCorrelationID} is non-portable.
+     *
+     * @param correlationID the message ID of a message being referred to
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the correlation ID due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getJMSCorrelationID()
+     * @see javax.jms.JMSProducer#getJMSCorrelationIDAsBytes()
+     * @see javax.jms.JMSProducer#setJMSCorrelationIDAsBytes(byte[])
+     */
+    JMSProducer setJMSCorrelationID(String correlationID);
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code int}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code int}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,int)
-	 */
-	int getIntProperty(String name);
+    /**
+     * Returns the {@code JMSCorrelationID} header value that has been set on this {@code JMSProducer}, as a {@code String}.
+     *
+     * <p>
+     * This method is used to return correlation ID values that are either provider-specific message IDs or
+     * application-specific {@code String} values.
+     *
+     * @return the correlation ID of a message as a {@code String}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the correlation ID due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setJMSCorrelationID(String)
+     * @see javax.jms.JMSProducer#getJMSCorrelationIDAsBytes()
+     * @see javax.jms.JMSProducer#setJMSCorrelationIDAsBytes(byte[])
+     */
+    String getJMSCorrelationID();
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code long}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code long}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,long)
-	 */
-	long getLongProperty(String name);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have their {@code JMSType} header value set to the
+     * specified message type.
+     *
+     * <p>
+     * This will override any {@code JMSType} header value that is already set on the message being sent.
+     *
+     * <p>
+     * Some JMS providers use a message repository that contains the definitions of messages sent by applications. The
+     * {@code JMSType} header field may reference a message's definition in the provider's repository.
+     *
+     * <p>
+     * The JMS API does not define a standard message definition repository, nor does it define a naming policy for the
+     * definitions it contains.
+     *
+     * <p>
+     * Some messaging systems require that a message type definition for each application message be created and that each
+     * message specify its type. In order to work with such JMS providers, JMS clients should assign a value to
+     * {@code JMSType}, whether the application makes use of it or not. This ensures that the field is properly set for
+     * those providers that require it.
+     *
+     * <p>
+     * To ensure portability, JMS clients should use symbolic values for {@code JMSType} that can be configured at
+     * installation time to the values defined in the current provider's message repository. If string literals are used,
+     * they may not be valid type names for some JMS providers.
+     *
+     * @param type the message type
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the message type due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#getJMSType()
+     */
+    JMSProducer setJMSType(String type);
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code float}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code float}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,float)
-	 */
-	float getFloatProperty(String name);
+    /**
+     * Returns the {@code JMSType} header value that has been set on this {@code JMSProducer}.
+     *
+     * @return the message type
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the message type due to some internal error.
+     *
+     * @see javax.jms.JMSProducer#setJMSType(String)
+     */
+    String getJMSType();
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code double}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code double}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,double)
-	 */
-	double getDoubleProperty(String name);
+    /**
+     * Specifies that messages sent using this {@code JMSProducer} will have their {@code JMSReplyTo} header value set to
+     * the specified {@code Destination} object.
+     *
+     * <p>
+     * This will override any {@code JMSReplyTo} header value that is already set on the message being sent.
+     *
+     * <p>
+     * The {@code JMSReplyTo} header field contains the destination where a reply to the current message should be sent. If
+     * it is null, no reply is expected. The destination may be either a {@code Queue} object or a {@code Topic} object.
+     *
+     * <p>
+     * Messages sent with a null {@code JMSReplyTo} value may be a notification of some event, or they may just be some data
+     * the sender thinks is of interest.
+     *
+     * <p>
+     * Messages with a {@code JMSReplyTo} value typically expect a response. A response is optional; it is up to the client
+     * to decide. These messages are called requests. A message sent in response to a request is called a reply.
+     *
+     * <p>
+     * In some cases a client may wish to match a request it sent earlier with a reply it has just received. The client can
+     * use the {@code JMSCorrelationID} header field for this purpose.
+     *
+     * @param replyTo {@code Destination} to which to send a response to this message
+     *
+     * @return this {@code JMSProducer}
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to set the {@code JMSReplyTo} destination due to some internal
+     * error.
+     *
+     * @see javax.jms.JMSProducer#getJMSReplyTo()
+     */
+    JMSProducer setJMSReplyTo(Destination replyTo);
 
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to a {@code String}.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the property value, converted to a {@code boolean}; if there
-	 *         is no property by this name, a null value is returned
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * @throws MessageFormatRuntimeException
-	 *             if this type conversion is invalid.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,String)
-	 */
-	String getStringProperty(String name);
-
-	/**
-	 * Returns the message property with the specified name that has been set on
-	 * this {@code JMSProducer}, converted to objectified format.
-	 * <p>
-	 * This method can be used to return, in objectified format, an object that
-	 * has been stored as a property in the message with the equivalent
-	 * {@code setObjectProperty} method call, or its equivalent primitive
-	 * <code>set<I>type</I>Property</code> method.
-	 * 
-	 * @param name
-	 *            the name of the property
-	 * 
-	 * @return the Java object property value with the specified name, in
-	 *         objectified format (for example, if the property was set as an
-	 *         {@code int}, an {@code Integer} is returned); if there
-	 *         is no property by this name, a null value is returned
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property value due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setProperty(java.lang.String,java.lang.Object)
-	 */
-	Object getObjectProperty(String name);
-
-	/**
-	 * Returns an unmodifiable {@code Set} view of the names of all the message
-	 * properties that have been set on this JMSProducer.
-	 * <p>
-	 * Note that JMS standard header fields are not considered properties and
-	 * are not returned in this Set.
-	 * <p>
-	 * The set is backed by the {@code JMSProducer}, so changes to the map are
-	 * reflected in the set. However the set may not be modified. Attempts to
-	 * modify the returned collection, whether directly or via its iterator,
-	 * will result in an {@code java.lang.UnsupportedOperationException}. Its behaviour matches
-	 * that defined in the {@code java.util.Collections} method
-	 * {@code unmodifiableSet}.
-	 * 
-	 * @return a {@code Set} containing the names of all the message properties
-	 *         that have been set on this {@code JMSProducer}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the property names due to
-	 *             some internal error.
-	 * 
-	 * @see java.util.Collections#unmodifiableSet
-	 */
-	Set<String> getPropertyNames();
- 
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have their {@code JMSCorrelationID} header value set to the
-	 * specified correlation ID, where correlation ID is specified as an array
-	 * of bytes.
-	 * <p>
-	 * This will override any {@code JMSCorrelationID} header value that is
-	 * already set on the message being sent.
-	 * <p>
-	 * The array is copied before the method returns, so future modifications to
-	 * the array will not alter the value in this {@code JMSProducer}.
-	 * <p>
-	 * If a provider supports the native concept of correlation ID, a JMS client
-	 * may need to assign specific {@code JMSCorrelationID} values to match
-	 * those expected by native messaging clients. JMS providers without native
-	 * correlation ID values are not required to support this method and its
-	 * corresponding get method; their implementation may throw a
-	 * {@code java.lang.UnsupportedOperationException}.
-	 * <p>
-	 * The use of a {@code byte[]} value for {@code JMSCorrelationID}
-	 * is non-portable.
-	 * 
-	 * @param correlationID
-	 *            the correlation ID value as an array of bytes
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the correlation ID due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setJMSCorrelationID(String)
-	 * @see javax.jms.JMSProducer#getJMSCorrelationID()
-	 * @see javax.jms.JMSProducer#getJMSCorrelationIDAsBytes()
-	 */
-	JMSProducer setJMSCorrelationIDAsBytes(byte[] correlationID);
-
-	/**
-	 * Returns the {@code JMSCorrelationID} header value that has been set
-	 * on this {@code JMSProducer}, as an array of bytes.
-	 * <p>
-	 * The use of a {@code byte[]} value for {@code JMSCorrelationID}
-	 * is non-portable.
-	 * 
-	 * @return the correlation ID as an array of bytes
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the correlation ID due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setJMSCorrelationID(String)
-	 * @see javax.jms.JMSProducer#getJMSCorrelationID()
-	 * @see javax.jms.JMSProducer#setJMSCorrelationIDAsBytes(byte[])
-	 */
-
-	byte[] getJMSCorrelationIDAsBytes();
-
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have their {@code JMSCorrelationID} header value set to the
-	 * specified correlation ID, where correlation ID is specified as a
-	 * {@code String}.
-	 * <p>
-	 * This will override any {@code JMSCorrelationID} header value that is
-	 * already set on the message being sent.
-	 * <p>
-	 * A client can use the {@code JMSCorrelationID} header field to link
-	 * one message with another. A typical use is to link a response message
-	 * with its request message.
-	 * <p>
-	 * {@code JMSCorrelationID} can hold one of the following:
-	 * <UL>
-	 * <LI>A provider-specific message ID
-	 * <LI>An application-specific {@code String}
-	 * <LI>A provider-native {@code byte[]} value
-	 * </UL>
-	 * <p>
-	 * Since each message sent by a JMS provider is assigned a message ID value,
-	 * it is convenient to link messages via message ID. All message ID values
-	 * must start with the {@code 'ID:'} prefix.
-	 * <p>
-	 * In some cases, an application (made up of several clients) needs to use
-	 * an application-specific value for linking messages. For instance, an
-	 * application may use {@code JMSCorrelationID} to hold a value
-	 * referencing some external information. Application-specified values must
-	 * not start with the {@code 'ID:'} prefix; this is reserved for
-	 * provider-generated message ID values.
-	 * <p>
-	 * If a provider supports the native concept of correlation ID, a JMS client
-	 * may need to assign specific {@code JMSCorrelationID} values to match
-	 * those expected by clients that do not use the JMS API. A
-	 * {@code byte[]} value is used for this purpose. JMS providers without
-	 * native correlation ID values are not required to support
-	 * {@code byte[]} values. The use of a {@code byte[]} value for
-	 * {@code JMSCorrelationID} is non-portable.
-	 * 
-	 * @param correlationID
-	 *            the message ID of a message being referred to
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the correlation ID due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getJMSCorrelationID()
-	 * @see javax.jms.JMSProducer#getJMSCorrelationIDAsBytes()
-	 * @see javax.jms.JMSProducer#setJMSCorrelationIDAsBytes(byte[])
-	 */
-	JMSProducer setJMSCorrelationID(String correlationID);
-
-	/**
-	 * Returns the {@code JMSCorrelationID} header value that has been set
-	 * on this {@code JMSProducer}, as a {@code String}.
-	 * <p>
-	 * This method is used to return correlation ID values that are either
-	 * provider-specific message IDs or application-specific {@code String}
-	 * values.
-	 * 
-	 * @return the correlation ID of a message as a {@code String}
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the correlation ID due to
-	 *             some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setJMSCorrelationID(String)
-	 * @see javax.jms.JMSProducer#getJMSCorrelationIDAsBytes()
-	 * @see javax.jms.JMSProducer#setJMSCorrelationIDAsBytes(byte[])
-	 */
-	String getJMSCorrelationID();
-
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have their {@code JMSType} header value set to the specified message
-	 * type.
-	 * <p>
-	 * This will override any {@code JMSType} header value that is already
-	 * set on the message being sent.
-	 * <p>
-	 * Some JMS providers use a message repository that contains the definitions
-	 * of messages sent by applications. The {@code JMSType} header field
-	 * may reference a message's definition in the provider's repository.
-	 * <p>
-	 * The JMS API does not define a standard message definition repository, nor
-	 * does it define a naming policy for the definitions it contains.
-	 * <p>
-	 * Some messaging systems require that a message type definition for each
-	 * application message be created and that each message specify its type. In
-	 * order to work with such JMS providers, JMS clients should assign a value
-	 * to {@code JMSType}, whether the application makes use of it or not.
-	 * This ensures that the field is properly set for those providers that
-	 * require it.
-	 * <p>
-	 * To ensure portability, JMS clients should use symbolic values for
-	 * {@code JMSType} that can be configured at installation time to the
-	 * values defined in the current provider's message repository. If string
-	 * literals are used, they may not be valid type names for some JMS
-	 * providers.
-	 * 
-	 * @param type
-	 *            the message type
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the message type due to some
-	 *             internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getJMSType()
-	 */
-	JMSProducer setJMSType(String type);
-
-	/**
-	 * Returns the {@code JMSType} header value that has been set on this
-	 * {@code JMSProducer}.
-	 * 
-	 * @return the message type
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the message type due to some
-	 *             internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setJMSType(String)
-	 */
-	String getJMSType();
-
-	/**
-	 * Specifies that messages sent using this {@code JMSProducer} will
-	 * have their {@code JMSReplyTo} header value set to the specified
-	 * {@code Destination} object.
-	 * <p>
-	 * This will override any {@code JMSReplyTo} header value that is
-	 * already set on the message being sent.
-	 * <p>
-	 * The {@code JMSReplyTo} header field contains the destination where a
-	 * reply to the current message should be sent. If it is null, no reply is
-	 * expected. The destination may be either a {@code Queue} object or a
-	 * {@code Topic} object.
-	 * <p>
-	 * Messages sent with a null {@code JMSReplyTo} value may be a
-	 * notification of some event, or they may just be some data the sender
-	 * thinks is of interest.
-	 * <p>
-	 * Messages with a {@code JMSReplyTo} value typically expect a
-	 * response. A response is optional; it is up to the client to decide. These
-	 * messages are called requests. A message sent in response to a request is
-	 * called a reply.
-	 * <p>
-	 * In some cases a client may wish to match a request it sent earlier with a
-	 * reply it has just received. The client can use the
-	 * {@code JMSCorrelationID} header field for this purpose.
-	 * 
-	 * @param replyTo
-	 *            {@code Destination} to which to send a response to this
-	 *            message
-	 * @return this {@code JMSProducer}
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to set the {@code JMSReplyTo}
-	 *             destination due to some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#getJMSReplyTo()
-	 */
-	JMSProducer setJMSReplyTo(Destination replyTo);
-
-	/**
-	 * Returns the {@code JMSReplyTo} header value that has been set on
-	 * this {@code JMSProducer}.
-	 * <p>
-	 * 
-	 * @return {@code Destination} the {@code JMSReplyTo} header value
-	 * 
-	 * @throws JMSRuntimeException
-	 *             if the JMS provider fails to get the {@code JMSReplyTo}
-	 *             destination due to some internal error.
-	 * 
-	 * @see javax.jms.JMSProducer#setJMSReplyTo(Destination)
-	 */
-	Destination getJMSReplyTo();
+    /**
+     * Returns the {@code JMSReplyTo} header value that has been set on this {@code JMSProducer}.
+     *
+     * @return {@code Destination} the {@code JMSReplyTo} header value
+     *
+     * @throws JMSRuntimeException if the JMS provider fails to get the {@code JMSReplyTo} destination due to some internal
+     * error.
+     *
+     * @see javax.jms.JMSProducer#setJMSReplyTo(Destination)
+     */
+    Destination getJMSReplyTo();
 
 }

--- a/src/main/java/javax/jms/JMSRuntimeException.java
+++ b/src/main/java/javax/jms/JMSRuntimeException.java
@@ -18,74 +18,65 @@ package javax.jms;
 
 /**
  * This is the root class of all unchecked exceptions in the JMS API.
+ *
  * <p>
- * In additional to the detailMessage and cause fields inherited from
- * {@code Throwable}, this class also allows a provider-specific errorCode
- * to be set.
- * 
+ * In additional to the detailMessage and cause fields inherited from {@code Throwable}, this class also allows a
+ * provider-specific errorCode to be set.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
-
 public class JMSRuntimeException extends RuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -5204332229969809982L;
 
-	/**
-	 * Provider-specific error code.
-	 **/
-	private String errorCode=null;
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -5204332229969809982L;
 
-	/**
-	 * Constructs a {@code JMSRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public JMSRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage);
-		this.errorCode = errorCode;
-	}
+    /**
+     * Provider-specific error code.
+     **/
+    private String errorCode = null;
 
-	/**
-	 * Constructs a {@code JMSRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public JMSRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
+    /**
+     * Constructs a {@code JMSRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public JMSRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage);
+        this.errorCode = errorCode;
+    }
 
-	/**
-	 * Constructs a {@code JMSRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public JMSRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage, cause);
-		this.errorCode = errorCode;
-	}
+    /**
+     * Constructs a {@code JMSRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public JMSRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
 
-	/**
-	 * Returns the vendor-specific error code.
-	 * 
-	 * @return the provider-specific error code
-	 **/
-	public String getErrorCode() {
-		return this.errorCode;
-	}
+    /**
+     * Constructs a {@code JMSRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public JMSRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, cause);
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Returns the vendor-specific error code.
+     *
+     * @return the provider-specific error code
+     **/
+    public String getErrorCode() {
+        return this.errorCode;
+    }
 }

--- a/src/main/java/javax/jms/JMSSecurityException.java
+++ b/src/main/java/javax/jms/JMSSecurityException.java
@@ -17,43 +17,38 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a provider rejects a user 
- *     name/password submitted by a client. It may also be thrown for any case 
- *     where a security restriction prevents a method from completing.
- * 
+ * This exception must be thrown when a provider rejects a user name/password submitted by a client. It may also be
+ * thrown for any case where a security restriction prevents a method from completing.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class JMSSecurityException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -7512859695190450217L;
 
-  /** Constructs a {@code JMSSecurityException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  JMSSecurityException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -7512859695190450217L;
 
-  /** Constructs a {@code JMSSecurityException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  JMSSecurityException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code JMSSecurityException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public JMSSecurityException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code JMSSecurityException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public JMSSecurityException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/JMSSecurityRuntimeException.java
+++ b/src/main/java/javax/jms/JMSSecurityRuntimeException.java
@@ -17,60 +17,49 @@
 package javax.jms;
 
 /**
- * This unchecked exception must be thrown when a provider rejects a user
- * name/password submitted by a client, or for any case where a security
- * restriction prevents a method from completing, and the method signature does
- * not permit a {@code JMSSecurityException} to be thrown.
- * 
+ * This unchecked exception must be thrown when a provider rejects a user name/password submitted by a client, or for
+ * any case where a security restriction prevents a method from completing, and the method signature does not permit a
+ * {@code JMSSecurityException} to be thrown.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
-
 public class JMSSecurityRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 1020149469192845616L;
-	
-	/**
-	 * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public JMSSecurityRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
 
-	/**
-	 * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public JMSSecurityRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage,errorCode);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 1020149469192845616L;
 
+    /**
+     * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public JMSSecurityRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
 
-	/**
-	 * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public JMSSecurityRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage,errorCode,cause);
-	}
-  
+    /**
+     * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public JMSSecurityRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code JMSSecurityRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public JMSSecurityRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
+
 }

--- a/src/main/java/javax/jms/JMSSessionMode.java
+++ b/src/main/java/javax/jms/JMSSessionMode.java
@@ -21,26 +21,29 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static javax.jms.JMSContext.AUTO_ACKNOWLEDGE;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation may be used to specify the session mode
- * to be used when injecting a {@code javax.jms.JMSContext} object.
- * The meaning and possible values of session mode are the same as for the 
- * {@code ConnectionFactory} method {@code createContext(int sessionMode)}.
- * 
+ * This annotation may be used to specify the session mode to be used when injecting a {@code javax.jms.JMSContext}
+ * object. The meaning and possible values of session mode are the same as for the {@code ConnectionFactory} method
+ * {@code createContext(int sessionMode)}.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
- * @see javax.jms.JMSContext#createContext(int) 
+ *
+ * @see javax.jms.JMSContext#createContext(int)
  */
 @Retention(RUNTIME)
-@Target({METHOD, FIELD, PARAMETER, TYPE})
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
 public @interface JMSSessionMode {
+
     /**
      * Specifies the session mode used when injecting a {@code javax.jms.JMSContext} object.
+     *
+     * @return The session mode used when injecting a {@code javax.jms.JMSContext} object.
      */
-    int value() default JMSContext.AUTO_ACKNOWLEDGE;
+    int value() default AUTO_ACKNOWLEDGE;
 }

--- a/src/main/java/javax/jms/ListenerProperties.java
+++ b/src/main/java/javax/jms/ListenerProperties.java
@@ -24,20 +24,19 @@ import java.lang.annotation.Target;
 
 /**
  * Containing annotation for annotations of type {@code ListenerProperty}.
+ *
  * <p>
- * This annotation is used internally when a method or class is annotated with
- * more than one {@code ListenerProperty} annotation. Applications do not need
- * to use this annotation directly.
- * 
- * @see ListenerProperty <p>
+ * This annotation is used internally when a method or class is annotated with more than one {@code ListenerProperty}
+ * annotation. Applications do not need to use this annotation directly.
+ *
+ * @see ListenerProperty
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
-@Target({ METHOD })
+@Target(METHOD)
 @Retention(RUNTIME)
 public @interface ListenerProperties {
 
-	ListenerProperty[] value();
+    ListenerProperty[] value();
 
 }

--- a/src/main/java/javax/jms/ListenerProperty.java
+++ b/src/main/java/javax/jms/ListenerProperty.java
@@ -24,44 +24,46 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies an arbitrary activation property to be used by a
- * callback method on a JMS message-driven bean must use the specified message
- * selector. It may be specified either on the callback method or on the
+ * This annotation specifies an arbitrary activation property to be used by a callback method on a JMS message-driven
+ * bean must use the specified message selector. It may be specified either on the callback method or on the
  * message-driven bean class.
+ *
  * <p>
- * If this annotation is specified on a method of a message-driven bean class
- * then that method must also be annotated with {@code QueueListener} or
- * {@code TopicListener}. If it is not then deployment will fail.
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
  * <p>
- * If this annotation is specified on the message-driven bean class then at
- * least one method must be annotated with {@code QueueListener} or
- * {@code TopicListener}. If no method is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
  * <p>
- * If this annotation is used to specify the same property on both a method of a
- * message-driven bean class and on the message-driven bean class itself then
- * deployment will fail.
+ * If this annotation is used to specify the same property on both a method of a message-driven bean class and on the
+ * message-driven bean class itself then deployment will fail.
+ *
  * <p>
- * Multiple {@code JMSListenerProperty} annotations may be used to set multiple
- * properties on the same callback method.
- * 
+ * Multiple {@code JMSListenerProperty} annotations may be used to set multiple properties on the same callback method.
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
 @Repeatable(ListenerProperties.class)
 @Retention(RUNTIME)
-@Target({ METHOD })
+@Target(METHOD)
 public @interface ListenerProperty {
 
-	/**
-	 * Name of the activation property
-	 */
-	String name();
+    /**
+     * Name of the activation property
+     *
+     * @return The name of the activation property
+     */
+    String name();
 
-	/**
-	 * Value of the activation property
-	 */
-	String value();
+    /**
+     * Value of the activation property
+     *
+     * @return The value of the activation property
+     */
+    String value();
 
 }

--- a/src/main/java/javax/jms/MapMessage.java
+++ b/src/main/java/javax/jms/MapMessage.java
@@ -18,504 +18,377 @@ package javax.jms;
 
 import java.util.Enumeration;
 
-/** A {@code MapMessage} object is used to send a set of name-value pairs.
-  * The names are {@code String} objects, and the values are primitive 
-  * data types in the Java programming language. The names must have a value that
-  * is not null, and not an empty string. The entries can be accessed 
-  * sequentially or randomly by name. The order of the entries is undefined. 
-  * {@code MapMessage} inherits from the {@code Message} interface
-  * and adds a message body that contains a Map.
-  *
-  * <P>The primitive types can be read or written explicitly using methods
-  * for each type. They may also be read or written generically as objects.
-  * For instance, a call to {@code MapMessage.setInt("foo", 6)} is 
-  * equivalent to {@code MapMessage.setObject("foo", new Integer(6))}.
-  * Both forms are provided, because the explicit form is convenient for
-  * static programming, and the object form is needed when types are not known
-  * at compile time.
-  *
-  * <P>When a client receives a {@code MapMessage}, it is in read-only 
-  * mode. If a client attempts to write to the message at this point, a 
-  * {@code MessageNotWriteableException} is thrown. If 
-  * {@code clearBody} is called, the message can now be both read from and 
-  * written to.
-  *
-  * <P>{@code MapMessage} objects support the following conversion table. 
-  * The marked cases must be supported. The unmarked cases must throw a 
-  * {@code JMSException}. The {@code String}-to-primitive conversions 
-  * may throw a runtime exception if the primitive's {@code valueOf()} 
-  * method does not accept it as a valid {@code String} representation of 
-  * the primitive.
-  *
-  * <P>A value written as the row type can be read as the column type.
-  *
-  * <PRE>
-  * |        | boolean byte short char int long float double String byte[]
-  * |----------------------------------------------------------------------
-  * |boolean |    X                                            X
-  * |byte    |          X     X         X   X                  X
-  * |short   |                X         X   X                  X
-  * |char    |                     X                           X
-  * |int     |                          X   X                  X
-  * |long    |                              X                  X
-  * |float   |                                    X     X      X
-  * |double  |                                          X      X
-  * |String  |    X     X     X         X   X     X     X      X
-  * |byte[]  |                                                        X
-  * |----------------------------------------------------------------------
-  * </PRE>
-  *
-  * <P>Attempting to read a null value as a primitive type must be treated
-  * as calling the primitive's corresponding {@code valueOf(String)} 
-  * conversion method with a null value. Since {@code char} does not 
-  * support a {@code String} conversion, attempting to read a null value 
-  * as a {@code char} must throw a {@code NullPointerException}.
-  *
-  * @see         javax.jms.Session#createMapMessage()
-  * @see         javax.jms.BytesMessage
-  * @see         javax.jms.Message
-  * @see         javax.jms.ObjectMessage
-  * @see         javax.jms.StreamMessage
-  * @see         javax.jms.TextMessage
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
- 
-public interface MapMessage extends Message { 
-
-
-    /** Returns the {@code boolean} value with the specified name.
-      *
-      * @param name the name of the {@code boolean}
-      *
-      * @return the {@code boolean} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */
-
-    boolean 
-    getBoolean(String name) throws JMSException;
-
-
-    /** Returns the {@code byte} value with the specified name.
-      *
-      * @param name the name of the {@code byte}
-      *
-      * @return the {@code byte} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */ 
-
-    byte 
-    getByte(String name) throws JMSException;
-
-
-    /** Returns the {@code short} value with the specified name.
-      *
-      * @param name the name of the {@code short}
-      *
-      * @return the {@code short} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */ 
-
-    short 
-    getShort(String name) throws JMSException;
-
-
-    /** Returns the Unicode character value with the specified name.
-      *
-      * @param name the name of the Unicode character
-      *
-      * @return the Unicode character value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.     
-      */ 
-
-    char 
-    getChar(String name) throws JMSException;
-
-
-    /** Returns the {@code int} value with the specified name.
-      *
-      * @param name the name of the {@code int}
-      *
-      * @return the {@code int} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */ 
-
-    int 
-    getInt(String name) throws JMSException;
-
-
-    /** Returns the {@code long} value with the specified name.
-      *
-      * @param name the name of the {@code long}
-      *
-      * @return the {@code long} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */ 
-
-    long 
-    getLong(String name) throws JMSException;
-
-
-    /** Returns the {@code float} value with the specified name.
-      *
-      * @param name the name of the {@code float}
-      *
-      * @return the {@code float} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.     
-      */ 
-
-    float 
-    getFloat(String name) throws JMSException;
-
-
-    /** Returns the {@code double} value with the specified name.
-      *
-      * @param name the name of the {@code double}
-      *
-      * @return the {@code double} value with the specified name
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */ 
-
-    double 
-    getDouble(String name) throws JMSException;
-
-
-    /** Returns the {@code String} value with the specified name.
-      *
-      * @param name the name of the {@code String}
-      *
-      * @return the {@code String} value with the specified name; if there 
-      * is no item by this name, a null value is returned
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */ 
-
-    String 
-    getString(String name) throws JMSException;
-
-
-    /** Returns the byte array value with the specified name.
-      *
-      * @param name the name of the byte array
-      *
-      * @return a copy of the byte array value with the specified name; if there
-      * is no
-      * item by this name, a null value is returned.
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.      
-      */ 
-
-    byte[] 
-    getBytes(String name) throws JMSException;
-
-
-    /** Returns the value of the object with the specified name.
-      *
-      * <P>This method can be used to return, in objectified format,
-      * an object in the Java programming language ("Java object") that had 
-      * been stored in the Map with the equivalent
-      * {@code setObject} method call, or its equivalent primitive
-      * <code>set<I>type</I></code> method.
-      *
-      * <P>Note that byte values are returned as {@code byte[]}, not 
-      * {@code Byte[]}.
-      *
-      * @param name the name of the Java object
-      *
-      * @return a copy of the Java object value with the specified name, in 
-      * objectified format (for example, if the object was set as an 
-      * {@code int}, an {@code Integer} is returned); if there is no 
-      * item by this name, a null value is returned
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      */ 
-
-    Object 
-    getObject(String name) throws JMSException;
-
-
-
-    /** Returns an {@code Enumeration} of all the names in the 
-      * {@code MapMessage} object.
-      *
-      * @return an enumeration of all the names in this {@code MapMessage}
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      */
-
-    Enumeration
-    getMapNames() throws JMSException;
-
-
-    /** Sets a {@code boolean} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code boolean}
-      * @param value the {@code boolean} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */
-
-    void 
-    setBoolean(String name, boolean value) throws JMSException;
-
-
-    /** Sets a {@code byte} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code byte}
-      * @param value the {@code byte} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-     * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setByte(String name, byte value) 
-			throws JMSException;
-
-
-    /** Sets a {@code short} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code short}
-      * @param value the {@code short} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-       * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setShort(String name, short value) 
-			throws JMSException;
-
-
-    /** Sets a Unicode character value with the specified name into the Map.
-      *
-      * @param name the name of the Unicode character
-      * @param value the Unicode character value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-       * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setChar(String name, char value) 
-			throws JMSException;
-
-
-    /** Sets an {@code int} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code int}
-      * @param value the {@code int} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setInt(String name, int value) 
-			throws JMSException;
-
-
-    /** Sets a {@code long} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code long}
-      * @param value the {@code long} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setLong(String name, long value) 
-			throws JMSException;
-
-
-    /** Sets a {@code float} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code float}
-      * @param value the {@code float} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-       * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setFloat(String name, float value) 
-			throws JMSException;
-
-
-    /** Sets a {@code double} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code double}
-      * @param value the {@code double} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setDouble(String name, double value) 
-			throws JMSException;
-
-
-    /** Sets a {@code String} value with the specified name into the Map.
-      *
-      * @param name the name of the {@code String}
-      * @param value the {@code String} value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setString(String name, String value) 
-			throws JMSException;
-
-
-    /** Sets a byte array value with the specified name into the Map.
-      *
-      * @param name the name of the byte array
-      * @param value the byte array value to set in the Map; the array
-      *              is copied so that the value for {@code name} will
-      *              not be altered by future modifications
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null, or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void
-    setBytes(String name, byte[] value) 
-			throws JMSException;
-
-
-    /** Sets a portion of the byte array value with the specified name into the 
-      * Map.
-      *  
-      * @param name the name of the byte array
-      * @param value the byte array value to set in the Map
-      * @param offset the initial offset within the byte array
-      * @param length the number of bytes to use
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-       * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
- 
-    void
-    setBytes(String name, byte[] value, 
-		 int offset, int length) 
-			throws JMSException;
-
-
-    /** Sets an object value with the specified name into the Map.
-      *
-      * <P>This method works only for the objectified primitive
-      * object types ({@code Integer}, {@code Double}, 
-      * {@code Long}&nbsp;...), {@code String} objects, and byte 
-      * arrays.
-      *
-      * @param name the name of the Java object
-      * @param value the Java object value to set in the Map
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageFormatException if the object is invalid.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    setObject(String name, Object value) 
-			throws JMSException;
-
-
-    /** Indicates whether an item exists in this {@code MapMessage} object.
-      *
-      * @param name the name of the item to test
-      *
-      * @return true if the item exists
-      *
-      * @exception JMSException if the JMS provider fails to determine if the 
-      *                         item exists due to some internal error.
-      */ 
- 
-    boolean
-    itemExists(String name) throws JMSException;
+/**
+ * A {@code MapMessage} object is used to send a set of name-value pairs. The names are {@code String} objects, and the
+ * values are primitive data types in the Java programming language. The names must have a value that is not null, and
+ * not an empty string. The entries can be accessed sequentially or randomly by name. The order of the entries is
+ * undefined. {@code MapMessage} inherits from the {@code Message} interface and adds a message body that contains a
+ * Map.
+ *
+ * <p>
+ * The primitive types can be read or written explicitly using methods for each type. They may also be read or written
+ * generically as objects. For instance, a call to {@code MapMessage.setInt("foo", 6)} is equivalent to
+ * {@code MapMessage.setObject("foo", new Integer(6))}. Both forms are provided, because the explicit form is convenient
+ * for static programming, and the object form is needed when types are not known at compile time.
+ *
+ * <p>
+ * When a client receives a {@code MapMessage}, it is in read-only mode. If a client attempts to write to the message at
+ * this point, a {@code MessageNotWriteableException} is thrown. If {@code clearBody} is called, the message can now be
+ * both read from and written to.
+ *
+ * <p>
+ * {@code MapMessage} objects support the following conversion table. The marked cases must be supported. The unmarked
+ * cases must throw a {@code JMSException}. The {@code String}-to-primitive conversions may throw a runtime exception if
+ * the primitive's {@code valueOf()} method does not accept it as a valid {@code String} representation of the
+ * primitive.
+ *
+ * <p>
+ * A value written as the row type can be read as the column type.
+ *
+ * <pre>
+ * |        | boolean byte short char int long float double String byte[]
+ * |----------------------------------------------------------------------
+ * |boolean |    X                                            X
+ * |byte    |          X     X         X   X                  X
+ * |short   |                X         X   X                  X
+ * |char    |                     X                           X
+ * |int     |                          X   X                  X
+ * |long    |                              X                  X
+ * |float   |                                    X     X      X
+ * |double  |                                          X      X
+ * |String  |    X     X     X         X   X     X     X      X
+ * |byte[]  |                                                        X
+ * |----------------------------------------------------------------------
+ * </pre>
+ *
+ * <p>
+ * Attempting to read a null value as a primitive type must be treated as calling the primitive's corresponding
+ * {@code valueOf(String)} conversion method with a null value. Since {@code char} does not support a {@code String}
+ * conversion, attempting to read a null value as a {@code char} must throw a {@code NullPointerException}.
+ *
+ * @see javax.jms.Session#createMapMessage()
+ * @see javax.jms.BytesMessage
+ * @see javax.jms.Message
+ * @see javax.jms.ObjectMessage
+ * @see javax.jms.StreamMessage
+ * @see javax.jms.TextMessage
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
+public interface MapMessage extends Message {
+
+    /**
+     * Returns the {@code boolean} value with the specified name.
+     *
+     * @param name the name of the {@code boolean}
+     *
+     * @return the {@code boolean} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    boolean getBoolean(String name) throws JMSException;
+
+    /**
+     * Returns the {@code byte} value with the specified name.
+     *
+     * @param name the name of the {@code byte}
+     *
+     * @return the {@code byte} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    byte getByte(String name) throws JMSException;
+
+    /**
+     * Returns the {@code short} value with the specified name.
+     *
+     * @param name the name of the {@code short}
+     *
+     * @return the {@code short} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    short getShort(String name) throws JMSException;
+
+    /**
+     * Returns the Unicode character value with the specified name.
+     *
+     * @param name the name of the Unicode character
+     *
+     * @return the Unicode character value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    char getChar(String name) throws JMSException;
+
+    /**
+     * Returns the {@code int} value with the specified name.
+     *
+     * @param name the name of the {@code int}
+     *
+     * @return the {@code int} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    int getInt(String name) throws JMSException;
+
+    /**
+     * Returns the {@code long} value with the specified name.
+     *
+     * @param name the name of the {@code long}
+     *
+     * @return the {@code long} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    long getLong(String name) throws JMSException;
+
+    /**
+     * Returns the {@code float} value with the specified name.
+     *
+     * @param name the name of the {@code float}
+     *
+     * @return the {@code float} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    float getFloat(String name) throws JMSException;
+
+    /**
+     * Returns the {@code double} value with the specified name.
+     *
+     * @param name the name of the {@code double}
+     *
+     * @return the {@code double} value with the specified name
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    double getDouble(String name) throws JMSException;
+
+    /**
+     * Returns the {@code String} value with the specified name.
+     *
+     * @param name the name of the {@code String}
+     *
+     * @return the {@code String} value with the specified name; if there is no item by this name, a null value is returned
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    String getString(String name) throws JMSException;
+
+    /**
+     * Returns the byte array value with the specified name.
+     *
+     * @param name the name of the byte array
+     *
+     * @return a copy of the byte array value with the specified name; if there is no item by this name, a null value is
+     * returned.
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    byte[] getBytes(String name) throws JMSException;
+
+    /**
+     * Returns the value of the object with the specified name.
+     *
+     * <p>
+     * This method can be used to return, in objectified format, an object in the Java programming language ("Java object")
+     * that had been stored in the Map with the equivalent {@code setObject} method call, or its equivalent primitive
+     * <code>set<I>type</I></code> method.
+     *
+     * <p>
+     * Note that byte values are returned as {@code byte[]}, not {@code Byte[]}.
+     *
+     * @param name the name of the Java object
+     *
+     * @return a copy of the Java object value with the specified name, in objectified format (for example, if the object
+     * was set as an {@code int}, an {@code Integer} is returned); if there is no item by this name, a null value is
+     * returned
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     */
+    Object getObject(String name) throws JMSException;
+
+    /**
+     * Returns an {@code Enumeration} of all the names in the {@code MapMessage} object.
+     *
+     * @return an enumeration of all the names in this {@code MapMessage}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     */
+    Enumeration getMapNames() throws JMSException;
+
+    /**
+     * Sets a {@code boolean} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code boolean}
+     * @param value the {@code boolean} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setBoolean(String name, boolean value) throws JMSException;
+
+    /**
+     * Sets a {@code byte} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code byte}
+     * @param value the {@code byte} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setByte(String name, byte value) throws JMSException;
+
+    /**
+     * Sets a {@code short} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code short}
+     * @param value the {@code short} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setShort(String name, short value) throws JMSException;
+
+    /**
+     * Sets a Unicode character value with the specified name into the Map.
+     *
+     * @param name the name of the Unicode character
+     * @param value the Unicode character value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setChar(String name, char value) throws JMSException;
+
+    /**
+     * Sets an {@code int} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code int}
+     * @param value the {@code int} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setInt(String name, int value) throws JMSException;
+
+    /**
+     * Sets a {@code long} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code long}
+     * @param value the {@code long} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setLong(String name, long value) throws JMSException;
+
+    /**
+     * Sets a {@code float} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code float}
+     * @param value the {@code float} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setFloat(String name, float value) throws JMSException;
+
+    /**
+     * Sets a {@code double} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code double}
+     * @param value the {@code double} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setDouble(String name, double value) throws JMSException;
+
+    /**
+     * Sets a {@code String} value with the specified name into the Map.
+     *
+     * @param name the name of the {@code String}
+     * @param value the {@code String} value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setString(String name, String value) throws JMSException;
+
+    /**
+     * Sets a byte array value with the specified name into the Map.
+     *
+     * @param name the name of the byte array
+     * @param value the byte array value to set in the Map; the array is copied so that the value for {@code name} will not
+     * be altered by future modifications
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null, or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setBytes(String name, byte[] value) throws JMSException;
+
+    /**
+     * Sets a portion of the byte array value with the specified name into the Map.
+     *
+     * @param name the name of the byte array
+     * @param value the byte array value to set in the Map
+     * @param offset the initial offset within the byte array
+     * @param length the number of bytes to use
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setBytes(String name, byte[] value, int offset, int length) throws JMSException;
+
+    /**
+     * Sets an object value with the specified name into the Map.
+     *
+     * <p>
+     * This method works only for the objectified primitive object types ({@code Integer}, {@code Double},
+     * {@code Long}&nbsp;...), {@code String} objects, and byte arrays.
+     *
+     * @param name the name of the Java object
+     * @param value the Java object value to set in the Map
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageFormatException if the object is invalid.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setObject(String name, Object value) throws JMSException;
+
+    /**
+     * Indicates whether an item exists in this {@code MapMessage} object.
+     *
+     * @param name the name of the item to test
+     *
+     * @return true if the item exists
+     *
+     * @exception JMSException if the JMS provider fails to determine if the item exists due to some internal error.
+     */
+    boolean itemExists(String name) throws JMSException;
 }

--- a/src/main/java/javax/jms/Message.java
+++ b/src/main/java/javax/jms/Message.java
@@ -18,1654 +18,1352 @@ package javax.jms;
 
 import java.util.Enumeration;
 
-/** The {@code Message} interface is the root interface of all JMS 
-  * messages. It defines the message header and the {@code acknowledge} 
-  * method used for all messages.
-  *
-  * <P>Most message-oriented middleware (MOM) products treat messages as 
-  * lightweight entities that consist
-  * of a header and a body. The header contains fields used for message
-  * routing and identification; the body contains the application data
-  * being sent.
-  *
-  * <P>Within this general form, the definition of a message varies
-  * significantly across products. It would be quite difficult for the JMS API
-  * to support all of these message models.
-  *
-  * <P>With this in mind, the JMS message model has the following goals:
-  * <UL>
-  *   <LI>Provide a single, unified message API
-  *   <LI>Provide an API suitable for creating messages that match the
-  *       format used by provider-native messaging applications
-  *   <LI>Support the development of heterogeneous applications that span
-  *       operating systems, machine architectures, and computer languages
-  *   <LI>Support messages containing objects in the Java programming language
-  *       ("Java objects")
-  *   <LI>Support messages containing Extensible Markup Language (XML) pages
-  * </UL>
-  *
-  * <P>JMS messages are composed of the following parts:
-  * <UL>
-  *   <LI>Header - All messages support the same set of header fields. 
-  *       Header fields contain values used by both clients and providers to 
-  *       identify and route messages.
-  *   <LI>Properties - Each message contains a built-in facility for supporting
-  *       application-defined property values. Properties provide an efficient 
-  *       mechanism for supporting application-defined message filtering.
-  *   <LI>Body - The JMS API defines several types of message body, which cover
-  *       the majority of messaging styles currently in use.
-  * </UL>
-  *
-  * <H4>Message Bodies</H4>
-  *
-  * <P>The JMS API defines five types of message body:
-  * <UL>
-  *   <LI>Stream - A {@code StreamMessage} object's message body contains 
-  *       a stream of primitive values in the Java programming 
-  *       language ("Java primitives"). It is filled and read sequentially.
-  *   <LI>Map - A {@code MapMessage} object's message body contains a set 
-  *       of name-value pairs, where names are {@code String} 
-  *       objects, and values are Java primitives. The entries can be accessed 
-  *       sequentially or randomly by name. The order of the entries is 
-  *       undefined.
-  *   <LI>Text - A {@code TextMessage} object's message body contains a 
-  *       {@code java.lang.String} object. This message type can be used
-  *       to transport plain-text messages, and XML messages.
-  *   <LI>Object - An {@code ObjectMessage} object's message body contains 
-  *       a {@code Serializable} Java object.
-  *   <LI>Bytes - A {@code BytesMessage} object's message body contains a 
-  *       stream of uninterpreted bytes. This message type is for 
-  *       literally encoding a body to match an existing message format. In 
-  *       many cases, it is possible to use one of the other body types, 
-  *       which are easier to use. Although the JMS API allows the use of  
-  *       message properties with byte messages, they are typically not used,
-  *       since the inclusion of properties may affect the format.
-  * </UL>
-  *
-  * <H4>Message Headers</H4>
-  *
-  * <P>The {@code JMSCorrelationID} header field is used for linking one 
-  * message with
-  * another. It typically links a reply message with its requesting message.
-  *
-  * <P>{@code JMSCorrelationID} can hold a provider-specific message ID,
-  * an application-specific {@code String} object, or a provider-native 
-  * {@code byte[]} value.
-  *
-  * <H4>Message Properties</H4>
-  *
-  * <P>A {@code Message} object contains a built-in facility for supporting
-  * application-defined property values. In effect, this provides a mechanism 
-  * for adding application-specific header fields to a message.
-  *
-  * <P>Properties allow an application, via message selectors, to have a JMS 
-  * provider select, or filter, messages on its behalf using 
-  * application-specific criteria.
-  *
-  * <P>Property names must obey the rules for a message selector identifier. 
-  * Property names must not be null, and must not be empty strings. If a property
-  * name is set and it is either null or an empty string, an 
-  * {@code IllegalArgumentException} must be thrown.
-  *
-  * <P>Property values can be {@code boolean}, {@code byte}, 
-  * {@code short}, {@code int}, {@code long}, {@code float},
-  * {@code double}, and {@code String}.
-  *
-  * <P>Property values are set prior to sending a message. When a client 
-  * receives a message, its properties are in read-only mode. If a 
-  * client attempts to set properties at this point, a 
-  * {@code MessageNotWriteableException} is thrown. If 
-  * {@code clearProperties} is called, the properties can now be both
-  * read from and written to. Note that header fields are distinct from 
-  * properties. Header fields are never in read-only mode. 
-  *
-  * <P>A property value may duplicate a value in a message's body, or it may 
-  * not. Although JMS does not define a policy for what should or should not 
-  * be made a property, application developers should note that JMS providers 
-  * will likely handle data in a message's body more efficiently than data in 
-  * a message's properties. For best performance, applications should use
-  * message properties only when they need to customize a message's header. 
-  * The primary reason for doing this is to support customized message 
-  * selection.
-  *
-  * <P>Message properties support the following conversion table. The marked 
-  * cases must be supported. The unmarked cases must throw a 
-  * {@code JMSException}. The {@code String}-to-primitive conversions 
-  * may throw a runtime exception if the
-  * primitive's {@code valueOf} method does not accept the 
-  * {@code String} as a valid representation of the primitive.
-  *
-  * <P>A value written as the row type can be read as the column type.
-  *
-  * <PRE>
-  * |        | boolean byte short int long float double String 
-  * |----------------------------------------------------------
-  * |boolean |    X                                       X
-  * |byte    |          X     X    X   X                  X 
-  * |short   |                X    X   X                  X 
-  * |int     |                     X   X                  X 
-  * |long    |                         X                  X 
-  * |float   |                               X     X      X 
-  * |double  |                                     X      X 
-  * |String  |    X     X     X    X   X     X     X      X 
-  * |----------------------------------------------------------
-  * </PRE>
-  *
-  * <P>In addition to the type-specific set/get methods for properties, JMS 
-  * provides the {@code setObjectProperty} and 
-  * {@code getObjectProperty} methods. These support the same set of 
-  * property types using the objectified primitive values. Their purpose is 
-  * to allow the decision of property type to made at execution time rather 
-  * than at compile time. They support the same property value conversions.
-  *
-  * <P>The {@code setObjectProperty} method accepts values of class 
-  * {@code Boolean}, {@code Byte}, {@code Short}, 
-  * {@code Integer}, {@code Long}, {@code Float}, 
-  * {@code Double}, and {@code String}. An attempt 
-  * to use any other class must throw a {@code JMSException}.
-  *
-  * <P>The {@code getObjectProperty} method only returns values of class 
-  * {@code Boolean}, {@code Byte}, {@code Short}, 
-  * {@code Integer}, {@code Long}, {@code Float}, 
-  * {@code Double}, and {@code String}.
-  *
-  * <P>The order of property values is not defined. To iterate through a 
-  * message's property values, use {@code getPropertyNames} to retrieve 
-  * a property name enumeration and then use the various property get methods 
-  * to retrieve their values.
-  *
-  * <P>A message's properties are deleted by the {@code clearProperties}
-  * method. This leaves the message with an empty set of properties.
-  *
-  * <P>Getting a property value for a name which has not been set returns a 
-  * null value. Only the {@code getStringProperty} and 
-  * {@code getObjectProperty} methods can return a null value. 
-  * Attempting to read a null value as a primitive type must be treated as 
-  * calling the primitive's corresponding {@code valueOf(String)} 
-  * conversion method with a null value.
-  *
-  * <P>The JMS API reserves the {@code JMSX} property name prefix for JMS 
-  * defined properties.
-  * The full set of these properties is defined in the Java Message Service
-  * specification. The specification also defines whether support for each
-  * property is mandatory or optional.  
-  * New JMS defined properties may be added in later versions 
-  * of the JMS API.  The 
-  * {@code String[] ConnectionMetaData.getJMSXPropertyNames} method 
-  * returns the names of the JMSX properties supported by a connection.
-  *
-  * <P>JMSX properties may be referenced in message selectors whether or not
-  * they are supported by a connection. If they are not present in a
-  * message, they are treated like any other absent property.
-  * The effect of setting a message selector on a property 
-  * which is set by the provider on receive is undefined.
-  *
-  * <P>JMSX properties defined in the specification as "set by provider on 
-  * send" are available to both the producer and the consumers of the message. 
-  * JMSX properties defined in the specification as "set by provider on 
-  * receive" are available only to the consumers.
-  *
-  * <P>{@code JMSXGroupID} and {@code JMSXGroupSeq} are standard 
-  * properties that clients 
-  * should use if they want to group messages. All providers must support them.
-  * Unless specifically noted, the values and semantics of the JMSX properties 
-  * are undefined.
-  *
-  * <P>The JMS API reserves the <CODE>JMS_<I>vendor_name</I></CODE> property 
-  * name prefix for provider-specific properties. Each provider defines its own 
-  * value for <CODE><I>vendor_name</I></CODE>. This is the mechanism a JMS 
-  * provider uses to make its special per-message services available to a JMS 
-  * client.
-  *
-  * <P>The purpose of provider-specific properties is to provide special 
-  * features needed to integrate JMS clients with provider-native clients in a 
-  * single JMS application. They should not be used for messaging between JMS 
-  * clients.
-  *
-  * <H4>Provider Implementations of JMS Message Interfaces</H4>
-  *
-  * <P>The JMS API provides a set of message interfaces that define the JMS 
-  * message 
-  * model. It does not provide implementations of these interfaces.
-  *
-  * <P>Each JMS provider supplies a set of message factories with its 
-  * {@code Session} object for creating instances of messages. This allows 
-  * a provider to use message implementations tailored to its specific needs.
-  *
-  * <P>A provider must be prepared to accept message implementations that are 
-  * not its own. They may not be handled as efficiently as its own 
-  * implementation; however, they must be handled.
-  *
-  * <P>Note the following exception case when a provider is handling a foreign 
-  * message implementation. If the foreign message implementation contains a 
-  * {@code JMSReplyTo} header field that is set to a foreign destination 
-  * implementation, the provider is not required to handle or preserve the 
-  * value of this header field. 
-  *
-  * <H4>Message Selectors</H4>
-  *
-  * <P>A JMS message selector allows a client to specify, by
-  * header field references and property references, the
-  * messages it is interested in. Only messages whose header 
-  * and property values
-  * match the 
-  * selector are delivered. What it means for a message not to be delivered
-  * depends on the {@code MessageConsumer} being used (see 
-  * {@link javax.jms.QueueReceiver QueueReceiver} and 
-  * {@link javax.jms.TopicSubscriber TopicSubscriber}).
-  *
-  * <P>Message selectors cannot reference message body values.
-  *
-  * <P>A message selector matches a message if the selector evaluates to 
-  * true when the message's header field values and property values are 
-  * substituted for their corresponding identifiers in the selector.
-  *
-  * <P>A message selector is a {@code String} whose syntax is based on a 
-  * subset of 
-  * the SQL92 conditional expression syntax. If the value of a message selector 
-  * is an empty string, the value is treated as a null and indicates that there 
-  * is no message selector for the message consumer. 
-  *
-  * <P>The order of evaluation of a message selector is from left to right 
-  * within precedence level. Parentheses can be used to change this order.
-  *
-  * <P>Predefined selector literals and operator names are shown here in 
-  * uppercase; however, they are case insensitive.
-  *
-  * <P>A selector can contain:
-  *
-  * <UL>
-  *   <LI>Literals:
-  *   <UL>
-  *     <LI>A string literal is enclosed in single quotes, with a single quote 
-  *         represented by doubled single quote; for example, 
-  *         {@code 'literal'} and {@code 'literal''s'}. Like 
-  *         string literals in the Java programming language, these use the 
-  *         Unicode character encoding.
-  *     <LI>An exact numeric literal is a numeric value without a decimal 
-  *         point, such as {@code 57}, {@code -957}, and  
-  *         {@code +62}; numbers in the range of {@code long} are 
-  *         supported. Exact numeric literals use the integer literal 
-  *         syntax of the Java programming language.
-  *     <LI>An approximate numeric literal is a numeric value in scientific 
-  *         notation, such as {@code 7E3} and {@code -57.9E2}, or a 
-  *         numeric value with a decimal, such as {@code 7.}, 
-  *         {@code -95.7}, and {@code +6.2}; numbers in the range of 
-  *         {@code double} are supported. Approximate literals use the 
-  *         floating-point literal syntax of the Java programming language.
-  *     <LI>The boolean literals {@code TRUE} and {@code FALSE}.
-  *   </UL>
-  *   <LI>Identifiers:
-  *   <UL>
-  *     <LI>An identifier is an unlimited-length sequence of letters 
-  *         and digits, the first of which must be a letter. A letter is any 
-  *         character for which the method {@code Character.isJavaLetter}
-  *         returns true. This includes {@code '_'} and {@code '$'}.
-  *         A letter or digit is any character for which the method 
-  *         {@code Character.isJavaLetterOrDigit} returns true.
-  *     <LI>Identifiers cannot be the names {@code NULL}, 
-  *         {@code TRUE}, and {@code FALSE}.
-  *     <LI>Identifiers cannot be {@code NOT}, {@code AND}, 
-  *         {@code OR}, {@code BETWEEN}, {@code LIKE}, 
-  *         {@code IN}, {@code IS}, or {@code ESCAPE}.
-  *     <LI>Identifiers are either header field references or property 
-  *         references.  The type of a property value in a message selector 
-  *         corresponds to the type used to set the property. If a property 
-  *         that does not exist in a message is referenced, its value is 
-  *         {@code NULL}.
-  *     <LI>The conversions that apply to the get methods for properties do not
-  *         apply when a property is used in a message selector expression.
-  *         For example, suppose you set a property as a string value, as in the
-  *         following:
-  *         <PRE>myMessage.setStringProperty("NumberOfOrders", "2");</PRE>
-  *         The following expression in a message selector would evaluate to 
-  *         false, because a string cannot be used in an arithmetic expression:
-  *         <PRE>"NumberOfOrders > 1"</PRE>
-  *     <LI>Identifiers are case-sensitive.
-  *     <LI>Message header field references are restricted to 
-  *         {@code JMSDeliveryMode}, {@code JMSPriority}, 
-  *         {@code JMSMessageID}, {@code JMSTimestamp}, 
-  *         {@code JMSCorrelationID}, and {@code JMSType}. 
-  *         {@code JMSMessageID}, {@code JMSCorrelationID}, and 
-  *         {@code JMSType} values may be null and if so are treated as a 
-  *         {@code NULL} value.
-  *     <LI>Any name beginning with {@code 'JMSX'} is a JMS defined  
-  *         property name.
-  *     <LI>Any name beginning with {@code 'JMS_'} is a provider-specific 
-  *         property name.
-  *     <LI>Any name that does not begin with {@code 'JMS'} is an 
-  *         application-specific property name.
-  *   </UL>
-  *   <LI>White space is the same as that defined for the Java programming
-  *       language: space, horizontal tab, form feed, and line terminator.
-  *   <LI>Expressions: 
-  *   <UL>
-  *     <LI>A selector is a conditional expression; a selector that evaluates 
-  *         to {@code true} matches; a selector that evaluates to 
-  *         {@code false} or unknown does not match.
-  *     <LI>Arithmetic expressions are composed of themselves, arithmetic 
-  *         operations, identifiers (whose value is treated as a numeric 
-  *         literal), and numeric literals.
-  *     <LI>Conditional expressions are composed of themselves, comparison 
-  *         operations, and logical operations.
-  *   </UL>
-  *   <LI>Standard bracketing {@code ()} for ordering expression evaluation
-  *      is supported.
-  *   <LI>Logical operators in precedence order: {@code NOT}, 
-  *       {@code AND}, {@code OR}
-  *   <LI>Comparison operators: {@code =}, {@code >}, {@code >=},
-  *       {@code <}, {@code <=}, {@code <>} (not equal)
-  *   <UL>
-  *     <LI>Only like type values can be compared. One exception is that it 
-  *         is valid to compare exact numeric values and approximate numeric 
-  *         values; the type conversion required is defined by the rules of 
-  *         numeric promotion in the Java programming language. If the 
-  *         comparison of non-like type values is attempted, the value of the 
-  *         operation is false. If either of the type values evaluates to 
-  *         {@code NULL}, the value of the expression is unknown.   
-  *     <LI>String and boolean comparison is restricted to {@code =} and 
-  *         {@code <>}. Two strings are equal 
-  *         if and only if they contain the same sequence of characters.
-  *   </UL>
-  *   <LI>Arithmetic operators in precedence order:
-  *   <UL>
-  *     <LI>{@code +}, {@code -} (unary)
-  *     <LI>{@code *}, {@code /} (multiplication and division)
-  *     <LI>{@code +}, {@code -} (addition and subtraction)
-  *     <LI>Arithmetic operations must use numeric promotion in the Java 
-  *         programming language.
-  *   </UL>
-  *   <LI><CODE><I>arithmetic-expr1</I> [NOT] BETWEEN <I>arithmetic-expr2</I> 
-  *       AND <I>arithmetic-expr3</I></CODE> (comparison operator)
-  *   <UL>
-  *     <LI><CODE>"age&nbsp;BETWEEN&nbsp;15&nbsp;AND&nbsp;19"</CODE> is 
-  *         equivalent to 
-  *         <CODE>"age&nbsp;>=&nbsp;15&nbsp;AND&nbsp;age&nbsp;<=&nbsp;19"</CODE>
-  *     <LI><CODE>"age&nbsp;NOT&nbsp;BETWEEN&nbsp;15&nbsp;AND&nbsp;19"</CODE> 
-  *         is equivalent to 
-  *         <CODE>"age&nbsp;<&nbsp;15&nbsp;OR&nbsp;age&nbsp;>&nbsp;19"</CODE>
-  *   </UL>
-  *   <LI><CODE><I>identifier</I> [NOT] IN (<I>string-literal1</I>, 
-  *       <I>string-literal2</I>,...)</CODE> (comparison operator where 
-  *       <CODE><I>identifier</I></CODE> has a <CODE>String</CODE> or 
-  *       <CODE>NULL</CODE> value)
-  *   <UL>
-  *     <LI><CODE>"Country&nbsp;IN&nbsp;('&nbsp;UK',&nbsp;'US',&nbsp;'France')"</CODE>
-  *         is true for 
-  *         <CODE>'UK'</CODE> and false for <CODE>'Peru'</CODE>; it is 
-  *         equivalent to the expression 
-  *         <CODE>"(Country&nbsp;=&nbsp;'&nbsp;UK')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;US')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;France')"</CODE>
-  *     <LI><CODE>"Country&nbsp;NOT&nbsp;IN&nbsp;('&nbsp;UK',&nbsp;'US',&nbsp;'France')"</CODE> 
-  *         is false for <CODE>'UK'</CODE> and true for <CODE>'Peru'</CODE>; it 
-  *         is equivalent to the expression 
-  *         <CODE>"NOT&nbsp;((Country&nbsp;=&nbsp;'&nbsp;UK')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;US')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;France'))"</CODE>
-  *     <LI>If identifier of an <CODE>IN</CODE> or <CODE>NOT IN</CODE> 
-  *         operation is <CODE>NULL</CODE>, the value of the operation is 
-  *         unknown.
-  *   </UL>
-  *   <LI><CODE><I>identifier</I> [NOT] LIKE <I>pattern-value</I> [ESCAPE 
-  *       <I>escape-character</I>]</CODE> (comparison operator, where 
-  *       <CODE><I>identifier</I></CODE> has a <CODE>String</CODE> value; 
-  *       <CODE><I>pattern-value</I></CODE> is a string literal where 
-  *       <CODE>'_'</CODE> stands for any single character; <CODE>'%'</CODE> 
-  *       stands for any sequence of characters, including the empty sequence; 
-  *       and all other characters stand for themselves. The optional 
-  *       <CODE><I>escape-character</I></CODE> is a single-character string 
-  *       literal whose character is used to escape the special meaning of the 
-  *       <CODE>'_'</CODE> and <CODE>'%'</CODE> in 
-  *       <CODE><I>pattern-value</I></CODE>.)
-  *   <UL>
-  *     <LI><CODE>"phone&nbsp;LIKE&nbsp;'12%3'"</CODE> is true for 
-  *         <CODE>'123'</CODE> or <CODE>'12993'</CODE> and false for 
-  *         <CODE>'1234'</CODE>
-  *     <LI><CODE>"word&nbsp;LIKE&nbsp;'l_se'"</CODE> is true for 
-  *         <CODE>'lose'</CODE> and false for <CODE>'loose'</CODE>
-  *     <LI><CODE>"underscored&nbsp;LIKE&nbsp;'\_%'&nbsp;ESCAPE&nbsp;'\'"</CODE>
-  *          is true for <CODE>'_foo'</CODE> and false for <CODE>'bar'</CODE>
-  *     <LI><CODE>"phone&nbsp;NOT&nbsp;LIKE&nbsp;'12%3'"</CODE> is false for 
-  *         <CODE>'123'</CODE> or <CODE>'12993'</CODE> and true for 
-  *         <CODE>'1234'</CODE>
-  *     <LI>If <CODE><I>identifier</I></CODE> of a <CODE>LIKE</CODE> or 
-  *         <CODE>NOT LIKE</CODE> operation is <CODE>NULL</CODE>, the value 
-  *         of the operation is unknown.
-  *   </UL>
-  *   <LI><CODE><I>identifier</I> IS NULL</CODE> (comparison operator that tests
-  *       for a null header field value or a missing property value)
-  *   <UL>
-  *     <LI><CODE>"prop_name&nbsp;IS&nbsp;NULL"</CODE>
-  *   </UL>
-  *   <LI><CODE><I>identifier</I> IS NOT NULL</CODE> (comparison operator that
-  *       tests for the existence of a non-null header field value or a property
-  *       value)
-  *   <UL>
-  *     <LI><CODE>"prop_name&nbsp;IS&nbsp;NOT&nbsp;NULL"</CODE>
-  *   </UL>
-  *
-  * <P>JMS providers are required to verify the syntactic correctness of a 
-  *    message selector at the time it is presented. A method that provides a 
-  *  syntactically incorrect selector must result in a {@code JMSException}.
-  * JMS providers may also optionally provide some semantic checking at the time
-  * the selector is presented. Not all semantic checking can be performed at
-  * the time a message selector is presented, because property types are not known.
-  * 
-  * <P>The following message selector selects messages with a message type 
-  * of car and color of blue and weight greater than 2500 pounds:
-  *
-  * <PRE>"JMSType&nbsp;=&nbsp;'car'&nbsp;AND&nbsp;color&nbsp;=&nbsp;'blue'&nbsp;AND&nbsp;weight&nbsp;>&nbsp;2500"</PRE>
-  *
-  * <H4>Null Values</H4>
-  *
-  * <P>As noted above, property values may be {@code NULL}. The evaluation 
-  * of selector expressions containing {@code NULL} values is defined by 
-  * SQL92 {@code NULL} semantics. A brief description of these semantics 
-  * is provided here.
-  *
-  * <P>SQL treats a {@code NULL} value as unknown. Comparison or arithmetic
-  * with an unknown value always yields an unknown value.
-  *
-  * <P>The {@code IS NULL} and {@code IS NOT NULL} operators convert 
-  * an unknown value into the respective {@code TRUE} and 
-  * {@code FALSE} values.
-  *
-  * <P>The boolean operators use three-valued logic as defined by the 
-  * following tables:
-  *
-  * <P><B>The definition of the {@code AND} operator</B>
-  *
-  * <PRE>
-  * | AND  |   T   |   F   |   U
-  * +------+-------+-------+-------
-  * |  T   |   T   |   F   |   U
-  * |  F   |   F   |   F   |   F
-  * |  U   |   U   |   F   |   U
-  * +------+-------+-------+-------
-  * </PRE>
-  *
-  * <P><B>The definition of the {@code OR} operator</B>
-  *
-  * <PRE>
-  * | OR   |   T   |   F   |   U
-  * +------+-------+-------+--------
-  * |  T   |   T   |   T   |   T
-  * |  F   |   T   |   F   |   U
-  * |  U   |   T   |   U   |   U
-  * +------+-------+-------+------- 
-  * </PRE> 
-  *
-  * <P><B>The definition of the {@code NOT} operator</B>
-  *
-  * <PRE>
-  * | NOT
-  * +------+------
-  * |  T   |   F
-  * |  F   |   T
-  * |  U   |   U
-  * +------+-------
-  * </PRE>
-  *
-  * <H4>Special Notes</H4>
-  *
-  * <P>When used in a message selector, the {@code JMSDeliveryMode} header 
-  *    field is treated as having the values {@code 'PERSISTENT'} and 
-  *    {@code 'NON_PERSISTENT'}.
-  *
-  * <P>Date and time values should use the standard {@code long} 
-  *    millisecond value. When a date or time literal is included in a message 
-  *    selector, it should be an integer literal for a millisecond value. The 
-  *    standard way to produce millisecond values is to use 
-  *    {@code java.util.Calendar}.
-  *
-  * <P>Although SQL supports fixed decimal comparison and arithmetic, JMS 
-  *    message selectors do not. This is the reason for restricting exact 
-  *    numeric literals to those without a decimal (and the addition of 
-  *    numerics with a decimal as an alternate representation for 
-  *    approximate numeric values).
-  *
-  * <P>SQL comments are not supported.
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  * @see         javax.jms.MessageConsumer#receive()
-  * @see         javax.jms.MessageConsumer#receive(long)
-  * @see         javax.jms.MessageConsumer#receiveNoWait()
-  * @see         javax.jms.MessageListener#onMessage(Message)
-  * @see         javax.jms.BytesMessage
-  * @see         javax.jms.MapMessage
-  * @see         javax.jms.ObjectMessage
-  * @see         javax.jms.StreamMessage
-  * @see         javax.jms.TextMessage
-  */
-
+/**
+ * The {@code Message} interface is the root interface of all JMS messages. It defines the message header and the
+ * {@code acknowledge} method used for all messages.
+ *
+ * <p>
+ * Most message-oriented middleware (MOM) products treat messages as lightweight entities that consist of a header and a
+ * body. The header contains fields used for message routing and identification; the body contains the application data
+ * being sent.
+ *
+ * <p>
+ * Within this general form, the definition of a message varies significantly across products. It would be quite
+ * difficult for the JMS API to support all of these message models.
+ *
+ * <p>
+ * With this in mind, the JMS message model has the following goals:
+ * <ul>
+ * <li>Provide a single, unified message API
+ * <li>Provide an API suitable for creating messages that match the format used by provider-native messaging
+ * applications
+ * <li>Support the development of heterogeneous applications that span operating systems, machine architectures, and
+ * computer languages
+ * <li>Support messages containing objects in the Java programming language ("Java objects")
+ * <li>Support messages containing Extensible Markup Language (XML) pages
+ * </ul>
+ *
+ * <p>
+ * JMS messages are composed of the following parts:
+ * <ul>
+ * <li>Header - All messages support the same set of header fields. Header fields contain values used by both clients
+ * and providers to identify and route messages.
+ * <li>Properties - Each message contains a built-in facility for supporting application-defined property values.
+ * Properties provide an efficient mechanism for supporting application-defined message filtering.
+ * <li>Body - The JMS API defines several types of message body, which cover the majority of messaging styles currently
+ * in use.
+ * </ul>
+ *
+ * <h3>Message Bodies</h3>
+ *
+ * <p>
+ * The JMS API defines five types of message body:
+ * <ul>
+ * <li>Stream - A {@code StreamMessage} object's message body contains a stream of primitive values in the Java
+ * programming language ("Java primitives"). It is filled and read sequentially.
+ * <li>Map - A {@code MapMessage} object's message body contains a set of name-value pairs, where names are
+ * {@code String} objects, and values are Java primitives. The entries can be accessed sequentially or randomly by name.
+ * The order of the entries is undefined.
+ * <li>Text - A {@code TextMessage} object's message body contains a {@code java.lang.String} object. This message type
+ * can be used to transport plain-text messages, and XML messages.
+ * <li>Object - An {@code ObjectMessage} object's message body contains a {@code Serializable} Java object.
+ * <li>Bytes - A {@code BytesMessage} object's message body contains a stream of uninterpreted bytes. This message type
+ * is for literally encoding a body to match an existing message format. In many cases, it is possible to use one of the
+ * other body types, which are easier to use. Although the JMS API allows the use of message properties with byte
+ * messages, they are typically not used, since the inclusion of properties may affect the format.
+ * </ul>
+ *
+ * <h3>Message Headers</h3>
+ *
+ * <p>
+ * The {@code JMSCorrelationID} header field is used for linking one message with another. It typically links a reply
+ * message with its requesting message.
+ *
+ * <p>
+ * {@code JMSCorrelationID} can hold a provider-specific message ID, an application-specific {@code String} object, or a
+ * provider-native {@code byte[]} value.
+ *
+ * <h3>Message Properties</h3>
+ *
+ * <p>
+ * A {@code Message} object contains a built-in facility for supporting application-defined property values. In effect,
+ * this provides a mechanism for adding application-specific header fields to a message.
+ *
+ * <p>
+ * Properties allow an application, via message selectors, to have a JMS provider select, or filter, messages on its
+ * behalf using application-specific criteria.
+ *
+ * <p>
+ * Property names must obey the rules for a message selector identifier. Property names must not be null, and must not
+ * be empty strings. If a property name is set and it is either null or an empty string, an
+ * {@code IllegalArgumentException} must be thrown.
+ *
+ * <p>
+ * Property values can be {@code boolean}, {@code byte}, {@code short}, {@code int}, {@code long}, {@code float},
+ * {@code double}, and {@code String}.
+ *
+ * <p>
+ * Property values are set prior to sending a message. When a client receives a message, its properties are in read-only
+ * mode. If a client attempts to set properties at this point, a {@code MessageNotWriteableException} is thrown. If
+ * {@code clearProperties} is called, the properties can now be both read from and written to. Note that header fields
+ * are distinct from properties. Header fields are never in read-only mode.
+ *
+ * <p>
+ * A property value may duplicate a value in a message's body, or it may not. Although JMS does not define a policy for
+ * what should or should not be made a property, application developers should note that JMS providers will likely
+ * handle data in a message's body more efficiently than data in a message's properties. For best performance,
+ * applications should use message properties only when they need to customize a message's header. The primary reason
+ * for doing this is to support customized message selection.
+ *
+ * <p>
+ * Message properties support the following conversion table. The marked cases must be supported. The unmarked cases
+ * must throw a {@code JMSException}. The {@code String}-to-primitive conversions may throw a runtime exception if the
+ * primitive's {@code valueOf} method does not accept the {@code String} as a valid representation of the primitive.
+ *
+ * <p>
+ * A value written as the row type can be read as the column type.
+ *
+ * <pre>
+ * |        | boolean byte short int long float double String
+ * |----------------------------------------------------------
+ * |boolean |    X                                       X
+ * |byte    |          X     X    X   X                  X
+ * |short   |                X    X   X                  X
+ * |int     |                     X   X                  X
+ * |long    |                         X                  X
+ * |float   |                               X     X      X
+ * |double  |                                     X      X
+ * |String  |    X     X     X    X   X     X     X      X
+ * |----------------------------------------------------------
+ * </pre>
+ *
+ * <p>
+ * In addition to the type-specific set/get methods for properties, JMS provides the {@code setObjectProperty} and
+ * {@code getObjectProperty} methods. These support the same set of property types using the objectified primitive
+ * values. Their purpose is to allow the decision of property type to made at execution time rather than at compile
+ * time. They support the same property value conversions.
+ *
+ * <p>
+ * The {@code setObjectProperty} method accepts values of class {@code Boolean}, {@code Byte}, {@code Short},
+ * {@code Integer}, {@code Long}, {@code Float}, {@code Double}, and {@code String}. An attempt to use any other class
+ * must throw a {@code JMSException}.
+ *
+ * <p>
+ * The {@code getObjectProperty} method only returns values of class {@code Boolean}, {@code Byte}, {@code Short},
+ * {@code Integer}, {@code Long}, {@code Float}, {@code Double}, and {@code String}.
+ *
+ * <p>
+ * The order of property values is not defined. To iterate through a message's property values, use
+ * {@code getPropertyNames} to retrieve a property name enumeration and then use the various property get methods to
+ * retrieve their values.
+ *
+ * <p>
+ * A message's properties are deleted by the {@code clearProperties} method. This leaves the message with an empty set
+ * of properties.
+ *
+ * <p>
+ * Getting a property value for a name which has not been set returns a null value. Only the {@code getStringProperty}
+ * and {@code getObjectProperty} methods can return a null value. Attempting to read a null value as a primitive type
+ * must be treated as calling the primitive's corresponding {@code valueOf(String)} conversion method with a null value.
+ *
+ * <p>
+ * The JMS API reserves the {@code JMSX} property name prefix for JMS defined properties. The full set of these
+ * properties is defined in the Java Message Service specification. The specification also defines whether support for
+ * each property is mandatory or optional. New JMS defined properties may be added in later versions of the JMS API. The
+ * {@code String[] ConnectionMetaData.getJMSXPropertyNames} method returns the names of the JMSX properties supported by
+ * a connection.
+ *
+ * <p>
+ * JMSX properties may be referenced in message selectors whether or not they are supported by a connection. If they are
+ * not present in a message, they are treated like any other absent property. The effect of setting a message selector
+ * on a property which is set by the provider on receive is undefined.
+ *
+ * <p>
+ * JMSX properties defined in the specification as "set by provider on send" are available to both the producer and the
+ * consumers of the message. JMSX properties defined in the specification as "set by provider on receive" are available
+ * only to the consumers.
+ *
+ * <p>
+ * {@code JMSXGroupID} and {@code JMSXGroupSeq} are standard properties that clients should use if they want to group
+ * messages. All providers must support them. Unless specifically noted, the values and semantics of the JMSX properties
+ * are undefined.
+ *
+ * <p>
+ * The JMS API reserves the <code>JMS_<I>vendor_name</I></code> property name prefix for provider-specific properties.
+ * Each provider defines its own value for <code><I>vendor_name</I></code>. This is the mechanism a JMS provider uses to
+ * make its special per-message services available to a JMS client.
+ *
+ * <p>
+ * The purpose of provider-specific properties is to provide special features needed to integrate JMS clients with
+ * provider-native clients in a single JMS application. They should not be used for messaging between JMS clients.
+ *
+ * <h3>Provider Implementations of JMS Message Interfaces</h3>
+ *
+ * <p>
+ * The JMS API provides a set of message interfaces that define the JMS message model. It does not provide
+ * implementations of these interfaces.
+ *
+ * <p>
+ * Each JMS provider supplies a set of message factories with its {@code Session} object for creating instances of
+ * messages. This allows a provider to use message implementations tailored to its specific needs.
+ *
+ * <p>
+ * A provider must be prepared to accept message implementations that are not its own. They may not be handled as
+ * efficiently as its own implementation; however, they must be handled.
+ *
+ * <p>
+ * Note the following exception case when a provider is handling a foreign message implementation. If the foreign
+ * message implementation contains a {@code JMSReplyTo} header field that is set to a foreign destination
+ * implementation, the provider is not required to handle or preserve the value of this header field.
+ *
+ * <h3>Message Selectors</h3>
+ *
+ * <p>
+ * A JMS message selector allows a client to specify, by header field references and property references, the messages
+ * it is interested in. Only messages whose header and property values match the selector are delivered. What it means
+ * for a message not to be delivered depends on the {@code MessageConsumer} being used (see
+ * {@link javax.jms.QueueReceiver QueueReceiver} and {@link javax.jms.TopicSubscriber TopicSubscriber}).
+ *
+ * <p>
+ * Message selectors cannot reference message body values.
+ *
+ * <p>
+ * A message selector matches a message if the selector evaluates to true when the message's header field values and
+ * property values are substituted for their corresponding identifiers in the selector.
+ *
+ * <p>
+ * A message selector is a {@code String} whose syntax is based on a subset of the SQL92 conditional expression syntax.
+ * If the value of a message selector is an empty string, the value is treated as a null and indicates that there is no
+ * message selector for the message consumer.
+ *
+ * <p>
+ * The order of evaluation of a message selector is from left to right within precedence level. Parentheses can be used
+ * to change this order.
+ *
+ * <p>
+ * Predefined selector literals and operator names are shown here in uppercase; however, they are case insensitive.
+ *
+ * <p>
+ * A selector can contain:
+ *
+ * <ul>
+ *  <li>Literals:
+ *    <ul>
+ *      <li>A string literal is enclosed in single quotes, with a single quote represented by doubled single quote; for
+ *          example, {@code 'literal'} and {@code 'literal''s'}. Like string literals in the Java programming language, these use
+ *          the Unicode character encoding.
+ *      <li>An exact numeric literal is a numeric value without a decimal point, such as {@code 57}, {@code -957}, and
+ *         {@code +62}; numbers in the range of {@code long} are supported. Exact numeric literals use the integer literal
+ *         syntax of the Java programming language.
+ *      <li>An approximate numeric literal is a numeric value in scientific notation, such as {@code 7E3} and
+ *         {@code -57.9E2}, or a numeric value with a decimal, such as {@code 7.}, {@code -95.7}, and {@code +6.2}; numbers in
+ *         the range of {@code double} are supported. Approximate literals use the floating-point literal syntax of the Java
+ *         programming language.
+ *      <li>The boolean literals {@code TRUE} and {@code FALSE}.
+ *    </ul>
+ *
+ *    <li>Identifiers:
+ *       <ul>
+ *         <li>An identifier is an unlimited-length sequence of letters and digits, the first of which must be a letter. A
+ *             letter is any character for which the method {@code Character.isJavaLetter} returns true. This includes {@code '_'}
+ *             and {@code '$'}. A letter or digit is any character for which the method {@code Character.isJavaLetterOrDigit}
+ *             returns true.
+ *         <li>Identifiers cannot be the names {@code NULL}, {@code TRUE}, and {@code FALSE}.
+ *         <li>Identifiers cannot be {@code NOT}, {@code AND}, {@code OR}, {@code BETWEEN}, {@code LIKE}, {@code IN},
+ *         {@code IS}, or {@code ESCAPE}.
+ *         <li>Identifiers are either header field references or property references. The type of a property value in a message
+ *             selector corresponds to the type used to set the property. If a property that does not exist in a message is
+ *             referenced, its value is {@code NULL}.
+ *         <li>The conversions that apply to the get methods for properties do not apply when a property is used in a message
+ *             selector expression. For example, suppose you set a property as a string value, as in the following:
+ *
+ * <pre>
+ * myMessage.setStringProperty("NumberOfOrders", "2");
+ * </pre>
+ *
+ * The following expression in a message selector would evaluate to false, because a string cannot be used in an
+ * arithmetic expression:
+ *
+ * <pre>
+ * "NumberOfOrders &gt; 1"
+ * </pre>
+ *
+ *        <li>Identifiers are case-sensitive.
+ *        <li>Message header field references are restricted to {@code JMSDeliveryMode}, {@code JMSPriority},
+ *            {@code JMSMessageID}, {@code JMSTimestamp}, {@code JMSCorrelationID}, and {@code JMSType}. {@code JMSMessageID},
+ *            {@code JMSCorrelationID}, and {@code JMSType} values may be null and if so are treated as a {@code NULL} value.
+ *        <li>Any name beginning with {@code 'JMSX'} is a JMS defined property name.
+ *        <li>Any name beginning with {@code 'JMS_'} is a provider-specific property name.
+ *        <li>Any name that does not begin with {@code 'JMS'} is an application-specific property name.
+ *      </ul>
+ *
+ *      <li>White space is the same as that defined for the Java programming language: space, horizontal tab, form feed, and
+ *          line terminator.
+ *
+ *      <li>Expressions:
+ *        <ul>
+ *          <li>A selector is a conditional expression; a selector that evaluates to {@code true} matches; a selector that
+ *              evaluates to {@code false} or unknown does not match.
+ *          <li>Arithmetic expressions are composed of themselves, arithmetic operations, identifiers (whose value is treated as
+ *              a numeric literal), and numeric literals.
+ *         <li>Conditional expressions are composed of themselves, comparison operations, and logical operations.
+ *       </ul>
+ *
+ *       <li>Standard bracketing {@code ()} for ordering expression evaluation is supported.
+ *       <li>Logical operators in precedence order: {@code NOT}, {@code AND}, {@code OR}
+ *       <li>Comparison operators: {@code =}, {@code >}, {@code >=}, {@code <}, {@code <=}, {@code <>} (not equal)
+ *         <ul>
+ *          <li>Only like type values can be compared. One exception is that it is valid to compare exact numeric values and
+ *              approximate numeric values; the type conversion required is defined by the rules of numeric promotion in the Java
+ *              programming language. If the comparison of non-like type values is attempted, the value of the operation is false. If
+ *              either of the type values evaluates to {@code NULL}, the value of the expression is unknown.
+ *           <li>String and boolean comparison is restricted to {@code =} and {@code <>}. Two strings are equal if and only if
+ *              they contain the same sequence of characters.
+ *         </ul>
+ *
+ *       <li>Arithmetic operators in precedence order:
+ *         <ul>
+ *          <li>{@code +}, {@code -} (unary)
+ *          <li>{@code *}, {@code /} (multiplication and division)
+ *          <li>{@code +}, {@code -} (addition and subtraction)
+ *          <li>Arithmetic operations must use numeric promotion in the Java programming language.
+ *         </ul>
+ *
+ *       <li><code><I>arithmetic-expr1</I> [NOT] BETWEEN <I>arithmetic-expr2</I>
+ *              AND <I>arithmetic-expr3</I></code> (comparison operator)
+ *              <ul>
+ * <li><code>"age&nbsp;BETWEEN&nbsp;15&nbsp;AND&nbsp;19"</code> is equivalent to
+ * <code>"age&nbsp;&gt;=&nbsp;15&nbsp;AND&nbsp;age&nbsp;&lt;=&nbsp;19"</code>
+ * <li><code>"age&nbsp;NOT&nbsp;BETWEEN&nbsp;15&nbsp;AND&nbsp;19"</code> is equivalent to
+ * <code>"age&nbsp;&lt;&nbsp;15&nbsp;OR&nbsp;age&nbsp;&gt;&nbsp;19"</code>
+ * </ul>
+ * <li><code><I>identifier</I> [NOT] IN (<I>string-literal1</I>,
+ *       <I>string-literal2</I>,...)</code> (comparison operator where <code><I>identifier</I></code> has a
+ * <code>String</code> or <code>NULL</code> value)
+ * <ul>
+ * <li><code>"Country&nbsp;IN&nbsp;('&nbsp;UK',&nbsp;'US',&nbsp;'France')"</code> is true for <code>'UK'</code> and
+ * false for <code>'Peru'</code>; it is equivalent to the expression
+ * <code>"(Country&nbsp;=&nbsp;'&nbsp;UK')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;US')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;France')"</code>
+ * <li><code>"Country&nbsp;NOT&nbsp;IN&nbsp;('&nbsp;UK',&nbsp;'US',&nbsp;'France')"</code> is false for
+ * <code>'UK'</code> and true for <code>'Peru'</code>; it is equivalent to the expression
+ * <code>"NOT&nbsp;((Country&nbsp;=&nbsp;'&nbsp;UK')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;US')&nbsp;OR&nbsp;(Country&nbsp;=&nbsp;'&nbsp;France'))"</code>
+ * <li>If identifier of an <code>IN</code> or <code>NOT IN</code> operation is <code>NULL</code>, the value of the
+ * operation is unknown.
+ * </ul>
+ * <li><code><I>identifier</I> [NOT] LIKE <I>pattern-value</I> [ESCAPE
+ *       <I>escape-character</I>]</code> (comparison operator, where <code><I>identifier</I></code> has a
+ * <code>String</code> value; <code><I>pattern-value</I></code> is a string literal where <code>'_'</code> stands for
+ * any single character; <code>'%'</code> stands for any sequence of characters, including the empty sequence; and all
+ * other characters stand for themselves. The optional <code><I>escape-character</I></code> is a single-character string
+ * literal whose character is used to escape the special meaning of the <code>'_'</code> and <code>'%'</code> in
+ * <code><I>pattern-value</I></code>.)
+ * <ul>
+ * <li><code>"phone&nbsp;LIKE&nbsp;'12%3'"</code> is true for <code>'123'</code> or <code>'12993'</code> and false for
+ * <code>'1234'</code>
+ * <li><code>"word&nbsp;LIKE&nbsp;'l_se'"</code> is true for <code>'lose'</code> and false for <code>'loose'</code>
+ * <li><code>"underscored&nbsp;LIKE&nbsp;'\_%'&nbsp;ESCAPE&nbsp;'\'"</code> is true for <code>'_foo'</code> and false
+ * for <code>'bar'</code>
+ * <li><code>"phone&nbsp;NOT&nbsp;LIKE&nbsp;'12%3'"</code> is false for <code>'123'</code> or <code>'12993'</code> and
+ * true for <code>'1234'</code>
+ * <li>If <code><I>identifier</I></code> of a <code>LIKE</code> or <code>NOT LIKE</code> operation is <code>NULL</code>,
+ * the value of the operation is unknown.
+ * </ul>
+ * <li><code><I>identifier</I> IS NULL</code> (comparison operator that tests for a null header field value or a missing
+ * property value)
+ * <ul>
+ * <li><code>"prop_name&nbsp;IS&nbsp;NULL"</code>
+ * </ul>
+ *
+ *   <li><code><I>identifier</I> IS NOT NULL</code> (comparison operator that tests for the existence of a non-null header
+ *       field value or a property value)
+ *      <ul>
+ *          <li><code>"prop_name&nbsp;IS&nbsp;NOT&nbsp;NULL"</code>
+ *      </ul>
+ * </ul>
+ *
+ * <p>
+ * JMS providers are required to verify the syntactic correctness of a message selector at the time it is presented. A
+ * method that provides a syntactically incorrect selector must result in a {@code JMSException}. JMS providers may also
+ * optionally provide some semantic checking at the time the selector is presented. Not all semantic checking can be
+ * performed at the time a message selector is presented, because property types are not known.
+ *
+ * <p>
+ * The following message selector selects messages with a message type of car and color of blue and weight greater than
+ * 2500 pounds:
+ *
+ * <pre>
+ * "JMSType&nbsp;=&nbsp;'car'&nbsp;AND&nbsp;color&nbsp;=&nbsp;'blue'&nbsp;AND&nbsp;weight&nbsp;&gt;&nbsp;2500"
+ * </pre>
+ *
+ * <h3>Null Values</h3>
+ *
+ * <p>
+ * As noted above, property values may be {@code NULL}. The evaluation of selector expressions containing {@code NULL}
+ * values is defined by SQL92 {@code NULL} semantics. A brief description of these semantics is provided here.
+ *
+ * <p>
+ * SQL treats a {@code NULL} value as unknown. Comparison or arithmetic with an unknown value always yields an unknown
+ * value.
+ *
+ * <p>
+ * The {@code IS NULL} and {@code IS NOT NULL} operators convert an unknown value into the respective {@code TRUE} and
+ * {@code FALSE} values.
+ *
+ * <p>
+ * The boolean operators use three-valued logic as defined by the following tables:
+ *
+ * <p>
+ * <B>The definition of the {@code AND} operator</B>
+ *
+ * <pre>
+ * | AND  |   T   |   F   |   U
+ * +------+-------+-------+-------
+ * |  T   |   T   |   F   |   U
+ * |  F   |   F   |   F   |   F
+ * |  U   |   U   |   F   |   U
+ * +------+-------+-------+-------
+ * </pre>
+ *
+ * <p>
+ * <B>The definition of the {@code OR} operator</B>
+ *
+ * <pre>
+ * | OR   |   T   |   F   |   U
+ * +------+-------+-------+--------
+ * |  T   |   T   |   T   |   T
+ * |  F   |   T   |   F   |   U
+ * |  U   |   T   |   U   |   U
+ * +------+-------+-------+-------
+ * </pre>
+ *
+ * <p>
+ * <B>The definition of the {@code NOT} operator</B>
+ *
+ * <pre>
+ * | NOT
+ * +------+------
+ * |  T   |   F
+ * |  F   |   T
+ * |  U   |   U
+ * +------+-------
+ * </pre>
+ *
+ * <h3>Special Notes</h3>
+ *
+ * <p>
+ * When used in a message selector, the {@code JMSDeliveryMode} header field is treated as having the values
+ * {@code 'PERSISTENT'} and {@code 'NON_PERSISTENT'}.
+ *
+ * <p>
+ * Date and time values should use the standard {@code long} millisecond value. When a date or time literal is included
+ * in a message selector, it should be an integer literal for a millisecond value. The standard way to produce
+ * millisecond values is to use {@code java.util.Calendar}.
+ *
+ * <p>
+ * Although SQL supports fixed decimal comparison and arithmetic, JMS message selectors do not. This is the reason for
+ * restricting exact numeric literals to those without a decimal (and the addition of numerics with a decimal as an
+ * alternate representation for approximate numeric values).
+ *
+ * <p>
+ * SQL comments are not supported.
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ * @see javax.jms.MessageConsumer#receive()
+ * @see javax.jms.MessageConsumer#receive(long)
+ * @see javax.jms.MessageConsumer#receiveNoWait()
+ * @see javax.jms.MessageListener#onMessage(Message)
+ * @see javax.jms.BytesMessage
+ * @see javax.jms.MapMessage
+ * @see javax.jms.ObjectMessage
+ * @see javax.jms.StreamMessage
+ * @see javax.jms.TextMessage
+ */
 public interface Message {
 
-    /** The message producer's default delivery mode is {@code PERSISTENT}.
+    /**
+     * The message producer's default delivery mode is {@code PERSISTENT}.
      *
-     *  @see DeliveryMode#PERSISTENT
+     * @see DeliveryMode#PERSISTENT
      */
-    static final int DEFAULT_DELIVERY_MODE = DeliveryMode.PERSISTENT;
+    int DEFAULT_DELIVERY_MODE = DeliveryMode.PERSISTENT;
 
-    /** The message producer's default priority is 4. 
+    /**
+     * The message producer's default priority is 4.
      */
-    static final int DEFAULT_PRIORITY = 4;
+    int DEFAULT_PRIORITY = 4;
 
-    /** The message producer's default time to live is unlimited; the message 
-     *  never expires. 
+    /**
+     * The message producer's default time to live is unlimited; the message never expires.
      */
-    static final long DEFAULT_TIME_TO_LIVE = 0;
-    
-    /** The message producer's default delivery delay is zero.
+    long DEFAULT_TIME_TO_LIVE = 0;
+
+    /**
+     * The message producer's default delivery delay is zero.
+     *
      * @since JMS 2.0
      */
-    static final long DEFAULT_DELIVERY_DELAY = 0;    
+    long DEFAULT_DELIVERY_DELAY = 0;
 
-
-    /** Gets the message ID.
-      *
-      * <P>The {@code JMSMessageID} header field contains a value that 
-      * uniquely identifies each message sent by a provider.
-      *  
-      * <P>When a message is sent, {@code JMSMessageID} can be ignored. 
-      * When the {@code send} or {@code publish} method returns, it 
-      * contains a provider-assigned value.
-      *
-      * <P>A {@code JMSMessageID} is a {@code String} value that 
-      * should function as a 
-      * unique key for identifying messages in a historical repository. 
-      * The exact scope of uniqueness is provider-defined. It should at 
-      * least cover all messages for a specific installation of a 
-      * provider, where an installation is some connected set of message 
-      * routers.
-      *
-      * <P>All {@code JMSMessageID} values must start with the prefix 
-      * {@code 'ID:'}. 
-      * Uniqueness of message ID values across different providers is 
-      * not required.
-      *
-      * <P>Since message IDs take some effort to create and increase a
-      * message's size, some JMS providers may be able to optimize message
-      * overhead if they are given a hint that the message ID is not used by
-      * an application. By calling the 
-      * {@code MessageProducer.setDisableMessageID} method, a JMS client 
-      * enables this potential optimization for all messages sent by that 
-      * message producer. If the JMS provider accepts this
-      * hint, these messages must have the message ID set to null; if the 
-      * provider ignores the hint, the message ID must be set to its normal 
-      * unique value.
-      *
-      * @return the message ID
-      *
-      * @exception JMSException if the JMS provider fails to get the message ID 
-      *                         due to some internal error.
-      * @see javax.jms.Message#setJMSMessageID(String)
-      * @see javax.jms.MessageProducer#setDisableMessageID(boolean)
-      */ 
- 
-    String
-    getJMSMessageID() throws JMSException;
-
-
-    /** Sets the message ID.
-      *  
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is sent. This message cannot be used by clients 
-     * to configure the message ID. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *
-      * @param id the ID of the message
-      *
-      * @exception JMSException if the JMS provider fails to set the message ID 
-      *                         due to some internal error.
-      *
-      * @see javax.jms.Message#getJMSMessageID()
-      */ 
-
-    void
-    setJMSMessageID(String id) throws JMSException;
-
-
-    /** Gets the message timestamp.
-      *  
-      * <P>The {@code JMSTimestamp} header field contains the time a 
-      * message was 
-      * handed off to a provider to be sent. It is not the time the 
-      * message was actually transmitted, because the actual send may occur 
-      * later due to transactions or other client-side queueing of messages.
-      *
-      * <P>When a message is sent, {@code JMSTimestamp} is ignored. When 
-      * the {@code send} or {@code publish}
-      * method returns, it contains a time value somewhere in the interval 
-      * between the call and the return. The value is in the format of a normal 
-      * millis time value in the Java programming language.
-      *
-      * <P>Since timestamps take some effort to create and increase a 
-      * message's size, some JMS providers may be able to optimize message 
-      * overhead if they are given a hint that the timestamp is not used by an 
-      * application. By calling the
-      * {@code MessageProducer.setDisableMessageTimestamp} method, a JMS 
-      * client enables this potential optimization for all messages sent by 
-      * that message producer. If the JMS provider accepts this
-      * hint, these messages must have the timestamp set to zero; if the 
-      * provider ignores the hint, the timestamp must be set to its normal 
-      * value.
-      *
-      * @return the message timestamp
-      *
-      * @exception JMSException if the JMS provider fails to get the timestamp
-      *                         due to some internal error.
-      *
-      * @see javax.jms.Message#setJMSTimestamp(long)
-      * @see javax.jms.MessageProducer#setDisableMessageTimestamp(boolean)
-      */
-
-    long
-    getJMSTimestamp() throws JMSException;
-
-
-    /** Sets the message timestamp.
-      *  
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is sent. This message cannot be used by clients 
-     * to configure the message timestamp. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *
-      * @param timestamp the timestamp for this message
-      *  
-      * @exception JMSException if the JMS provider fails to set the timestamp
-      *                         due to some internal error.
-      *
-      * @see javax.jms.Message#getJMSTimestamp()
-      */
-
-    void
-    setJMSTimestamp(long timestamp) throws JMSException;
-
-
-    /** Gets the correlation ID as an array of bytes for the message.
-      *  
-      * <P>The use of a {@code byte[]} value for 
-      * {@code JMSCorrelationID} is non-portable.
-      *
-      * @return the correlation ID of a message as an array of bytes
-      *
-      * @exception JMSException if the JMS provider fails to get the correlation
-      *                         ID due to some internal error.
-      *  
-      * @see javax.jms.Message#setJMSCorrelationID(String)
-      * @see javax.jms.Message#getJMSCorrelationID()
-      * @see javax.jms.Message#setJMSCorrelationIDAsBytes(byte[])
-      */
-
-    byte []
-    getJMSCorrelationIDAsBytes() throws JMSException;
-
-
-    /** Sets the correlation ID as an array of bytes for the message.
-      * 
-      * <P>The array is copied before the method returns, so
-      * future modifications to the array will not alter this message header.
-      *  
-      * <P>If a provider supports the native concept of correlation ID, a 
-      * JMS client may need to assign specific {@code JMSCorrelationID} 
-      * values to match those expected by native messaging clients. 
-      * JMS providers without native correlation ID values are not required to 
-      * support this method and its corresponding get method; their 
-      * implementation may throw a
-      * {@code java.lang.UnsupportedOperationException}. 
-      *
-      * <P>The use of a {@code byte[]} value for 
-      * {@code JMSCorrelationID} is non-portable.
-      *
-      * @param correlationID the correlation ID value as an array of bytes
-      *  
-      * @exception JMSException if the JMS provider fails to set the correlation
-      *                         ID due to some internal error.
-      *  
-      * @see javax.jms.Message#setJMSCorrelationID(String)
-      * @see javax.jms.Message#getJMSCorrelationID()
-      * @see javax.jms.Message#getJMSCorrelationIDAsBytes()
-      */
-
-    void
-    setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException;
-
-
-    /** Sets the correlation ID for the message.
-      *  
-      * <P>A client can use the {@code JMSCorrelationID} header field to 
-      * link one message with another. A typical use is to link a response 
-      * message with its request message.
-      *  
-      * <P>{@code JMSCorrelationID} can hold one of the following:
-      *    <UL>
-      *      <LI>A provider-specific message ID
-      *      <LI>An application-specific {@code String}
-      *      <LI>A provider-native {@code byte[]} value
-      *    </UL>
-      *  
-      * <P>Since each message sent by a JMS provider is assigned a message ID
-      * value, it is convenient to link messages via message ID. All message ID
-      * values must start with the {@code 'ID:'} prefix.
-      *  
-      * <P>In some cases, an application (made up of several clients) needs to
-      * use an application-specific value for linking messages. For instance,
-      * an application may use {@code JMSCorrelationID} to hold a value 
-      * referencing some external information. Application-specified values 
-      * must not start with the {@code 'ID:'} prefix; this is reserved for 
-      * provider-generated message ID values.
-      *  
-      * <P>If a provider supports the native concept of correlation ID, a JMS
-      * client may need to assign specific {@code JMSCorrelationID} values 
-      * to match those expected by clients that do not use the JMS API. A 
-      * {@code byte[]} value is used for this
-      * purpose. JMS providers without native correlation ID values are not
-      * required to support {@code byte[]} values. The use of a 
-      * {@code byte[]} value for {@code JMSCorrelationID} is 
-      * non-portable.
-      *  
-      * @param correlationID the message ID of a message being referred to
-      *  
-      * @exception JMSException if the JMS provider fails to set the correlation
-      *                         ID due to some internal error.
-      *  
-      * @see javax.jms.Message#getJMSCorrelationID()
-      * @see javax.jms.Message#getJMSCorrelationIDAsBytes()
-      * @see javax.jms.Message#setJMSCorrelationIDAsBytes(byte[])
-      */ 
-
-    void
-    setJMSCorrelationID(String correlationID) throws JMSException;
-
-
-    /** Gets the correlation ID for the message.
-      *  
-      * <P>This method is used to return correlation ID values that are 
-      * either provider-specific message IDs or application-specific 
-      * {@code String} values.
-      *
-      * @return the correlation ID of a message as a {@code String}
-      *
-      * @exception JMSException if the JMS provider fails to get the correlation
-      *                         ID due to some internal error.
-      *
-      * @see javax.jms.Message#setJMSCorrelationID(String)
-      * @see javax.jms.Message#getJMSCorrelationIDAsBytes()
-      * @see javax.jms.Message#setJMSCorrelationIDAsBytes(byte[])
-      */ 
- 
-    String
-    getJMSCorrelationID() throws JMSException;
-
-
-    /** Gets the {@code Destination} object to which a reply to this 
-      * message should be sent.
-      *  
-      * @return {@code Destination} to which to send a response to this 
-      *         message
-      *
-      * @exception JMSException if the JMS provider fails to get the  
-      *                         {@code JMSReplyTo} destination due to some 
-      *                         internal error.
-      *
-      * @see javax.jms.Message#setJMSReplyTo(Destination)
-      */ 
- 
-    Destination
-    getJMSReplyTo() throws JMSException;
-
-
-    /** Sets the {@code Destination} object to which a reply to this 
-      * message should be sent.
-      *  
-      * <P>The {@code JMSReplyTo} header field contains the destination 
-      * where a reply 
-      * to the current message should be sent. If it is null, no reply is 
-      * expected. The destination may be either a {@code Queue} object or
-      * a {@code Topic} object.
-      *
-      * <P>Messages sent with a null {@code JMSReplyTo} value may be a 
-      * notification of some event, or they may just be some data the sender 
-      * thinks is of interest.
-      *
-      * <P>Messages with a {@code JMSReplyTo} value typically expect a 
-      * response. A response is optional; it is up to the client to decide.  
-      * These messages are called requests. A message sent in response to a 
-      * request is called a reply.
-      *
-      * <P>In some cases a client may wish to match a request it sent earlier 
-      * with a reply it has just received. The client can use the 
-      * {@code JMSCorrelationID} header field for this purpose.
-      *
-      * @param replyTo {@code Destination} to which to send a response to 
-      *                this message
-      *
-      * @exception JMSException if the JMS provider fails to set the  
-      *                         {@code JMSReplyTo} destination due to some 
-      *                         internal error.
-      *
-      * @see javax.jms.Message#getJMSReplyTo()
-      */ 
-
-    void
-    setJMSReplyTo(Destination replyTo) throws JMSException;
-
-
-    /** Gets the {@code Destination} object for this message.
-      *  
-      * <P>The {@code JMSDestination} header field contains the 
-      * destination to which the message is being sent.
-      *  
-      * <P>When a message is sent, this field is ignored. After completion
-      * of the {@code send} or {@code publish} method, the field 
-      * holds the destination specified by the method.
-      *  
-      * <P>When a message is received, its {@code JMSDestination} value 
-      * must be equivalent to the value assigned when it was sent.
-      *
-      * @return the destination of this message
-      *  
-      * @exception JMSException if the JMS provider fails to get the destination
-      *                         due to some internal error.
-      *  
-      * @see javax.jms.Message#setJMSDestination(Destination)
-      */ 
-
-    Destination
-    getJMSDestination() throws JMSException;
-
-
-    /** Sets the {@code Destination} object for this message.
-      *  
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is sent. This message cannot be used by clients 
-     * to configure the destination of the message. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *
-      * @param destination the destination for this message
-      *  
-      * @exception JMSException if the JMS provider fails to set the destination
-      *                         due to some internal error.
-      *  
-      * @see javax.jms.Message#getJMSDestination()
-      */ 
-
-    void
-    setJMSDestination(Destination destination) throws JMSException;
-
-
-    /** Gets the {@code DeliveryMode} value specified for this message.
-      *  
-      * @return the delivery mode for this message
-      *  
-      * @exception JMSException if the JMS provider fails to get the 
-      *                         delivery mode due to some internal error.
-      *  
-      * @see javax.jms.Message#setJMSDeliveryMode(int)
-      * @see javax.jms.DeliveryMode
-      */ 
- 
-    int
-    getJMSDeliveryMode() throws JMSException;
- 
- 
-    /** Sets the {@code DeliveryMode} value for this message.
-      *  
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is sent. This message cannot be used by clients 
-     * to configure the delivery mode of the message. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *
-      * @param deliveryMode the delivery mode for this message
-      *  
-      * @exception JMSException if the JMS provider fails to set the 
-      *                         delivery mode due to some internal error.
-      *  
-      * @see javax.jms.Message#getJMSDeliveryMode()
-      * @see javax.jms.DeliveryMode
-      */ 
- 
-    void 
-    setJMSDeliveryMode(int deliveryMode) throws JMSException;
-
-
-    /** Gets an indication of whether this message is being redelivered.
-      *
-      * <P>If a client receives a message with the {@code JMSRedelivered} 
-      * field set,
-      * it is likely, but not guaranteed, that this message was delivered
-      * earlier but that its receipt was not acknowledged
-      * at that time.
-      *
-      * @return true if this message is being redelivered
-      *  
-      * @exception JMSException if the JMS provider fails to get the redelivered
-      *                         state due to some internal error.
-      *
-      * @see javax.jms.Message#setJMSRedelivered(boolean)
-      */ 
- 
-    boolean
-    getJMSRedelivered() throws JMSException;
- 
- 
-    /** Specifies whether this message is being redelivered.
-      *  
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is delivered. This message cannot be used by clients 
-     * to configure the redelivered status of the message. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *
-      * @param redelivered an indication of whether this message is being
-      * redelivered
-      *  
-      * @exception JMSException if the JMS provider fails to set the redelivered
-      *                         state due to some internal error.
-      *
-      * @see javax.jms.Message#getJMSRedelivered()
-      */ 
- 
-    void
-    setJMSRedelivered(boolean redelivered) throws JMSException;
-
-
-    /** Gets the message type identifier supplied by the client when the
-      * message was sent.
-      *
-      * @return the message type
-      *  
-      * @exception JMSException if the JMS provider fails to get the message 
-      *                         type due to some internal error.
-      *
-      * @see javax.jms.Message#setJMSType(String)
-      */
-       
-    String
-    getJMSType() throws JMSException;
-
-
-    /** Sets the message type.
-      *
-      * <P>Some JMS providers use a message repository that contains the 
-      * definitions of messages sent by applications. The {@code JMSType} 
-      * header field may reference a message's definition in the provider's
-      * repository.
-      *
-      * <P>The JMS API does not define a standard message definition repository,
-      * nor does it define a naming policy for the definitions it contains. 
-      *
-      * <P>Some messaging systems require that a message type definition for 
-      * each application message be created and that each message specify its 
-      * type. In order to work with such JMS providers, JMS clients should 
-      * assign a value to {@code JMSType}, whether the application makes 
-      * use of it or not. This ensures that the field is properly set for those 
-      * providers that require it.
-      *
-      * <P>To ensure portability, JMS clients should use symbolic values for 
-      * {@code JMSType} that can be configured at installation time to the 
-      * values defined in the current provider's message repository. If string 
-      * literals are used, they may not be valid type names for some JMS 
-      * providers.
-      *
-      * @param type the message type
-      *  
-      * @exception JMSException if the JMS provider fails to set the message 
-      *                         type due to some internal error.
-      *
-      * @see javax.jms.Message#getJMSType()
-      */
-
-    void 
-    setJMSType(String type) throws JMSException;
-
-
-    /** Gets the message's expiration time.
-      *  
-      * <P>When a message is sent, the {@code JMSExpiration} header field 
-      * is left unassigned. After completion of the {@code send} or 
-      * {@code publish} method, it holds the expiration time of the
-      * message. This is the the difference, measured in milliseconds, 
-      * between the expiration time and midnight, January 1, 1970 UTC.
-      *
-      * <P>If the time-to-live is specified as zero, {@code JMSExpiration} 
-      * is set to zero to indicate that the message does not expire.
-      *
-      * <P>When a message's expiration time is reached, a provider should
-      * discard it. The JMS API does not define any form of notification of 
-      * message expiration.
-      *
-      * <P>Clients should not receive messages that have expired; however,
-      * the JMS API does not guarantee that this will not happen.
-      *
-      * @return the message's expiration time value
-      *  
-      * @exception JMSException if the JMS provider fails to get the message 
-      *                         expiration due to some internal error.
-      *
-      * @see javax.jms.Message#setJMSExpiration(long)
-      */ 
- 
-    long
-    getJMSExpiration() throws JMSException;
- 
- 
-    /** Sets the message's expiration value.
-      *
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is sent. This message cannot be used by clients 
-     * to configure the expiration time of the message. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *  
-      * @param expiration the message's expiration time
-      *  
-      * @exception JMSException if the JMS provider fails to set the message 
-      *                         expiration due to some internal error.
-      *
-      * @see javax.jms.Message#getJMSExpiration() 
-      */
- 
-    void
-    setJMSExpiration(long expiration) throws JMSException;
-    
     /**
-	 * Gets the message's delivery time value.
-	 * 
-	 * <P>
-	 * When a message is sent, the {@code JMSDeliveryTime} header field is
-	 * left unassigned. After completion of the {@code send} or
-	 * {@code publish} method, it holds the delivery time of the message.
-	 * This is the the difference, measured in milliseconds, 
-     * between the delivery time and midnight, January 1, 1970 UTC.
-	 * <p>
-	 * A message's delivery time is the earliest time when a JMS provider may
-	 * deliver the message to a consumer. The provider must not deliver messages
-	 * before the delivery time has been reached.
-	 * 
-	 * @return the message's delivery time value
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the delivery time due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.Message#setJMSDeliveryTime(long)
-	 * 
-	 * @since JMS 2.0
-	 */ 
-   long getJMSDeliveryTime() throws JMSException;
-
-   	/**
-	 * Sets the message's delivery time value.
-	 * <P>
-	 * This method is for use by JMS providers only to set this field when a
-	 * message is sent. This message cannot be used by clients to configure the
-	 * delivery time of the message. This method is public to allow a JMS
-	 * provider to set this field when sending a message whose implementation is
-	 * not its own.
-	 * 
-	 * @param deliveryTime
-	 *            the message's delivery time value
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set the delivery time due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.Message#getJMSDeliveryTime()
-	 * 
-	 * @since JMS 2.0
-	 */ 
-   void setJMSDeliveryTime(long deliveryTime) throws JMSException;    
-
-
-    /** Gets the message priority level.
-      *  
-      * <P>The JMS API defines ten levels of priority value, with 0 as the 
-      * lowest
-      * priority and 9 as the highest. In addition, clients should consider
-      * priorities 0-4 as gradations of normal priority and priorities 5-9
-      * as gradations of expedited priority.
-      *  
-      * <P>The JMS API does not require that a provider strictly implement 
-      * priority 
-      * ordering of messages; however, it should do its best to deliver 
-      * expedited messages ahead of normal messages.
-      *  
-      * @return the default message priority
-      *  
-      * @exception JMSException if the JMS provider fails to get the message 
-      *                         priority due to some internal error.
-      *
-      * @see javax.jms.Message#setJMSPriority(int) 
-      */ 
-
-    int
-    getJMSPriority() throws JMSException;
-
-
-    /** Sets the priority level for this message.
-      *  
-     * <P>This method is for use by JMS providers only to set this field 
-     * when a message is sent. This message cannot be used by clients 
-     * to configure the priority level of the message. This method is public
-     * to allow a JMS provider to set this field when sending a message
-     * whose implementation is not its own.
-      *
-      * @param priority the priority of this message
-      *  
-      * @exception JMSException if the JMS provider fails to set the message 
-      *                         priority due to some internal error.
-      *
-      * @see javax.jms.Message#getJMSPriority() 
-      */ 
-
-    void
-    setJMSPriority(int priority) throws JMSException;
-
-
-    /** Clears a message's properties.
-      *
-      * <P>The message's header fields and body are not cleared.
-      *
-      * @exception JMSException if the JMS provider fails to clear the message 
-      *                         properties due to some internal error.
-      */ 
-
-    void
-    clearProperties() throws JMSException;
-
-
-    /** Indicates whether a property value exists.
-      *
-      * @param name the name of the property to test
-      *
-      * @return true if the property exists
-      *  
-      * @exception JMSException if the JMS provider fails to determine if the 
-      *                         property exists due to some internal error.
-      */
-
-    boolean
-    propertyExists(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code boolean} property with the  
-      * specified name.
-      *  
-      * @param name the name of the {@code boolean} property
-      *  
-      * @return the {@code boolean} property value for the specified name
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid. 
-      */ 
-
-    boolean
-    getBooleanProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code byte} property with the specified 
-      * name.
-      *  
-      * @param name the name of the {@code byte} property
-      *  
-      * @return the {@code byte} property value for the specified name
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid. 
-      */ 
-
-    byte
-    getByteProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code short} property with the specified 
-      * name.
-      *
-      * @param name the name of the {@code short} property
-      *
-      * @return the {@code short} property value for the specified name
-      *
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */
-   
-    short
-    getShortProperty(String name) throws JMSException;
- 
- 
-    /** Returns the value of the {@code int} property with the specified 
-      * name.
-      *  
-      * @param name the name of the {@code int} property
-      *  
-      * @return the {@code int} property value for the specified name
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */ 
-
-    int
-    getIntProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code long} property with the specified 
-      * name.
-      *  
-      * @param name the name of the {@code long} property
-      *  
-      * @return the {@code long} property value for the specified name
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */ 
-
-    long
-    getLongProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code float} property with the specified 
-      * name.
-      *  
-      * @param name the name of the {@code float} property
-      *  
-      * @return the {@code float} property value for the specified name
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */ 
-
-    float
-    getFloatProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code double} property with the specified
-      * name.
-      *  
-      * @param name the name of the {@code double} property
-      *  
-      * @return the {@code double} property value for the specified name
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */ 
-
-    double
-    getDoubleProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the {@code String} property with the specified
-      * name.
-      *  
-      * @param name the name of the {@code String} property
-      *  
-      * @return the {@code String} property value for the specified name;
-      * if there is no property by this name, a null value is returned
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      * @exception MessageFormatException if this type conversion is invalid.
-      */ 
-
-    String
-    getStringProperty(String name) throws JMSException;
-
-
-    /** Returns the value of the Java object property with the specified name.
-      *  
-      * <P>This method can be used to return, in objectified format,
-      * an object that has been stored as a property in the message with the 
-      * equivalent <CODE>setObjectProperty</CODE> method call, or its equivalent
-      * primitive <CODE>set<I>type</I>Property</CODE> method.
-      *  
-      * @param name the name of the Java object property
-      *  
-      * @return the Java object property value with the specified name, in 
-      * objectified format (for example, if the property was set as an 
-      * {@code int}, an {@code Integer} is 
-      * returned); if there is no property by this name, a null value 
-      * is returned
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                         value due to some internal error.
-      */ 
-
-    Object
-    getObjectProperty(String name) throws JMSException;
-
-
-    /** Returns an {@code Enumeration} of all the property names.
-      *
-      * <P>Note that JMS standard header fields are not considered
-      * properties and are not returned in this enumeration.
-      *  
-      * @return an enumeration of all the names of property values
-      *  
-      * @exception JMSException if the JMS provider fails to get the property
-      *                          names due to some internal error.
-      */ 
-     
-    Enumeration
-    getPropertyNames() throws JMSException;
-
-
-    /** Sets a {@code boolean} property value with the specified name into 
-      * the message.
-      *
-      * @param name the name of the {@code boolean} property
-      * @param value the {@code boolean} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setBooleanProperty(String name, boolean value)
-                        throws JMSException;
-
-
-    /** Sets a {@code byte} property value with the specified name into 
-      * the message.
-      *  
-      * @param name the name of the {@code byte} property
-      * @param value the {@code byte} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setByteProperty(String name, byte value)
-                        throws JMSException;
-
-
-    /** Sets a {@code short} property value with the specified name into
-      * the message.
-      *  
-      * @param name the name of the {@code short} property
-      * @param value the {@code short} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setShortProperty(String name, short value)
-                        throws JMSException;
-
-
-    /** Sets an {@code int} property value with the specified name into
-      * the message.
-      *  
-      * @param name the name of the {@code int} property
-      * @param value the {@code int} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setIntProperty(String name, int value)
-                        throws JMSException;
-
-
-    /** Sets a {@code long} property value with the specified name into 
-      * the message.
-      *  
-      * @param name the name of the {@code long} property
-      * @param value the {@code long} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setLongProperty(String name, long value)
-                        throws JMSException;
-
-
-    /** Sets a {@code float} property value with the specified name into 
-      * the message.
-      *  
-      * @param name the name of the {@code float} property
-      * @param value the {@code float} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setFloatProperty(String name, float value)
-                        throws JMSException;
-
-
-    /** Sets a {@code double} property value with the specified name into 
-      * the message.
-      *  
-      * @param name the name of the {@code double} property
-      * @param value the {@code double} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setDoubleProperty(String name, double value)
-                        throws JMSException;
-
-
-    /** Sets a {@code String} property value with the specified name into 
-      * the message.
-      *
-      * @param name the name of the {@code String} property
-      * @param value the {@code String} property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setStringProperty(String name, String value)
-                        throws JMSException;
-
-
-    /** Sets a Java object property value with the specified name into the 
-      * message.
-      *  
-      * <P>Note that this method works only for the objectified primitive
-      * object types ({@code Integer}, {@code Double}, 
-      * {@code Long} ...) and {@code String} objects.
-      *  
-      * @param name the name of the Java object property
-      * @param value the Java object property value to set
-      *  
-      * @exception JMSException if the JMS provider fails to set the property
-      *                          due to some internal error.
-      * @exception IllegalArgumentException if the name is null or if the name is
-      *                          an empty string.
-      * @exception MessageFormatException if the object is invalid
-      * @exception MessageNotWriteableException if properties are read-only
-      */ 
-
-    void
-    setObjectProperty(String name, Object value)
-                        throws JMSException;
-
-
-    /** Acknowledges all consumed messages of the session of this consumed 
-      * message.
-      *  
-      * <P>All consumed JMS messages support the {@code acknowledge} 
-      * method for use when a client has specified that its JMS session's 
-      * consumed messages are to be explicitly acknowledged.  By invoking 
-      * {@code acknowledge} on a consumed message, a client acknowledges 
-      * all messages consumed by the session that the message was delivered to.
-      * 
-      * <P>Calls to {@code acknowledge} are ignored for both transacted 
-      * sessions and sessions specified to use implicit acknowledgement modes.
-      *
-      * <P>A client may individually acknowledge each message as it is consumed,
-      * or it may choose to acknowledge messages as an application-defined group 
-      * (which is done by calling acknowledge on the last received message of the group,
-      *  thereby acknowledging all messages consumed by the session.)
-      *
-      * <P>Messages that have been received but not acknowledged may be 
-      * redelivered.
-      *
-      * @exception JMSException if the JMS provider fails to acknowledge the
-      *                         messages due to some internal error.
-      * @exception IllegalStateException if this method is called on a closed
-      *                         session.
-      *
-      * @see javax.jms.Session#CLIENT_ACKNOWLEDGE
-      */ 
-
-    void
-    acknowledge() throws JMSException;
-
-
-    /** Clears out the message body. Clearing a message's body does not clear 
-      * its header values or property entries.
-      *
-      * <P>If this message body was read-only, calling this method leaves
-      * the message body in the same state as an empty body in a newly
-      * created message.
-      *
-      * @exception JMSException if the JMS provider fails to clear the message
-      *                         body due to some internal error.
-      */
-
-    void
-    clearBody() throws JMSException;
-    
-	/**
-	 * Returns the message body as an object of the specified type. 
-	 * This method may be called on any type of message except for
-	 * <tt>StreamMessage</tt>. The message
-	 * body must be capable of being assigned to the specified type. This means
-	 * that the specified class or interface must be either the same as, or a
-	 * superclass or superinterface of, the class of the message body. 
-	 * If the message has no body then any type may be specified and null is returned.
-	 * <p>
-	 * 
-	 * @param c
-	 *            The type to which the message body will be assigned. <br>
-	 *            If the message is a {@code TextMessage} then this parameter must 
-	 *            be set to {@code String.class} or another type to which
-	 *            a {@code String} is assignable. <br>
-	 *            If the message is a {@code ObjectMessage} then parameter must 
-	 *            must be set to {@code java.io.Serializable.class} or
-	 *            another type to which the body is assignable. <br>
-	 *            If the message is a {@code MapMessage} then this parameter must 
-	 *            be set to {@code java.util.Map.class} (or {@code java.lang.Object.class}). <br>
-	 *            If the message is a {@code BytesMessage} then this parameter must 
-	 *            be set to {@code byte[].class} (or {@code java.lang.Object.class}). This method
-	 *            will reset the {@code BytesMessage} before and after use.<br>
-	 *            If the message is a 
-	 *            {@code TextMessage}, {@code ObjectMessage}, {@code MapMessage} 
-	 *            or {@code BytesMessage} and the message has no body, 
-	 *            then the above does not apply and this parameter may be set to any type;
-	 *            the returned value will always be null.<br>
-	 *            If the message is a {@code Message} (but not one of its subtypes)
-	 *            then this parameter may be set to any type;
-	 *            the returned value will always be null.
-	 * 
-	 * @return the message body
-	 * 
-	 * @exception MessageFormatException
-	 * 				  <ul>
-	 *                <li>if the message is a {@code StreamMessage}
-	 *                <li> if the message body cannot be assigned to 
-	 *                the specified type 
-	 *                <li> if the message is an {@code ObjectMessage} and object
-	 *                deserialization fails.
-	 *                </ul>
-	 *                
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the message body due to
-	 *                some internal error.
-	 *                
-	 * @since JMS 2.0                
-	 */
-	<T> T getBody(Class<T> c) throws JMSException;
-
-	/**
-	 * Returns whether the message body is capable of being assigned to the
-	 * specified type. If this method returns true then a subsequent call to the
-	 * method {@code getBody} on the same message with the same type argument would not throw a
-	 * MessageFormatException.
-	 * <p>
-	 * If the message is a {@code StreamMessage} then false is always returned. 
-	 * If the message is a {@code ObjectMessage} and object deserialization
-	 * fails then false is returned. If the message has no body then any type may be specified and true is
-	 * returned.
-	 * 
-	 * @param c
-	 *            The specified type <br>
-	 *            If the message is a {@code TextMessage} then this method will
-	 *            only return true if this parameter is set to
-	 *            {@code String.class} or another type to which a {@code String}
-	 *            is assignable. <br>
-	 *            If the message is a {@code ObjectMessage} then this
-	 *            method will only return true if this parameter is set to
-	 *            {@code java.io.Serializable.class} or another class to
-	 *            which the body is assignable. <br>
-	 *            If the message is a {@code MapMessage} then this method
-	 *            will only return true if this parameter is set to
-	 *            {@code java.util.Map.class} (or {@code java.lang.Object.class}). <br>
-	 *            If the message is a {@code BytesMessage} then this this
-	 *            method will only return true if this parameter is set to
-	 *            {@code byte[].class} (or {@code java.lang.Object.class}). <br>
-	 *            If the message is a 
-	 *            {@code TextMessage}, {@code ObjectMessage}, {@code MapMessage} 
-	 *            or {@code BytesMessage} and the message has no body, 
-	 *            then the above does not apply and this method will return true
-	 *            irrespective of the value of this parameter.<br>
-	 *            If the message is a 
-	 *            {@code Message} (but not one of its subtypes)
-	 *            then this method will return true
-	 *            irrespective of the value of this parameter.          
-	 * 
-	 * @return whether the message body is capable of being assigned to the
-	 *         specified type
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to return a value due to some
-	 *                internal error.
-	 */
-	boolean isBodyAssignableTo(Class c) throws JMSException;    
+     * Gets the message ID.
+     *
+     * <p>
+     * The {@code JMSMessageID} header field contains a value that uniquely identifies each message sent by a provider.
+     *
+     * <p>
+     * When a message is sent, {@code JMSMessageID} can be ignored. When the {@code send} or {@code publish} method returns,
+     * it contains a provider-assigned value.
+     *
+     * <p>
+     * A {@code JMSMessageID} is a {@code String} value that should function as a unique key for identifying messages in a
+     * historical repository. The exact scope of uniqueness is provider-defined. It should at least cover all messages for a
+     * specific installation of a provider, where an installation is some connected set of message routers.
+     *
+     * <p>
+     * All {@code JMSMessageID} values must start with the prefix {@code 'ID:'}. Uniqueness of message ID values across
+     * different providers is not required.
+     *
+     * <p>
+     * Since message IDs take some effort to create and increase a message's size, some JMS providers may be able to
+     * optimize message overhead if they are given a hint that the message ID is not used by an application. By calling the
+     * {@code MessageProducer.setDisableMessageID} method, a JMS client enables this potential optimization for all messages
+     * sent by that message producer. If the JMS provider accepts this hint, these messages must have the message ID set to
+     * null; if the provider ignores the hint, the message ID must be set to its normal unique value.
+     *
+     * @return the message ID
+     *
+     * @exception JMSException if the JMS provider fails to get the message ID due to some internal error.
+     * @see javax.jms.Message#setJMSMessageID(String)
+     * @see javax.jms.MessageProducer#setDisableMessageID(boolean)
+     */
+    String getJMSMessageID() throws JMSException;
+
+    /**
+     * Sets the message ID.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the message ID. This method is public to allow a JMS provider to set this field when sending a
+     * message whose implementation is not its own.
+     *
+     * @param id the ID of the message
+     *
+     * @exception JMSException if the JMS provider fails to set the message ID due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSMessageID()
+     */
+    void setJMSMessageID(String id) throws JMSException;
+
+    /**
+     * Gets the message timestamp.
+     *
+     * <p>
+     * The {@code JMSTimestamp} header field contains the time a message was handed off to a provider to be sent. It is not
+     * the time the message was actually transmitted, because the actual send may occur later due to transactions or other
+     * client-side queueing of messages.
+     *
+     * <p>
+     * When a message is sent, {@code JMSTimestamp} is ignored. When the {@code send} or {@code publish} method returns, it
+     * contains a time value somewhere in the interval between the call and the return. The value is in the format of a
+     * normal millis time value in the Java programming language.
+     *
+     * <p>
+     * Since timestamps take some effort to create and increase a message's size, some JMS providers may be able to optimize
+     * message overhead if they are given a hint that the timestamp is not used by an application. By calling the
+     * {@code MessageProducer.setDisableMessageTimestamp} method, a JMS client enables this potential optimization for all
+     * messages sent by that message producer. If the JMS provider accepts this hint, these messages must have the timestamp
+     * set to zero; if the provider ignores the hint, the timestamp must be set to its normal value.
+     *
+     * @return the message timestamp
+     *
+     * @exception JMSException if the JMS provider fails to get the timestamp due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSTimestamp(long)
+     * @see javax.jms.MessageProducer#setDisableMessageTimestamp(boolean)
+     */
+    long getJMSTimestamp() throws JMSException;
+
+    /**
+     * Sets the message timestamp.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the message timestamp. This method is public to allow a JMS provider to set this field when
+     * sending a message whose implementation is not its own.
+     *
+     * @param timestamp the timestamp for this message
+     *
+     * @exception JMSException if the JMS provider fails to set the timestamp due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSTimestamp()
+     */
+    void setJMSTimestamp(long timestamp) throws JMSException;
+
+    /**
+     * Gets the correlation ID as an array of bytes for the message.
+     *
+     * <p>
+     * The use of a {@code byte[]} value for {@code JMSCorrelationID} is non-portable.
+     *
+     * @return the correlation ID of a message as an array of bytes
+     *
+     * @exception JMSException if the JMS provider fails to get the correlation ID due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSCorrelationID(String)
+     * @see javax.jms.Message#getJMSCorrelationID()
+     * @see javax.jms.Message#setJMSCorrelationIDAsBytes(byte[])
+     */
+    byte[] getJMSCorrelationIDAsBytes() throws JMSException;
+
+    /**
+     * Sets the correlation ID as an array of bytes for the message.
+     *
+     * <p>
+     * The array is copied before the method returns, so future modifications to the array will not alter this message
+     * header.
+     *
+     * <p>
+     * If a provider supports the native concept of correlation ID, a JMS client may need to assign specific
+     * {@code JMSCorrelationID} values to match those expected by native messaging clients. JMS providers without native
+     * correlation ID values are not required to support this method and its corresponding get method; their implementation
+     * may throw a {@code java.lang.UnsupportedOperationException}.
+     *
+     * <p>
+     * The use of a {@code byte[]} value for {@code JMSCorrelationID} is non-portable.
+     *
+     * @param correlationID the correlation ID value as an array of bytes
+     *
+     * @exception JMSException if the JMS provider fails to set the correlation ID due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSCorrelationID(String)
+     * @see javax.jms.Message#getJMSCorrelationID()
+     * @see javax.jms.Message#getJMSCorrelationIDAsBytes()
+     */
+    void setJMSCorrelationIDAsBytes(byte[] correlationID) throws JMSException;
+
+    /**
+     * Sets the correlation ID for the message.
+     *
+     * <p>
+     * A client can use the {@code JMSCorrelationID} header field to link one message with another. A typical use is to link
+     * a response message with its request message.
+     *
+     * <p>
+     * {@code JMSCorrelationID} can hold one of the following:
+     * <ul>
+     * <li>A provider-specific message ID
+     * <li>An application-specific {@code String}
+     * <li>A provider-native {@code byte[]} value
+     * </ul>
+     *
+     * <p>
+     * Since each message sent by a JMS provider is assigned a message ID value, it is convenient to link messages via
+     * message ID. All message ID values must start with the {@code 'ID:'} prefix.
+     *
+     * <p>
+     * In some cases, an application (made up of several clients) needs to use an application-specific value for linking
+     * messages. For instance, an application may use {@code JMSCorrelationID} to hold a value referencing some external
+     * information. Application-specified values must not start with the {@code 'ID:'} prefix; this is reserved for
+     * provider-generated message ID values.
+     *
+     * <p>
+     * If a provider supports the native concept of correlation ID, a JMS client may need to assign specific
+     * {@code JMSCorrelationID} values to match those expected by clients that do not use the JMS API. A {@code byte[]}
+     * value is used for this purpose. JMS providers without native correlation ID values are not required to support
+     * {@code byte[]} values. The use of a {@code byte[]} value for {@code JMSCorrelationID} is non-portable.
+     *
+     * @param correlationID the message ID of a message being referred to
+     *
+     * @exception JMSException if the JMS provider fails to set the correlation ID due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSCorrelationID()
+     * @see javax.jms.Message#getJMSCorrelationIDAsBytes()
+     * @see javax.jms.Message#setJMSCorrelationIDAsBytes(byte[])
+     */
+    void setJMSCorrelationID(String correlationID) throws JMSException;
+
+    /**
+     * Gets the correlation ID for the message.
+     *
+     * <p>
+     * This method is used to return correlation ID values that are either provider-specific message IDs or
+     * application-specific {@code String} values.
+     *
+     * @return the correlation ID of a message as a {@code String}
+     *
+     * @exception JMSException if the JMS provider fails to get the correlation ID due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSCorrelationID(String)
+     * @see javax.jms.Message#getJMSCorrelationIDAsBytes()
+     * @see javax.jms.Message#setJMSCorrelationIDAsBytes(byte[])
+     */
+    String getJMSCorrelationID() throws JMSException;
+
+    /**
+     * Gets the {@code Destination} object to which a reply to this message should be sent.
+     *
+     * @return {@code Destination} to which to send a response to this message
+     *
+     * @exception JMSException if the JMS provider fails to get the {@code JMSReplyTo} destination due to some internal
+     * error.
+     *
+     * @see javax.jms.Message#setJMSReplyTo(Destination)
+     */
+    Destination getJMSReplyTo() throws JMSException;
+
+    /**
+     * Sets the {@code Destination} object to which a reply to this message should be sent.
+     *
+     * <p>
+     * The {@code JMSReplyTo} header field contains the destination where a reply to the current message should be sent. If
+     * it is null, no reply is expected. The destination may be either a {@code Queue} object or a {@code Topic} object.
+     *
+     * <p>
+     * Messages sent with a null {@code JMSReplyTo} value may be a notification of some event, or they may just be some data
+     * the sender thinks is of interest.
+     *
+     * <p>
+     * Messages with a {@code JMSReplyTo} value typically expect a response. A response is optional; it is up to the client
+     * to decide. These messages are called requests. A message sent in response to a request is called a reply.
+     *
+     * <p>
+     * In some cases a client may wish to match a request it sent earlier with a reply it has just received. The client can
+     * use the {@code JMSCorrelationID} header field for this purpose.
+     *
+     * @param replyTo {@code Destination} to which to send a response to this message
+     *
+     * @exception JMSException if the JMS provider fails to set the {@code JMSReplyTo} destination due to some internal
+     * error.
+     *
+     * @see javax.jms.Message#getJMSReplyTo()
+     */
+    void setJMSReplyTo(Destination replyTo) throws JMSException;
+
+    /**
+     * Gets the {@code Destination} object for this message.
+     *
+     * <p>
+     * The {@code JMSDestination} header field contains the destination to which the message is being sent.
+     *
+     * <p>
+     * When a message is sent, this field is ignored. After completion of the {@code send} or {@code publish} method, the
+     * field holds the destination specified by the method.
+     *
+     * <p>
+     * When a message is received, its {@code JMSDestination} value must be equivalent to the value assigned when it was
+     * sent.
+     *
+     * @return the destination of this message
+     *
+     * @exception JMSException if the JMS provider fails to get the destination due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSDestination(Destination)
+     */
+    Destination getJMSDestination() throws JMSException;
+
+    /**
+     * Sets the {@code Destination} object for this message.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the destination of the message. This method is public to allow a JMS provider to set this field
+     * when sending a message whose implementation is not its own.
+     *
+     * @param destination the destination for this message
+     *
+     * @exception JMSException if the JMS provider fails to set the destination due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSDestination()
+     */
+    void setJMSDestination(Destination destination) throws JMSException;
+
+    /**
+     * Gets the {@code DeliveryMode} value specified for this message.
+     *
+     * @return the delivery mode for this message
+     *
+     * @exception JMSException if the JMS provider fails to get the delivery mode due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSDeliveryMode(int)
+     * @see javax.jms.DeliveryMode
+     */
+    int getJMSDeliveryMode() throws JMSException;
+
+    /**
+     * Sets the {@code DeliveryMode} value for this message.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the delivery mode of the message. This method is public to allow a JMS provider to set this
+     * field when sending a message whose implementation is not its own.
+     *
+     * @param deliveryMode the delivery mode for this message
+     *
+     * @exception JMSException if the JMS provider fails to set the delivery mode due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSDeliveryMode()
+     * @see javax.jms.DeliveryMode
+     */
+    void setJMSDeliveryMode(int deliveryMode) throws JMSException;
+
+    /**
+     * Gets an indication of whether this message is being redelivered.
+     *
+     * <p>
+     * If a client receives a message with the {@code JMSRedelivered} field set, it is likely, but not guaranteed, that this
+     * message was delivered earlier but that its receipt was not acknowledged at that time.
+     *
+     * @return true if this message is being redelivered
+     *
+     * @exception JMSException if the JMS provider fails to get the redelivered state due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSRedelivered(boolean)
+     */
+    boolean getJMSRedelivered() throws JMSException;
+
+    /**
+     * Specifies whether this message is being redelivered.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is delivered. This message cannot be
+     * used by clients to configure the redelivered status of the message. This method is public to allow a JMS provider to
+     * set this field when sending a message whose implementation is not its own.
+     *
+     * @param redelivered an indication of whether this message is being redelivered
+     *
+     * @exception JMSException if the JMS provider fails to set the redelivered state due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSRedelivered()
+     */
+    void setJMSRedelivered(boolean redelivered) throws JMSException;
+
+    /**
+     * Gets the message type identifier supplied by the client when the message was sent.
+     *
+     * @return the message type
+     *
+     * @exception JMSException if the JMS provider fails to get the message type due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSType(String)
+     */
+    String getJMSType() throws JMSException;
+
+    /**
+     * Sets the message type.
+     *
+     * <p>
+     * Some JMS providers use a message repository that contains the definitions of messages sent by applications. The
+     * {@code JMSType} header field may reference a message's definition in the provider's repository.
+     *
+     * <p>
+     * The JMS API does not define a standard message definition repository, nor does it define a naming policy for the
+     * definitions it contains.
+     *
+     * <p>
+     * Some messaging systems require that a message type definition for each application message be created and that each
+     * message specify its type. In order to work with such JMS providers, JMS clients should assign a value to
+     * {@code JMSType}, whether the application makes use of it or not. This ensures that the field is properly set for
+     * those providers that require it.
+     *
+     * <p>
+     * To ensure portability, JMS clients should use symbolic values for {@code JMSType} that can be configured at
+     * installation time to the values defined in the current provider's message repository. If string literals are used,
+     * they may not be valid type names for some JMS providers.
+     *
+     * @param type the message type
+     *
+     * @exception JMSException if the JMS provider fails to set the message type due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSType()
+     */
+    void setJMSType(String type) throws JMSException;
+
+    /**
+     * Gets the message's expiration time.
+     *
+     * <p>
+     * When a message is sent, the {@code JMSExpiration} header field is left unassigned. After completion of the
+     * {@code send} or {@code publish} method, it holds the expiration time of the message. This is the the difference,
+     * measured in milliseconds, between the expiration time and midnight, January 1, 1970 UTC.
+     *
+     * <p>
+     * If the time-to-live is specified as zero, {@code JMSExpiration} is set to zero to indicate that the message does not
+     * expire.
+     *
+     * <p>
+     * When a message's expiration time is reached, a provider should discard it. The JMS API does not define any form of
+     * notification of message expiration.
+     *
+     * <p>
+     * Clients should not receive messages that have expired; however, the JMS API does not guarantee that this will not
+     * happen.
+     *
+     * @return the message's expiration time value
+     *
+     * @exception JMSException if the JMS provider fails to get the message expiration due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSExpiration(long)
+     */
+    long getJMSExpiration() throws JMSException;
+
+    /**
+     * Sets the message's expiration value.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the expiration time of the message. This method is public to allow a JMS provider to set this
+     * field when sending a message whose implementation is not its own.
+     *
+     * @param expiration the message's expiration time
+     *
+     * @exception JMSException if the JMS provider fails to set the message expiration due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSExpiration()
+     */
+    void setJMSExpiration(long expiration) throws JMSException;
+
+    /**
+     * Gets the message's delivery time value.
+     *
+     * <p>
+     * When a message is sent, the {@code JMSDeliveryTime} header field is left unassigned. After completion of the
+     * {@code send} or {@code publish} method, it holds the delivery time of the message. This is the the difference,
+     * measured in milliseconds, between the delivery time and midnight, January 1, 1970 UTC.
+     *
+     * <p>
+     * A message's delivery time is the earliest time when a JMS provider may deliver the message to a consumer. The
+     * provider must not deliver messages before the delivery time has been reached.
+     *
+     * @return the message's delivery time value
+     *
+     * @exception JMSException if the JMS provider fails to get the delivery time due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSDeliveryTime(long)
+     *
+     * @since JMS 2.0
+     */
+    long getJMSDeliveryTime() throws JMSException;
+
+    /**
+     * Sets the message's delivery time value.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the delivery time of the message. This method is public to allow a JMS provider to set this
+     * field when sending a message whose implementation is not its own.
+     *
+     * @param deliveryTime the message's delivery time value
+     *
+     * @exception JMSException if the JMS provider fails to set the delivery time due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSDeliveryTime()
+     *
+     * @since JMS 2.0
+     */
+    void setJMSDeliveryTime(long deliveryTime) throws JMSException;
+
+    /**
+     * Gets the message priority level.
+     *
+     * <p>
+     * The JMS API defines ten levels of priority value, with 0 as the lowest priority and 9 as the highest. In addition,
+     * clients should consider priorities 0-4 as gradations of normal priority and priorities 5-9 as gradations of expedited
+     * priority.
+     *
+     * <p>
+     * The JMS API does not require that a provider strictly implement priority ordering of messages; however, it should do
+     * its best to deliver expedited messages ahead of normal messages.
+     *
+     * @return the default message priority
+     *
+     * @exception JMSException if the JMS provider fails to get the message priority due to some internal error.
+     *
+     * @see javax.jms.Message#setJMSPriority(int)
+     */
+    int getJMSPriority() throws JMSException;
+
+    /**
+     * Sets the priority level for this message.
+     *
+     * <p>
+     * This method is for use by JMS providers only to set this field when a message is sent. This message cannot be used by
+     * clients to configure the priority level of the message. This method is public to allow a JMS provider to set this
+     * field when sending a message whose implementation is not its own.
+     *
+     * @param priority the priority of this message
+     *
+     * @exception JMSException if the JMS provider fails to set the message priority due to some internal error.
+     *
+     * @see javax.jms.Message#getJMSPriority()
+     */
+    void setJMSPriority(int priority) throws JMSException;
+
+    /**
+     * Clears a message's properties.
+     *
+     * <p>
+     * The message's header fields and body are not cleared.
+     *
+     * @exception JMSException if the JMS provider fails to clear the message properties due to some internal error.
+     */
+    void clearProperties() throws JMSException;
+
+    /**
+     * Indicates whether a property value exists.
+     *
+     * @param name the name of the property to test
+     *
+     * @return true if the property exists
+     *
+     * @exception JMSException if the JMS provider fails to determine if the property exists due to some internal error.
+     */
+    boolean propertyExists(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code boolean} property with the specified name.
+     *
+     * @param name the name of the {@code boolean} property
+     *
+     * @return the {@code boolean} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    boolean getBooleanProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code byte} property with the specified name.
+     *
+     * @param name the name of the {@code byte} property
+     *
+     * @return the {@code byte} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    byte getByteProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code short} property with the specified name.
+     *
+     * @param name the name of the {@code short} property
+     *
+     * @return the {@code short} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    short getShortProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code int} property with the specified name.
+     *
+     * @param name the name of the {@code int} property
+     *
+     * @return the {@code int} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    int getIntProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code long} property with the specified name.
+     *
+     * @param name the name of the {@code long} property
+     *
+     * @return the {@code long} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    long getLongProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code float} property with the specified name.
+     *
+     * @param name the name of the {@code float} property
+     *
+     * @return the {@code float} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    float getFloatProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code double} property with the specified name.
+     *
+     * @param name the name of the {@code double} property
+     *
+     * @return the {@code double} property value for the specified name
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    double getDoubleProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the {@code String} property with the specified name.
+     *
+     * @param name the name of the {@code String} property
+     *
+     * @return the {@code String} property value for the specified name; if there is no property by this name, a null value
+     * is returned
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     * @exception MessageFormatException if this type conversion is invalid.
+     */
+    String getStringProperty(String name) throws JMSException;
+
+    /**
+     * Returns the value of the Java object property with the specified name.
+     *
+     * <p>
+     * This method can be used to return, in objectified format, an object that has been stored as a property in the message
+     * with the equivalent <code>setObjectProperty</code> method call, or its equivalent primitive
+     * <code>set<I>type</I>Property</code> method.
+     *
+     * @param name the name of the Java object property
+     *
+     * @return the Java object property value with the specified name, in objectified format (for example, if the property
+     * was set as an {@code int}, an {@code Integer} is returned); if there is no property by this name, a null value is
+     * returned
+     *
+     * @exception JMSException if the JMS provider fails to get the property value due to some internal error.
+     */
+    Object getObjectProperty(String name) throws JMSException;
+
+    /**
+     * Returns an {@code Enumeration} of all the property names.
+     *
+     * <p>
+     * Note that JMS standard header fields are not considered properties and are not returned in this enumeration.
+     *
+     * @return an enumeration of all the names of property values
+     *
+     * @exception JMSException if the JMS provider fails to get the property names due to some internal error.
+     */
+    Enumeration getPropertyNames() throws JMSException;
+
+    /**
+     * Sets a {@code boolean} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code boolean} property
+     * @param value the {@code boolean} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setBooleanProperty(String name, boolean value) throws JMSException;
+
+    /**
+     * Sets a {@code byte} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code byte} property
+     * @param value the {@code byte} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setByteProperty(String name, byte value) throws JMSException;
+
+    /**
+     * Sets a {@code short} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code short} property
+     * @param value the {@code short} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setShortProperty(String name, short value) throws JMSException;
+
+    /**
+     * Sets an {@code int} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code int} property
+     * @param value the {@code int} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setIntProperty(String name, int value) throws JMSException;
+
+    /**
+     * Sets a {@code long} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code long} property
+     * @param value the {@code long} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setLongProperty(String name, long value) throws JMSException;
+
+    /**
+     * Sets a {@code float} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code float} property
+     * @param value the {@code float} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setFloatProperty(String name, float value) throws JMSException;
+
+    /**
+     * Sets a {@code double} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code double} property
+     * @param value the {@code double} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setDoubleProperty(String name, double value) throws JMSException;
+
+    /**
+     * Sets a {@code String} property value with the specified name into the message.
+     *
+     * @param name the name of the {@code String} property
+     * @param value the {@code String} property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setStringProperty(String name, String value) throws JMSException;
+
+    /**
+     * Sets a Java object property value with the specified name into the message.
+     *
+     * <p>
+     * Note that this method works only for the objectified primitive object types ({@code Integer}, {@code Double},
+     * {@code Long} ...) and {@code String} objects.
+     *
+     * @param name the name of the Java object property
+     * @param value the Java object property value to set
+     *
+     * @exception JMSException if the JMS provider fails to set the property due to some internal error.
+     * @exception IllegalArgumentException if the name is null or if the name is an empty string.
+     * @exception MessageFormatException if the object is invalid
+     * @exception MessageNotWriteableException if properties are read-only
+     */
+    void setObjectProperty(String name, Object value) throws JMSException;
+
+    /**
+     * Acknowledges all consumed messages of the session of this consumed message.
+     *
+     * <p>
+     * All consumed JMS messages support the {@code acknowledge} method for use when a client has specified that its JMS
+     * session's consumed messages are to be explicitly acknowledged. By invoking {@code acknowledge} on a consumed message,
+     * a client acknowledges all messages consumed by the session that the message was delivered to.
+     *
+     * <p>
+     * Calls to {@code acknowledge} are ignored for both transacted sessions and sessions specified to use implicit
+     * acknowledgement modes.
+     *
+     * <p>
+     * A client may individually acknowledge each message as it is consumed, or it may choose to acknowledge messages as an
+     * application-defined group (which is done by calling acknowledge on the last received message of the group, thereby
+     * acknowledging all messages consumed by the session.)
+     *
+     * <p>
+     * Messages that have been received but not acknowledged may be redelivered.
+     *
+     * @exception JMSException if the JMS provider fails to acknowledge the messages due to some internal error.
+     * @exception IllegalStateException if this method is called on a closed session.
+     *
+     * @see javax.jms.Session#CLIENT_ACKNOWLEDGE
+     */
+    void acknowledge() throws JMSException;
+
+    /**
+     * Clears out the message body. Clearing a message's body does not clear its header values or property entries.
+     *
+     * <p>
+     * If this message body was read-only, calling this method leaves the message body in the same state as an empty body in
+     * a newly created message.
+     *
+     * @exception JMSException if the JMS provider fails to clear the message body due to some internal error.
+     */
+    void clearBody() throws JMSException;
+
+    /**
+     * Returns the message body as an object of the specified type. This method may be called on any type of message except
+     * for <tt>StreamMessage</tt>. The message body must be capable of being assigned to the specified type. This means that
+     * the specified class or interface must be either the same as, or a superclass or superinterface of, the class of the
+     * message body. If the message has no body then any type may be specified and null is returned.
+     * <p>
+     *
+     * @param <T> The type of the message body
+     * @param c The type to which the message body will be assigned. <br>
+     * If the message is a {@code TextMessage} then this parameter must be set to {@code String.class} or another type to
+     * which a {@code String} is assignable. <br>
+     * If the message is a {@code ObjectMessage} then parameter must must be set to {@code java.io.Serializable.class} or
+     * another type to which the body is assignable. <br>
+     * If the message is a {@code MapMessage} then this parameter must be set to {@code java.util.Map.class} (or
+     * {@code java.lang.Object.class}). <br>
+     * If the message is a {@code BytesMessage} then this parameter must be set to {@code byte[].class} (or
+     * {@code java.lang.Object.class}). This method will reset the {@code BytesMessage} before and after use.<br>
+     * If the message is a {@code TextMessage}, {@code ObjectMessage}, {@code MapMessage} or {@code BytesMessage} and the
+     * message has no body, then the above does not apply and this parameter may be set to any type; the returned value will
+     * always be null.<br>
+     * If the message is a {@code Message} (but not one of its subtypes) then this parameter may be set to any type; the
+     * returned value will always be null.
+     *
+     * @return the message body
+     *
+     * @exception MessageFormatException
+     * <ul>
+     * <li>if the message is a {@code StreamMessage}
+     * <li>if the message body cannot be assigned to the specified type
+     * <li>if the message is an {@code ObjectMessage} and object deserialization fails.
+     * </ul>
+     *
+     * @exception JMSException if the JMS provider fails to get the message body due to some internal error.
+     *
+     * @since JMS 2.0
+     */
+    <T> T getBody(Class<T> c) throws JMSException;
+
+    /**
+     * Returns whether the message body is capable of being assigned to the specified type. If this method returns true then
+     * a subsequent call to the method {@code getBody} on the same message with the same type argument would not throw a
+     * MessageFormatException.
+     * <p>
+     * If the message is a {@code StreamMessage} then false is always returned. If the message is a {@code ObjectMessage}
+     * and object deserialization fails then false is returned. If the message has no body then any type may be specified
+     * and true is returned.
+     *
+     * @param c The specified type <br>
+     * If the message is a {@code TextMessage} then this method will only return true if this parameter is set to
+     * {@code String.class} or another type to which a {@code String} is assignable. <br>
+     * If the message is a {@code ObjectMessage} then this method will only return true if this parameter is set to
+     * {@code java.io.Serializable.class} or another class to which the body is assignable. <br>
+     * If the message is a {@code MapMessage} then this method will only return true if this parameter is set to
+     * {@code java.util.Map.class} (or {@code java.lang.Object.class}). <br>
+     * If the message is a {@code BytesMessage} then this this method will only return true if this parameter is set to
+     * {@code byte[].class} (or {@code java.lang.Object.class}). <br>
+     * If the message is a {@code TextMessage}, {@code ObjectMessage}, {@code MapMessage} or {@code BytesMessage} and the
+     * message has no body, then the above does not apply and this method will return true irrespective of the value of this
+     * parameter.<br>
+     * If the message is a {@code Message} (but not one of its subtypes) then this method will return true irrespective of
+     * the value of this parameter.
+     *
+     * @return whether the message body is capable of being assigned to the specified type
+     *
+     * @exception JMSException if the JMS provider fails to return a value due to some internal error.
+     */
+    boolean isBodyAssignableTo(Class c) throws JMSException;
 }

--- a/src/main/java/javax/jms/MessageConsumer.java
+++ b/src/main/java/javax/jms/MessageConsumer.java
@@ -16,187 +16,170 @@
 
 package javax.jms;
 
-/** A client uses a {@code MessageConsumer} object to receive messages 
- * from a destination.  A {@code MessageConsumer} object is created by 
- * passing a {@code Destination} object to a message-consumer creation
- * method supplied by a session.
+/**
+ * A client uses a {@code MessageConsumer} object to receive messages from a destination. A {@code MessageConsumer}
+ * object is created by passing a {@code Destination} object to a message-consumer creation method supplied by a
+ * session.
  *
- * <P>{@code MessageConsumer} is the parent interface for all message 
- * consumers.
+ * <p>
+ * {@code MessageConsumer} is the parent interface for all message consumers.
  *
- * <P>A {@code MessageConsumer} can be created with a message selector. A message
- * selector allows 
- * the client to restrict the messages delivered to the message consumer to 
- * those that match the selector.
  * <p>
- * A client may either synchronously receive a {@code MessageConsumer}'s 
- * messages or have the {@code MessageConsumer} asynchronously deliver them 
- * as they arrive. 
+ * A {@code MessageConsumer} can be created with a message selector. A message selector allows the client to restrict
+ * the messages delivered to the message consumer to those that match the selector.
+ *
  * <p>
- * For synchronous receipt, a client can request the next message from a 
- * {@code MessageConsumer} using one of its {@code receive} methods. There are several 
- * variations of {@code receive} that allow a client to poll or wait for the next message. 
+ * A client may either synchronously receive a {@code MessageConsumer}'s messages or have the {@code MessageConsumer}
+ * asynchronously deliver them as they arrive.
+ *
  * <p>
- * For asynchronous delivery, a client can register a {@code MessageListener} object 
- * with a {@code MessageConsumer}.
- * As messages arrive at the {@code MessageConsumer}, it delivers them by calling 
- * the {@code MessageListener}'s {@code onMessage} method.
+ * For synchronous receipt, a client can request the next message from a {@code MessageConsumer} using one of its
+ * {@code receive} methods. There are several variations of {@code receive} that allow a client to poll or wait for the
+ * next message.
+ *
+ * <p>
+ * For asynchronous delivery, a client can register a {@code MessageListener} object with a {@code MessageConsumer}. As
+ * messages arrive at the {@code MessageConsumer}, it delivers them by calling the {@code MessageListener}'s
+ * {@code onMessage} method.
+ *
  * <p>
  * It is a client programming error for a {@code MessageListener} to throw an exception.
  *
- * @see         javax.jms.QueueReceiver
- * @see         javax.jms.TopicSubscriber
- * @see         javax.jms.Session
- * 
+ * @see javax.jms.QueueReceiver
+ * @see javax.jms.TopicSubscriber
+ * @see javax.jms.Session
+ *
  * @version JMS 2.0
  * @since JMS 1.0
  */
-public interface MessageConsumer extends AutoCloseable{
+public interface MessageConsumer extends AutoCloseable {
 
-    /** Gets this message consumer's message selector expression.
-     *  
-      * @return this message consumer's message selector, or null if no
-      *         message selector exists for the message consumer (that is, if 
-      *         the message selector was not set or was set to null or the 
-      *         empty string)
-      *  
-      * @exception JMSException if the JMS provider fails to get the message
-      *                         selector due to some internal error.
-      */ 
+    /**
+     * Gets this message consumer's message selector expression.
+     *
+     * @return this message consumer's message selector, or null if no message selector exists for the message consumer
+     * (that is, if the message selector was not set or was set to null or the empty string)
+     *
+     * @exception JMSException if the JMS provider fails to get the message selector due to some internal error.
+     */
+    String getMessageSelector() throws JMSException;
 
-    String
-    getMessageSelector() throws JMSException;
-
-
-    /** Gets the {@code MessageConsumer}'s {@code MessageListener}. 
+    /**
+     * Gets the {@code MessageConsumer}'s {@code MessageListener}.
+     *
      * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSException} to be thrown though this is not guaranteed.
-     * 
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
      * @return the {@code MessageConsumer}'s {@code MessageListener}, or null if one was not set
-     *  
-     * @exception JMSException if the JMS provider fails to get the {@code MessageListener}
-     *                         for one of the following reasons:
-     *                         <ul>
-     *                         <li>an internal error has occurred or
-     *                         <li>this method has been called in a Java EE web or EJB application 
-     *                         (though it is not guaranteed that an exception is thrown in this case)
-     *                         </ul>                      
-     *                         
+     *
+     * @exception JMSException if the JMS provider fails to get the {@code MessageListener} for one of the following
+     * reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
      * @see javax.jms.MessageConsumer#setMessageListener(javax.jms.MessageListener)
      */
     MessageListener getMessageListener() throws JMSException;
-    
-    /** Sets the {@code MessageConsumer}'s {@code MessageListener}.
+
+    /**
+     * Sets the {@code MessageConsumer}'s {@code MessageListener}.
+     *
      * <p>
-     * Setting the the {@code MessageListener} to null is the equivalent of 
-     * unsetting the {@code MessageListener} for the {@code MessageConsumer}. 
+     * Setting the the {@code MessageListener} to null is the equivalent of unsetting the {@code MessageListener} for the
+     * {@code MessageConsumer}.
+     *
      * <p>
-     * The effect of calling this method
-     * while messages are being consumed by an existing listener
-     * or the {@code MessageConsumer} is being used to consume messages synchronously
-     * is undefined.
+     * The effect of calling this method while messages are being consumed by an existing listener or the
+     * {@code MessageConsumer} is being used to consume messages synchronously is undefined.
+     *
      * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSException} to be thrown though this is not guaranteed.
-     * 
-     * @param listener the listener to which the messages are to be 
-     *                 delivered
-     *  
-     * @exception JMSException if the JMS provider fails to set the {@code MessageConsumer}'s {@code MessageListener}
-     *                         for one of the following reasons:
-     *                         <ul>
-     *                         <li>an internal error has occurred or  
-     *                         <li>this method has been called in a Java EE web or EJB application 
-     *                         (though it is not guaranteed that an exception is thrown in this case)
-     *                         </ul>    
-     *                         
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @param listener the listener to which the messages are to be delivered
+     *
+     * @exception JMSException if the JMS provider fails to set the {@code MessageConsumer}'s {@code MessageListener} for
+     * one of the following reasons:
+     * <ul>
+     * <li>an internal error has occurred or
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
      * @see javax.jms.MessageConsumer#getMessageListener()
-     */ 
+     */
     void setMessageListener(MessageListener listener) throws JMSException;
-           
-    /** Receives the next message produced for this message consumer.
-      *  
-      * <P>This call blocks indefinitely until a message is produced
-      * or until this message consumer is closed.
-      *
-      * <P>If this {@code receive} is done within a transaction, the 
-      * consumer retains the message until the transaction commits.
-      *  
-      * @return the next message produced for this message consumer, or 
-      * null if this message consumer is concurrently closed
-      *  
-      * @exception JMSException if the JMS provider fails to receive the next
-      *                         message due to some internal error.
-      * 
-      */ 
- 
-    Message
-    receive() throws JMSException;
 
+    /**
+     * Receives the next message produced for this message consumer.
+     *
+     * <p>
+     * This call blocks indefinitely until a message is produced or until this message consumer is closed.
+     *
+     * <p>
+     * If this {@code receive} is done within a transaction, the consumer retains the message until the transaction commits.
+     *
+     * @return the next message produced for this message consumer, or null if this message consumer is concurrently closed
+     *
+     * @exception JMSException if the JMS provider fails to receive the next message due to some internal error.
+     *
+     */
+    Message receive() throws JMSException;
 
-    /** Receives the next message that arrives within the specified
-      * timeout interval.
-      *  
-      * <P>This call blocks until a message arrives, the
-      * timeout expires, or this message consumer is closed.
-      * A {@code timeout} of zero never expires, and the call blocks 
-      * indefinitely.
-      *
-      * @param timeout the timeout value (in milliseconds)
-      *
-      * @return the next message produced for this message consumer, or 
-      * null if the timeout expires or this message consumer is concurrently 
-      * closed
-      *
-      * @exception JMSException if the JMS provider fails to receive the next
-      *                         message due to some internal error.
-      */ 
+    /**
+     * Receives the next message that arrives within the specified timeout interval.
+     *
+     * <p>
+     * This call blocks until a message arrives, the timeout expires, or this message consumer is closed. A {@code timeout}
+     * of zero never expires, and the call blocks indefinitely.
+     *
+     * @param timeout the timeout value (in milliseconds)
+     *
+     * @return the next message produced for this message consumer, or null if the timeout expires or this message consumer
+     * is concurrently closed
+     *
+     * @exception JMSException if the JMS provider fails to receive the next message due to some internal error.
+     */
+    Message receive(long timeout) throws JMSException;
 
-    Message
-    receive(long timeout) throws JMSException;
+    /**
+     * Receives the next message if one is immediately available.
+     *
+     * @return the next message produced for this message consumer, or null if one is not available
+     *
+     * @exception JMSException if the JMS provider fails to receive the next message due to some internal error.
+     */
+    Message receiveNoWait() throws JMSException;
 
-
-    /** Receives the next message if one is immediately available.
-      *
-      * @return the next message produced for this message consumer, or 
-      * null if one is not available
-      *  
-      * @exception JMSException if the JMS provider fails to receive the next
-      *                         message due to some internal error.
-      */ 
-
-    Message
-    receiveNoWait() throws JMSException;
-
-
-	/**
-	 * Closes the message consumer.
-	 * <p>
-	 * Since a provider may allocate some resources on behalf of a
-	 * {@code MessageConsumer} outside the Java virtual machine, clients should
-	 * close them when they are not needed. Relying on garbage collection to
-	 * eventually reclaim these resources may not be timely enough.
-	 * <P>
-	 * This call will block until a {@code receive} call in progress on this
-	 * consumer has completed. A blocked {@code receive} call returns null when
-	 * this message consumer is closed.
-	 * <p>
-	 * If this method is called whilst a message listener is in progress in
-	 * another thread then it will block until the message listener has
-	 * completed.
-	 * <p>
-	 * This method may be called from a message listener's {@code onMessage}
-	 * method on its own consumer. After this method returns the
-	 * {@code onMessage} method will be allowed to complete normally. 
-	 * <p>
-	 * This method is the only {@code MessageConsumer} method that can be called
-	 * concurrently.
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to close the consumer due to
-	 *                some internal error.
-	 */
-
-	void close() throws JMSException;
+    /**
+     * Closes the message consumer.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a {@code MessageConsumer} outside the Java virtual machine,
+     * clients should close them when they are not needed. Relying on garbage collection to eventually reclaim these
+     * resources may not be timely enough.
+     *
+     * <p>
+     * This call will block until a {@code receive} call in progress on this consumer has completed. A blocked
+     * {@code receive} call returns null when this message consumer is closed.
+     *
+     * <p>
+     * If this method is called whilst a message listener is in progress in another thread then it will block until the
+     * message listener has completed.
+     *
+     * <p>
+     * This method may be called from a message listener's {@code onMessage} method on its own consumer. After this method
+     * returns the {@code onMessage} method will be allowed to complete normally.
+     *
+     * <p>
+     * This method is the only {@code MessageConsumer} method that can be called concurrently.
+     *
+     * @exception JMSException if the JMS provider fails to close the consumer due to some internal error.
+     */
+    @Override
+    void close() throws JMSException;
 }

--- a/src/main/java/javax/jms/MessageEOFException.java
+++ b/src/main/java/javax/jms/MessageEOFException.java
@@ -17,43 +17,38 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when an unexpected 
- *     end of stream has been reached when a {@code StreamMessage} or 
- *     {@code BytesMessage} is being read.
- * 
+ * This exception must be thrown when an unexpected end of stream has been reached when a {@code StreamMessage} or
+ * {@code BytesMessage} is being read.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class MessageEOFException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -4829621000056590895L;
 
-  /** Constructs a {@code MessageEOFException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  MessageEOFException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -4829621000056590895L;
 
-  /** Constructs a {@code MessageEOFException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  MessageEOFException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code MessageEOFException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public MessageEOFException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code MessageEOFException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public MessageEOFException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/MessageFormatException.java
+++ b/src/main/java/javax/jms/MessageFormatException.java
@@ -17,51 +17,45 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a JMS client 
- *     attempts to use a data type not supported by a message or attempts to 
- *     read data in a message as the wrong type. It must also be thrown when 
- *     equivalent type errors are made with message property values. For 
- *     example, this exception must be thrown if 
- *     {@code StreamMessage.writeObject} is given an unsupported class or 
- *     if {@code StreamMessage.readShort} is used to read a 
- *     {@code boolean} value. Note that the special case of a failure 
- *     caused by an attempt to read improperly formatted {@code String} 
- *     data as numeric values must throw the 
- *     {@code java.lang.NumberFormatException}.
- * 
+ * This exception must be thrown when a JMS client attempts to use a data type not supported by a message or attempts to
+ * read data in a message as the wrong type.
+ *
+ * <p>
+ * It must also be thrown when equivalent type errors are made with message
+ * property values. For example, this exception must be thrown if {@code StreamMessage.writeObject} is given an
+ * unsupported class or if {@code StreamMessage.readShort} is used to read a {@code boolean} value. Note that the
+ * special case of a failure caused by an attempt to read improperly formatted {@code String} data as numeric values
+ * must throw the {@code java.lang.NumberFormatException}.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class MessageFormatException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -3642297253594750138L;
 
-  /** Constructs a {@code MessageFormatException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  MessageFormatException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -3642297253594750138L;
 
-  /** Constructs a {@code MessageFormatException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  MessageFormatException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code MessageFormatException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public MessageFormatException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code MessageFormatException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public MessageFormatException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/MessageFormatRuntimeException.java
+++ b/src/main/java/javax/jms/MessageFormatRuntimeException.java
@@ -17,62 +17,53 @@
 package javax.jms;
 
 /**
- * This unchecked exception must be thrown when a JMS application attempts to
- * use a data type not supported by a message or attempts to read data in a
- * message as the wrong type, and the method signature does not permit a
- * {@code MessageFormatException} to be thrown. It must also be thrown when
- * equivalent type errors are made with message property values. Note that the
- * special case of a failure caused by an attempt to read improperly formatted
- * {@code String} data as numeric values must throw the
- * {@code java.lang.NumberFormatException}.
- * 
+ * This unchecked exception must be thrown when a JMS application attempts to use a data type not supported by a message
+ * or attempts to read data in a message as the wrong type, and the method signature does not permit a
+ * {@code MessageFormatException} to be thrown.
+ *
+ * <p>
+ * It must also be thrown when equivalent type errors are made with message
+ * property values. Note that the special case of a failure caused by an attempt to read improperly formatted
+ * {@code String} data as numeric values must throw the {@code java.lang.NumberFormatException}.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
+ *
  **/
-
 public class MessageFormatRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 416918643772467720L;
 
-	/**
-	 * Constructs a {@code MessageFormatRuntimeException} with the specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public MessageFormatRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
-	
-	/**
-	 * Constructs a {@code MessageFormatRuntimeException} with the specified detail message
-	 * and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public MessageFormatRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage, errorCode);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 416918643772467720L;
 
-	/**
-	 * Constructs a {@code MessageFormatRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public MessageFormatRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage,errorCode,cause);
-	}
+    /**
+     * Constructs a {@code MessageFormatRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public MessageFormatRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    /**
+     * Constructs a {@code MessageFormatRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public MessageFormatRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code MessageFormatRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public MessageFormatRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
 }

--- a/src/main/java/javax/jms/MessageHeader.java
+++ b/src/main/java/javax/jms/MessageHeader.java
@@ -16,58 +16,61 @@
 
 package javax.jms;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies that a callback method parameter must be set to the specified
- * message header value. This annotation may be applied to parameters on a
- * callback method on a JMS message-driven bean that has been annotated with the
- * {@code JMSQueueListener} , {@code JMSNonDurableTopicListener} or
- * {@code JMSDurableTopicListener} annotation.
+ * Specifies that a callback method parameter must be set to the specified message header value. This annotation may be
+ * applied to parameters on a callback method on a JMS message-driven bean that has been annotated with the
+ * {@code JMSQueueListener} , {@code JMSNonDurableTopicListener} or {@code JMSDurableTopicListener} annotation.
+ *
  * <p>
- * The parameter type must match the header type as shown in the following
- * table. If it does not then deployment will fail.
- * <p>
+ * The parameter type must match the header type as shown in the following table. If it does not then deployment will
+ * fail.
+ *
  * <pre>
  * +-------------------+------------------------------------------------+
  * | Annotation                                     | Parameter         |
  * |                                                | type              |
  * +-------------------+------------------------------------------------+
- * | @MessageHeader(Header.JMSCorrelationID)        | String            |     
- * | @MessageHeader(Header.JMSCorrelationIDAsBytes) | byte[]            | 
- * | @MessageHeader(Header.JMSDeliveryMode)         | Integer or int    | 
- * | @MessageHeader(Header.JMSDeliveryTime)         | Long or long      | 
- * | @MessageHeader(Header.JMSDestination)          | Destination       | 
- * | @MessageHeader(Header.JMSExpiration)           | Long or long      | 
- * | @MessageHeader(Header.JMSMessageID)            | String            | 
+ * | @MessageHeader(Header.JMSCorrelationID)        | String            |
+ * | @MessageHeader(Header.JMSCorrelationIDAsBytes) | byte[]            |
+ * | @MessageHeader(Header.JMSDeliveryMode)         | Integer or int    |
+ * | @MessageHeader(Header.JMSDeliveryTime)         | Long or long      |
+ * | @MessageHeader(Header.JMSDestination)          | Destination       |
+ * | @MessageHeader(Header.JMSExpiration)           | Long or long      |
+ * | @MessageHeader(Header.JMSMessageID)            | String            |
  * | @MessageHeader(Header.JMSPriority)             | Integer or int    |
- * | @MessageHeader(Header.JMSRedelivered)          | Boolean or boolean| 
- * | @MessageHeader(Header.JMSReplyTo)              | Destination       | 
- * | @MessageHeader(Header.JMSTimestamp)            | Long or long      | 
- * | @MessageHeader(Header.JMSType)                 | String            | 
+ * | @MessageHeader(Header.JMSRedelivered)          | Boolean or boolean|
+ * | @MessageHeader(Header.JMSReplyTo)              | Destination       |
+ * | @MessageHeader(Header.JMSTimestamp)            | Long or long      |
+ * | @MessageHeader(Header.JMSType)                 | String            |
  * +-------------------+------------------------------------------------+
  * </pre>
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
+ *
  * @see MessageProperty
- * 
+ *
  */
-@Target({ ElementType.PARAMETER })
-@Retention(RetentionPolicy.RUNTIME)
+@Target(PARAMETER)
+@Retention(RUNTIME)
 public @interface MessageHeader {
 
     /**
      * Specifies the header field to be used
+     *
+     * @return The header field to be used
      */
     Header value();
 
     public enum Header {
-        JMSCorrelationID, JMSCorrelationIDAsBytes, JMSDeliveryMode, JMSDeliveryTime, JMSDestination, JMSExpiration, JMSMessageID, JMSPriority, JMSRedelivered, JMSReplyTo, JMSTimestamp, JMSType
+        JMSCorrelationID, JMSCorrelationIDAsBytes, JMSDeliveryMode, JMSDeliveryTime, JMSDestination, JMSExpiration, JMSMessageID, JMSPriority, JMSRedelivered,
+        JMSReplyTo, JMSTimestamp, JMSType
     }
 
 }

--- a/src/main/java/javax/jms/MessageListener.java
+++ b/src/main/java/javax/jms/MessageListener.java
@@ -16,28 +16,24 @@
 
 package javax.jms;
 
-
-/** A {@code MessageListener} object is used to receive asynchronously 
-  * delivered messages.
-  * <p>
-  * Each session must ensure that it passes messages serially to the
-  * listener. This means that a listener assigned to one or more consumers
-  * of the same session can assume that the {@code onMessage} method 
-  * is not called with the next message until the session has completed the 
-  * last call.
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code MessageListener} object is used to receive asynchronously delivered messages.
+ *
+ * <p>
+ * Each session must ensure that it passes messages serially to the listener. This means that a listener assigned to one
+ * or more consumers of the same session can assume that the {@code onMessage} method is not called with the next
+ * message until the session has completed the last call.
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 public interface MessageListener {
 
-    /** Passes a message to the listener.
-      *
-      * @param message the message passed to the listener
-      */
-
-    void 
-    onMessage(Message message);
+    /**
+     * Passes a message to the listener.
+     *
+     * @param message the message passed to the listener
+     */
+    void onMessage(Message message);
 }

--- a/src/main/java/javax/jms/MessageNotReadableException.java
+++ b/src/main/java/javax/jms/MessageNotReadableException.java
@@ -17,42 +17,37 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a JMS client attempts to read a 
- *     write-only message.
- * 
+ * This exception must be thrown when a JMS client attempts to read a write-only message.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  **/
-
 public class MessageNotReadableException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = 8044835867550650748L;
 
-  /** Constructs a {@code MessageNotReadableException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  MessageNotReadableException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = 8044835867550650748L;
 
-  /** Constructs a {@code MessageNotReadableException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  MessageNotReadableException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code MessageNotReadableException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public MessageNotReadableException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code MessageNotReadableException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public MessageNotReadableException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/MessageNotWriteableException.java
+++ b/src/main/java/javax/jms/MessageNotWriteableException.java
@@ -17,42 +17,36 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a JMS client attempts to write to a 
- *     read-only message.
- * 
+ * This exception must be thrown when a JMS client attempts to write to a read-only message.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  **/
-
 public class MessageNotWriteableException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -4241931174711518830L;
 
-  /** Constructs a {@code MessageNotWriteableException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  MessageNotWriteableException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -4241931174711518830L;
 
-  /** Constructs a {@code MessageNotWriteableException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  MessageNotWriteableException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code MessageNotWriteableException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public MessageNotWriteableException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code MessageNotWriteableException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public MessageNotWriteableException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/MessageNotWriteableRuntimeException.java
+++ b/src/main/java/javax/jms/MessageNotWriteableRuntimeException.java
@@ -17,60 +17,47 @@
 package javax.jms;
 
 /**
- * <P>
- * This unchecked exception must be thrown when a JMS client attempts to write
- * to a read-only message.
- * 
+ * This unchecked exception must be thrown when a JMS client attempts to write to a read-only message.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
  **/
-
 public class MessageNotWriteableRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 6075922984499850209L;
 
-	/**
-	 * Constructs a {@code MessageNotWriteableRuntimeException} with the
-	 * specified reason and error code.
-	 * 
-	 * @param reason
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a string specifying the vendor-specific error code
-	 * 
-	 **/
-	public MessageNotWriteableRuntimeException(String reason, String errorCode) {
-		super(reason, errorCode);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 6075922984499850209L;
 
-	/**
-	 * Constructs a {@code MessageNotWriteableRuntimeException} with the
-	 * specified reason. The error code defaults to null.
-	 * 
-	 * @param reason
-	 *            a description of the exception
-	 **/
-	public MessageNotWriteableRuntimeException(String reason) {
-		super(reason);
-	}
-	
-	/**
-	 * Constructs a {@code MessageNotWriteableRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public MessageNotWriteableRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage,errorCode,cause);
-	}
+    /**
+     * Constructs a {@code MessageNotWriteableRuntimeException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public MessageNotWriteableRuntimeException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code MessageNotWriteableRuntimeException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public MessageNotWriteableRuntimeException(String reason) {
+        super(reason);
+    }
+
+    /**
+     * Constructs a {@code MessageNotWriteableRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public MessageNotWriteableRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
 
 }

--- a/src/main/java/javax/jms/MessageProducer.java
+++ b/src/main/java/javax/jms/MessageProducer.java
@@ -17,1131 +17,873 @@
 package javax.jms;
 
 /**
- * A client uses a {@code MessageProducer} object to send messages to a
- * destination. A {@code MessageProducer} object is created by passing a
- * {@code Destination} object to a message-producer creation method
- * supplied by a session.
- * 
- * <P>
- * {@code MessageProducer} is the parent interface for all message
- * producers.
- * 
- * <P>
- * A client also has the option of creating a message producer without supplying
- * a destination. In this case, a destination must be provided with every send
- * operation. A typical use for this kind of message producer is to send replies
- * to requests using the request's {@code JMSReplyTo} destination.
- * 
- * <P>
- * A client can specify a default delivery mode, priority, time to live and
- * delivery delay for messages sent by a message producer. It can also specify
- * the delivery mode, priority, and time to live for an individual message.
- * 
- * <P>
- * A client can specify a time-to-live value in milliseconds for each message it
- * sends. This value defines a message expiration time that is the sum of the
- * message's time-to-live and the GMT when it is sent (for transacted sends,
- * this is the time the client sends the message, not the time the transaction
- * is committed).
- * 
- * <P>
- * A JMS provider should do its best to expire messages accurately; however, the
- * JMS API does not define the accuracy provided.
+ * A client uses a {@code MessageProducer} object to send messages to a destination. A {@code MessageProducer} object is
+ * created by passing a {@code Destination} object to a message-producer creation method supplied by a session.
+ *
+ * <p>
+ * {@code MessageProducer} is the parent interface for all message producers.
+ *
+ * <p>
+ * A client also has the option of creating a message producer without supplying a destination. In this case, a
+ * destination must be provided with every send operation. A typical use for this kind of message producer is to send
+ * replies to requests using the request's {@code JMSReplyTo} destination.
+ *
+ * <p>
+ * A client can specify a default delivery mode, priority, time to live and delivery delay for messages sent by a
+ * message producer. It can also specify the delivery mode, priority, and time to live for an individual message.
+ *
+ * <p>
+ * A client can specify a time-to-live value in milliseconds for each message it sends. This value defines a message
+ * expiration time that is the sum of the message's time-to-live and the GMT when it is sent (for transacted sends, this
+ * is the time the client sends the message, not the time the transaction is committed).
+ *
+ * <p>
+ * A JMS provider should do its best to expire messages accurately; however, the JMS API does not define the accuracy
+ * provided.
+ *
  * @see javax.jms.TopicPublisher
  * @see javax.jms.QueueSender
  * @see javax.jms.Session#createProducer
- * 
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
+ *
  */
-
 public interface MessageProducer extends AutoCloseable {
 
-	/**
-	 * Specify whether message IDs may be disabled.
-	 * <p>
-	 * Since message IDs take some effort to create and increase a message's
-	 * size, some JMS providers may be able to optimise message overhead if they
-	 * are given a hint that the message ID is not used by an application. By
-	 * calling this method, a JMS application enables this potential optimisation for all
-	 * messages sent using this {@code MessageProducer}. If the JMS provider accepts this
-	 * hint, these messages must have the message ID set to null; if the
-	 * provider ignores the hint, the message ID must be set to its normal
-	 * unique value.
-	 * <p>
-	 * Message IDs are enabled by default.
-	 * 
-	 * @param value
-	 *            indicates if message IDs may be disabled
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set message ID to disabled
-	 *                due to some internal error.
-	 */
-	void setDisableMessageID(boolean value) throws JMSException;
+    /**
+     * Specify whether message IDs may be disabled.
+     *
+     * <p>
+     * Since message IDs take some effort to create and increase a message's size, some JMS providers may be able to
+     * optimise message overhead if they are given a hint that the message ID is not used by an application. By calling this
+     * method, a JMS application enables this potential optimisation for all messages sent using this
+     * {@code MessageProducer}. If the JMS provider accepts this hint, these messages must have the message ID set to null;
+     * if the provider ignores the hint, the message ID must be set to its normal unique value.
+     *
+     * <p>
+     * Message IDs are enabled by default.
+     *
+     * @param value indicates if message IDs may be disabled
+     *
+     * @exception JMSException if the JMS provider fails to set message ID to disabled due to some internal error.
+     */
+    void setDisableMessageID(boolean value) throws JMSException;
 
-	/**
-	 * Gets an indication of whether message IDs are disabled.
-	 * 
-	 * @return an indication of whether message IDs are disabled
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to determine if message IDs are
-	 *                disabled due to some internal error.
-	 */
-	boolean getDisableMessageID() throws JMSException;
+    /**
+     * Gets an indication of whether message IDs are disabled.
+     *
+     * @return an indication of whether message IDs are disabled
+     *
+     * @exception JMSException if the JMS provider fails to determine if message IDs are disabled due to some internal
+     * error.
+     */
+    boolean getDisableMessageID() throws JMSException;
 
-	/**
-	 * Specify whether message timestamps may be disabled.
-	 * <p>
-	 * Since timestamps take some effort to create and increase a message's
-	 * size, some JMS providers may be able to optimise message overhead if they
-	 * are given a hint that the timestamp is not used by an application. By
-	 * calling this method, a JMS application enables this potential optimisation for
-	 * all messages sent using this {@code MessageProducer}. If the JMS provider accepts
-	 * this hint, these messages must have the timestamp set to zero; if the
-	 * provider ignores the hint, the timestamp must be set to its normal value.
-	 * <p>
-	 * Message timestamps are enabled by default.
-	 * 
-	 * @param value
-	 *            indicates whether message timestamps may be disabled
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set timestamps to disabled
-	 *                due to some internal error.
-	 */
-	void setDisableMessageTimestamp(boolean value) throws JMSException;
+    /**
+     * Specify whether message timestamps may be disabled.
+     *
+     * <p>
+     * Since timestamps take some effort to create and increase a message's size, some JMS providers may be able to optimise
+     * message overhead if they are given a hint that the timestamp is not used by an application. By calling this method, a
+     * JMS application enables this potential optimisation for all messages sent using this {@code MessageProducer}. If the
+     * JMS provider accepts this hint, these messages must have the timestamp set to zero; if the provider ignores the hint,
+     * the timestamp must be set to its normal value.
+     *
+     * <p>
+     * Message timestamps are enabled by default.
+     *
+     * @param value indicates whether message timestamps may be disabled
+     *
+     * @exception JMSException if the JMS provider fails to set timestamps to disabled due to some internal error.
+     */
+    void setDisableMessageTimestamp(boolean value) throws JMSException;
 
-	/**
-	 * Gets an indication of whether message timestamps are disabled.
-	 * 
-	 * @return an indication of whether message timestamps are disabled
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to determine if timestamps are
-	 *                disabled due to some internal error.
-	 */
-	boolean getDisableMessageTimestamp() throws JMSException;
+    /**
+     * Gets an indication of whether message timestamps are disabled.
+     *
+     * @return an indication of whether message timestamps are disabled
+     *
+     * @exception JMSException if the JMS provider fails to determine if timestamps are disabled due to some internal error.
+     */
+    boolean getDisableMessageTimestamp() throws JMSException;
 
-	/**
-	 * Sets the producer's default delivery mode.
-	 * 
-	 * <P>
-	 * Delivery mode is set to {@code PERSISTENT} by default.
-	 * 
-	 * @param deliveryMode
-	 *            the message delivery mode for this message producer; legal
-	 *            values are {@code DeliveryMode.NON_PERSISTENT} and
-	 *            {@code DeliveryMode.PERSISTENT}
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set the delivery mode due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#getDeliveryMode
-	 * @see javax.jms.DeliveryMode#NON_PERSISTENT
-	 * @see javax.jms.DeliveryMode#PERSISTENT
-	 * @see javax.jms.Message#DEFAULT_DELIVERY_MODE
-	 */
+    /**
+     * Sets the producer's default delivery mode.
+     *
+     * <p>
+     * Delivery mode is set to {@code PERSISTENT} by default.
+     *
+     * @param deliveryMode the message delivery mode for this message producer; legal values are
+     * {@code DeliveryMode.NON_PERSISTENT} and {@code DeliveryMode.PERSISTENT}
+     *
+     * @exception JMSException if the JMS provider fails to set the delivery mode due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#getDeliveryMode
+     * @see javax.jms.DeliveryMode#NON_PERSISTENT
+     * @see javax.jms.DeliveryMode#PERSISTENT
+     * @see javax.jms.Message#DEFAULT_DELIVERY_MODE
+     */
 
-	void setDeliveryMode(int deliveryMode) throws JMSException;
+    void setDeliveryMode(int deliveryMode) throws JMSException;
 
-	/**
-	 * Gets the producer's default delivery mode.
-	 * 
-	 * @return the message delivery mode for this message producer
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the delivery mode due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#setDeliveryMode
-	 */
+    /**
+     * Gets the producer's default delivery mode.
+     *
+     * @return the message delivery mode for this message producer
+     *
+     * @exception JMSException if the JMS provider fails to get the delivery mode due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#setDeliveryMode
+     */
+    int getDeliveryMode() throws JMSException;
 
-	int getDeliveryMode() throws JMSException;
+    /**
+     * Sets the producer's default priority.
+     *
+     * <p>
+     * The JMS API defines ten levels of priority value, with 0 as the lowest priority and 9 as the highest. Clients should
+     * consider priorities 0-4 as gradations of normal priority and priorities 5-9 as gradations of expedited priority.
+     * Priority is set to 4 by default.
+     *
+     * @param defaultPriority the message priority for this message producer; must be a value between 0 and 9
+     *
+     * @exception JMSException if the JMS provider fails to set the priority due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#getPriority
+     * @see javax.jms.Message#DEFAULT_PRIORITY
+     */
+    void setPriority(int defaultPriority) throws JMSException;
 
-	/**
-	 * Sets the producer's default priority.
-	 * 
-	 * <P>
-	 * The JMS API defines ten levels of priority value, with 0 as the lowest
-	 * priority and 9 as the highest. Clients should consider priorities 0-4 as
-	 * gradations of normal priority and priorities 5-9 as gradations of
-	 * expedited priority. Priority is set to 4 by default.
-	 * 
-	 * @param defaultPriority
-	 *            the message priority for this message producer; must be a
-	 *            value between 0 and 9
-	 * 
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set the priority due to some
-	 *                internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#getPriority
-	 * @see javax.jms.Message#DEFAULT_PRIORITY
-	 */
+    /**
+     * Gets the producer's default priority.
+     *
+     * @return the message priority for this message producer
+     *
+     * @exception JMSException if the JMS provider fails to get the priority due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#setPriority
+     */
+    int getPriority() throws JMSException;
 
-	void setPriority(int defaultPriority) throws JMSException;
+    /**
+     * Sets the default length of time in milliseconds from its dispatch time that a produced message should be retained by
+     * the message system.
+     *
+     * <p>
+     * Time to live is set to zero by default.
+     *
+     * @param timeToLive the message time to live in milliseconds; zero is unlimited
+     *
+     * @exception JMSException if the JMS provider fails to set the time to live due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#getTimeToLive
+     * @see javax.jms.Message#DEFAULT_TIME_TO_LIVE
+     */
+    void setTimeToLive(long timeToLive) throws JMSException;
 
-	/**
-	 * Gets the producer's default priority.
-	 * 
-	 * @return the message priority for this message producer
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the priority due to some
-	 *                internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#setPriority
-	 */
+    /**
+     * Gets the default length of time in milliseconds from its dispatch time that a produced message should be retained by
+     * the message system.
+     *
+     * @return the message time to live in milliseconds; zero is unlimited
+     *
+     * @exception JMSException if the JMS provider fails to get the time to live due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#setTimeToLive
+     */
+    long getTimeToLive() throws JMSException;
 
-	int getPriority() throws JMSException;
+    /**
+     * Sets the minimum length of time in milliseconds that must elapse after a message is sent before the JMS provider may
+     * deliver the message to a consumer.
+     *
+     * <p>
+     * For transacted sends, this time starts when the client sends the message, not when the transaction is committed.
+     *
+     * <p>
+     * deliveryDelay is set to zero by default.
+     *
+     * @param deliveryDelay the delivery delay in milliseconds.
+     *
+     * @exception JMSException if the JMS provider fails to set the delivery delay due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#getDeliveryDelay
+     * @see javax.jms.Message#DEFAULT_DELIVERY_DELAY
+     *
+     * @since JMS 2.0
+     */
+    void setDeliveryDelay(long deliveryDelay) throws JMSException;
 
-	/**
-	 * Sets the default length of time in milliseconds from its dispatch time
-	 * that a produced message should be retained by the message system.
-	 * 
-	 * <P>
-	 * Time to live is set to zero by default.
-	 * 
-	 * @param timeToLive
-	 *            the message time to live in milliseconds; zero is unlimited
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set the time to live due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#getTimeToLive
-	 * @see javax.jms.Message#DEFAULT_TIME_TO_LIVE
-	 */
+    /**
+     * Gets the minimum length of time in milliseconds that must elapse after a message is sent before the JMS provider may
+     * deliver the message to a consumer.
+     *
+     * @return the delivery delay in milliseconds.
+     *
+     * @exception JMSException if the JMS provider fails to get the delivery delay due to some internal error.
+     *
+     * @see javax.jms.MessageProducer#setDeliveryDelay
+     *
+     * @since JMS 2.0
+     */
+    long getDeliveryDelay() throws JMSException;
 
-	void setTimeToLive(long timeToLive) throws JMSException;
+    /**
+     * Gets the destination associated with this {@code MessageProducer}.
+     *
+     * @return this producer's {@code Destination}
+     *
+     * @exception JMSException if the JMS provider fails to get the destination for this {@code MessageProducer} due to some
+     * internal error.
+     *
+     * @since JMS 1.1
+     */
+    Destination getDestination() throws JMSException;
 
-	/**
-	 * Gets the default length of time in milliseconds from its dispatch time
-	 * that a produced message should be retained by the message system.
-	 * 
-	 * @return the message time to live in milliseconds; zero is unlimited
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the time to live due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#setTimeToLive
-	 */
+    /**
+     * Closes the message producer.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a {@code MessageProducer} outside the Java virtual machine,
+     * clients should close them when they are not needed. Relying on garbage collection to eventually reclaim these
+     * resources may not be timely enough.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>MessageProducer</tt> have
+     * been completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to
+     * complete normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>MessageProducer</tt>. Doing
+     * so will cause an <tt>IllegalStateException</tt> to be thrown.
+     *
+     * @exception IllegalStateException this method has been called by a <tt>CompletionListener</tt> callback method on its
+     * own <tt>MessageProducer</tt>
+     * @exception JMSException if the JMS provider fails to close the producer due to some internal error.
+     */
+    @Override
+    void close() throws JMSException;
 
-	long getTimeToLive() throws JMSException;
+    /**
+     * Sends a message using the {@code MessageProducer}'s default delivery mode, priority, and time to live.
+     *
+     * @param message the message to send
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code MessageProducer} with an invalid
+     * destination.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * did not specify a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     *
+     * @since JMS 1.1
+     */
+    void send(Message message) throws JMSException;
 
-	/**
-	 * Sets the minimum length of time in milliseconds that must elapse after a
-	 * message is sent before the JMS provider may deliver the message to a
-	 * consumer.
-	 * <p>
-	 * For transacted sends, this time starts when the client sends the message,
-	 * not when the transaction is committed.
-	 * <p>
-	 * deliveryDelay is set to zero by default.
-	 * 
-	 * @param deliveryDelay
-	 *            the delivery delay in milliseconds.
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to set the delivery delay due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#getDeliveryDelay
-	 * @see javax.jms.Message#DEFAULT_DELIVERY_DELAY
-	 * 
-	 * @since JMS 2.0
-	 */
+    /**
+     * Sends a message, specifying delivery mode, priority, and time to live.
+     *
+     * @param message the message to send
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code MessageProducer} with an invalid
+     * destination.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * did not specify a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @since JMS 1.1
+     */
+    void send(Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
 
-	void setDeliveryDelay(long deliveryDelay) throws JMSException;
+    /**
+     * Sends a message to a destination for an unidentified message producer using the {@code MessageProducer}'s default
+     * delivery mode, priority, and time to live.
+     *
+     * <p>
+     * Typically, a message producer is assigned a destination at creation time; however, the JMS API also supports
+     * unidentified message producers, which require that the destination be supplied every time a message is sent.
+     *
+     * @param destination the destination to send this message to
+     * @param message the message to send
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid destination.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * specified a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @since JMS 1.1
+     */
+    void send(Destination destination, Message message) throws JMSException;
 
-	/**
-	 * Gets the minimum length of time in milliseconds that must elapse after a
-	 * message is sent before the JMS provider may deliver the message to a
-	 * consumer.
-	 * 
-	 * @return the delivery delay in milliseconds.
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the delivery delay due to
-	 *                some internal error.
-	 * 
-	 * @see javax.jms.MessageProducer#setDeliveryDelay
-	 * 
-	 * @since JMS 2.0
-	 */
+    /**
+     * Sends a message to a destination for an unidentified message producer, specifying delivery mode, priority and time to
+     * live.
+     *
+     * <p>
+     * Typically, a message producer is assigned a destination at creation time; however, the JMS API also supports
+     * unidentified message producers, which require that the destination be supplied every time a message is sent.
+     *
+     * @param destination the destination to send this message to
+     * @param message the message to send
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid destination.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * specified a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @since JMS 1.1
+     */
+    void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
 
-	long getDeliveryDelay() throws JMSException;
+    /**
+     * Sends a message using the {@code MessageProducer}'s default delivery mode, priority, and time to live, performing
+     * part of the work involved in sending the message in a separate thread and notifying the specified
+     * <tt>CompletionListener</tt> when the operation has completed. JMS refers to this as an "asynchronous send".
+     *
+     * <p>
+     * When the message has been successfully sent the JMS provider invokes the callback method <tt>onCompletion</tt> on an
+     * application-specified <tt>CompletionListener</tt> object. Only when that callback has been invoked can the
+     * application be sure that the message has been successfully sent with the same degree of confidence as if a normal
+     * synchronous send had been performed. An application which requires this degree of confidence must therefore wait for
+     * the callback to be invoked before continuing.
+     *
+     * <p>
+     * The following information is intended to give an indication of how an asynchronous send would typically be
+     * implemented.
+     *
+     * <p>
+     * In some JMS providers, a normal synchronous send involves sending the message to a remote JMS server and then waiting
+     * for an acknowledgement to be received before returning. It is expected that such a provider would implement an
+     * asynchronous send by sending the message to the remote JMS server and then returning without waiting for an
+     * acknowledgement. When the acknowledgement is received, the JMS provider would notify the application by invoking the
+     * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object. If for some reason the
+     * acknowledgement is not received the JMS provider would notify the application by invoking the
+     * <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+     *
+     * <p>
+     * In those cases where the JMS specification permits a lower level of reliability, a normal synchronous send might not
+     * wait for an acknowledgement. In that case it is expected that an asynchronous send would be similar to a synchronous
+     * send: the JMS provider would send the message to the remote JMS server and then return without waiting for an
+     * acknowledgement. However the JMS provider would still notify the application that the send had completed by invoking
+     * the <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
+     *
+     * <p>
+     * It is up to the JMS provider to decide exactly what is performed in the calling thread and what, if anything, is
+     * performed asynchronously, so long as it satisfies the requirements given below:
+     *
+     * <p>
+     * <b>Quality of service</b>: After the send operation has completed successfully, which means that the message has been
+     * successfully sent with the same degree of confidence as if a normal synchronous send had been performed, the JMS
+     * provider must invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
+     * must not be invoked earlier than this.
+     *
+     * <p>
+     * <b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt> method then an appropriate
+     * exception should be thrown in the thread that is calling the <tt>send</tt> method. In this case the JMS provider must
+     * not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
+     * encountered which cannot be thrown in the thread that is calling the <tt>send</tt> method then the JMS provider must
+     * call the <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases if an exception occurs it is
+     * undefined whether or not the message was successfully sent.
+     *
+     * <p>
+     * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages then JMS message
+     * ordering requirements must be satisfied. This applies even if a combination of synchronous and asynchronous sends has
+     * been performed. The application is not required to wait for an asynchronous send to complete before sending the next
+     * message.
+     *
+     * <p>
+     * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the <tt>MessageProducer</tt> or its
+     * <tt>Session</tt> or <tt>Connection</tt> then the JMS provider must block until any incomplete send operations have
+     * been completed and all {@code CompletionListener} callbacks have returned before closing the object and returning. If
+     * the session is transacted (uses a local transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
+     * <tt>rollback</tt> method is called the JMS provider must block until any incomplete send operations have been
+     * completed and all {@code CompletionListener} callbacks have returned before performing the commit or rollback.
+     * Incomplete sends should be allowed to complete normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>Connection</tt>,
+     * <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on its own
+     * <tt>Session</tt>. Doing so will cause the <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> to throw an
+     * <tt>IllegalStateException</tt>.
+     *
+     * <p>
+     * <b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web container. Doing so may
+     * cause a {@code JMSException} to be thrown though this is not guaranteed.
+     *
+     * <p>
+     * <b>Message headers</b> JMS defines a number of message header fields and message properties which must be set by the
+     * "JMS provider on send". If the send is asynchronous these fields and properties may be accessed on the sending client
+     * only after the <tt>CompletionListener</tt> has been invoked. If the <tt>CompletionListener</tt>'s
+     * <tt>onException</tt> method is called then the state of these message header fields and properties is undefined.
+     *
+     * <p>
+     * <b>Restrictions on threading</b>: Applications that perform an asynchronous send must confirm to the threading
+     * restrictions defined in JMS. This means that the session may be used by only one thread at a time.
+     *
+     * <p>
+     * Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the thread of control which calls
+     * the <tt>CompletionListener</tt>. The application thread may therefore continue to use the session after performing an
+     * asynchronous send. However the <tt>CompletionListener</tt>'s callback methods must not use the session if an
+     * application thread might be using the session at the same time.
+     *
+     * <p>
+     * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only invoke one
+     * <tt>CompletionListener</tt> callback method at a time. For a given <tt>MessageProducer</tt>, callbacks (both
+     * {@code onCompletion} and {@code onException}) will be performed in the same order as the corresponding calls to the
+     * asynchronous send method. A JMS provider must not invoke the <tt>CompletionListener</tt> from the thread that is
+     * calling the asynchronous <tt>send</tt> method.
+     *
+     * <p>
+     * <b>Restrictions on the use of the Message object</b>: Applications which perform an asynchronous send must take
+     * account of the restriction that a <tt>Message</tt> object is designed to be accessed by one logical thread of control
+     * at a time and does not support concurrent use.
+     *
+     * <p>
+     * After the <tt>send</tt> method has returned, the application must not attempt to read the headers, properties or body
+     * of the <tt>Message</tt> object until the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt>
+     * method has been called. This is because the JMS provider may be modifying the <tt>Message</tt> object in another
+     * thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the application attempts to access or
+     * modify the <tt>Message</tt> object after the <tt>send</tt> method has returned and before the
+     * <tt>CompletionListener</tt> has been invoked. If the JMS provider does not throw an exception then the behaviour is
+     * undefined.
+     *
+     * @param message the message to send
+     * @param completionListener a {@code CompletionListener} to be notified when the send has completed
+     *
+     * @exception JMSException if an internal error occurs
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code MessageProducer} with an invalid
+     * destination.
+     * @exception java.lang.IllegalArgumentException if the specified {@code CompletionListener} is null
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * did not specify a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @see javax.jms.CompletionListener
+     *
+     * @since JMS 2.0
+     */
+    void send(Message message, CompletionListener completionListener) throws JMSException;
 
-	/**
-	 * Gets the destination associated with this {@code MessageProducer}.
-	 * 
-	 * @return this producer's {@code Destination}
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to get the destination for this
-	 *                {@code MessageProducer} due to some internal error.
-	 *                
-	 * @since JMS 1.1
-	 */
+    /**
+     * Sends a message, specifying delivery mode, priority and time to live, performing part of the work involved in sending
+     * the message in a separate thread and notifying the specified <tt>CompletionListener</tt> when the operation has
+     * completed. JMS refers to this as an "asynchronous send".
+     *
+     * <p>
+     * When the message has been successfully sent the JMS provider invokes the callback method <tt>onCompletion</tt> on an
+     * application-specified <tt>CompletionListener</tt> object. Only when that callback has been invoked can the
+     * application be sure that the message has been successfully sent with the same degree of confidence as if a normal
+     * synchronous send had been performed. An application which requires this degree of confidence must therefore wait for
+     * the callback to be invoked before continuing.
+     *
+     * <p>
+     * The following information is intended to give an indication of how an asynchronous send would typically be
+     * implemented.
+     *
+     * <p>
+     * In some JMS providers, a normal synchronous send involves sending the message to a remote JMS server and then waiting
+     * for an acknowledgement to be received before returning. It is expected that such a provider would implement an
+     * asynchronous send by sending the message to the remote JMS server and then returning without waiting for an
+     * acknowledgement. When the acknowledgement is received, the JMS provider would notify the application by invoking the
+     * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object. If for some reason the
+     * acknowledgement is not received the JMS provider would notify the application by invoking the
+     * <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+     *
+     * <p>
+     * In those cases where the JMS specification permits a lower level of reliability, a normal synchronous send might not
+     * wait for an acknowledgement. In that case it is expected that an asynchronous send would be similar to a synchronous
+     * send: the JMS provider would send the message to the remote JMS server and then return without waiting for an
+     * acknowledgement. However the JMS provider would still notify the application that the send had completed by invoking
+     * the <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
+     *
+     * <p>
+     * It is up to the JMS provider to decide exactly what is performed in the calling thread and what, if anything, is
+     * performed asynchronously, so long as it satisfies the requirements given below:
+     *
+     * <p>
+     * <b>Quality of service</b>: After the send operation has completed successfully, which means that the message has been
+     * successfully sent with the same degree of confidence as if a normal synchronous send had been performed, the JMS
+     * provider must invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
+     * must not be invoked earlier than this.
+     *
+     * <p>
+     * <b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt> method then an appropriate
+     * exception should be thrown in the thread that is calling the <tt>send</tt> method. In this case the JMS provider must
+     * not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
+     * encountered which cannot be thrown in the thread that is calling the <tt>send</tt> method then the JMS provider must
+     * call the <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases if an exception occurs it is
+     * undefined whether or not the message was successfully sent.
+     *
+     * <p>
+     * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages then JMS message
+     * ordering requirements must be satisfied. This applies even if a combination of synchronous and asynchronous sends has
+     * been performed. The application is not required to wait for an asynchronous send to complete before sending the next
+     * message.
+     *
+     * <p>
+     * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the <tt>MessageProducer</tt> or its
+     * <tt>Session</tt> or <tt>Connection</tt> then the JMS provider must block until any incomplete send operations have
+     * been completed and all {@code CompletionListener} callbacks have returned before closing the object and returning. If
+     * the session is transacted (uses a local transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
+     * <tt>rollback</tt> method is called the JMS provider must block until any incomplete send operations have been
+     * completed and all {@code CompletionListener} callbacks have returned before performing the commit or rollback.
+     * Incomplete sends should be allowed to complete normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>Connection</tt>,
+     * <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on its own
+     * <tt>Session</tt>. Doing so will cause the <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> to throw an
+     * <tt>IllegalStateException</tt>.
+     *
+     * <p>
+     * <b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web container. Doing so may
+     * cause a {@code JMSException} to be thrown though this is not guaranteed.
+     *
+     * <p>
+     * <b>Message headers</b> JMS defines a number of message header fields and message properties which must be set by the
+     * "JMS provider on send". If the send is asynchronous these fields and properties may be accessed on the sending client
+     * only after the <tt>CompletionListener</tt> has been invoked. If the <tt>CompletionListener</tt>'s
+     * <tt>onException</tt> method is called then the state of these message header fields and properties is undefined.
+     *
+     * <p>
+     * <b>Restrictions on threading</b>: Applications that perform an asynchronous send must confirm to the threading
+     * restrictions defined in JMS. This means that the session may be used by only one thread at a time.
+     *
+     * <p>
+     * Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the thread of control which calls
+     * the <tt>CompletionListener</tt>. The application thread may therefore continue to use the session after performing an
+     * asynchronous send. However the <tt>CompletionListener</tt>'s callback methods must not use the session if an
+     * application thread might be using the session at the same time.
+     *
+     * <p>
+     * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only invoke one
+     * <tt>CompletionListener</tt> callback method at a time. For a given <tt>MessageProducer</tt>, callbacks (both
+     * {@code onCompletion} and {@code onException}) will be performed in the same order as the corresponding calls to the
+     * asynchronous send method. A JMS provider must not invoke the <tt>CompletionListener</tt> from the thread that is
+     * calling the asynchronous <tt>send</tt> method.
+     *
+     * <p>
+     * <b>Restrictions on the use of the Message object</b>: Applications which perform an asynchronous send must take
+     * account of the restriction that a <tt>Message</tt> object is designed to be accessed by one logical thread of control
+     * at a time and does not support concurrent use.
+     *
+     * <p>
+     * After the <tt>send</tt> method has returned, the application must not attempt to read the headers, properties or body
+     * of the <tt>Message</tt> object until the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt>
+     * method has been called. This is because the JMS provider may be modifying the <tt>Message</tt> object in another
+     * thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the application attempts to access or
+     * modify the <tt>Message</tt> object after the <tt>send</tt> method has returned and before the
+     * <tt>CompletionListener</tt> has been invoked. If the JMS provider does not throw an exception then the behaviour is
+     * undefined.
+     *
+     * @param message the message to send
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     * @param completionListener a {@code CompletionListener} to be notified when the send has completed
+     *
+     * @exception JMSException if an internal error occurs
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code MessageProducer} with an invalid
+     * destination.
+     * @exception java.lang.IllegalArgumentException if the specified {@code CompletionListener} is null
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * did not specify a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @see javax.jms.CompletionListener
+     *
+     * @since JMS 2.0
+     */
+    void send(Message message, int deliveryMode, int priority, long timeToLive, CompletionListener completionListener) throws JMSException;
 
-	Destination getDestination() throws JMSException;
+    /**
+     * Sends a message to a destination for an unidentified message producer, using the {@code MessageProducer}'s default
+     * delivery mode, priority, and time to live, performing part of the work involved in sending the message in a separate
+     * thread and notifying the specified <tt>CompletionListener</tt> when the operation has completed. JMS refers to this
+     * as an "asynchronous send".
+     *
+     * <p>
+     * Typically, a message producer is assigned a destination at creation time; however, the JMS API also supports
+     * unidentified message producers, which require that the destination be supplied every time a message is sent.
+     *
+     * <p>
+     * When the message has been successfully sent the JMS provider invokes the callback method <tt>onCompletion</tt> on an
+     * application-specified <tt>CompletionListener</tt> object. Only when that callback has been invoked can the
+     * application be sure that the message has been successfully sent with the same degree of confidence as if a normal
+     * synchronous send had been performed. An application which requires this degree of confidence must therefore wait for
+     * the callback to be invoked before continuing.
+     *
+     * <p>
+     * The following information is intended to give an indication of how an asynchronous send would typically be
+     * implemented.
+     *
+     * <p>
+     * In some JMS providers, a normal synchronous send involves sending the message to a remote JMS server and then waiting
+     * for an acknowledgement to be received before returning. It is expected that such a provider would implement an
+     * asynchronous send by sending the message to the remote JMS server and then returning without waiting for an
+     * acknowledgement. When the acknowledgement is received, the JMS provider would notify the application by invoking the
+     * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object. If for some reason the
+     * acknowledgement is not received the JMS provider would notify the application by invoking the
+     * <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+     *
+     * <p>
+     * In those cases where the JMS specification permits a lower level of reliability, a normal synchronous send might not
+     * wait for an acknowledgement. In that case it is expected that an asynchronous send would be similar to a synchronous
+     * send: the JMS provider would send the message to the remote JMS server and then return without waiting for an
+     * acknowledgement. However the JMS provider would still notify the application that the send had completed by invoking
+     * the <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
+     *
+     * <p>
+     * It is up to the JMS provider to decide exactly what is performed in the calling thread and what, if anything, is
+     * performed asynchronously, so long as it satisfies the requirements given below:
+     *
+     * <p>
+     * <b>Quality of service</b>: After the send operation has completed successfully, which means that the message has been
+     * successfully sent with the same degree of confidence as if a normal synchronous send had been performed, the JMS
+     * provider must invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
+     * must not be invoked earlier than this.
+     *
+     * <p>
+     * <b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt> method then an appropriate
+     * exception should be thrown in the thread that is calling the <tt>send</tt> method. In this case the JMS provider must
+     * not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
+     * encountered which cannot be thrown in the thread that is calling the <tt>send</tt> method then the JMS provider must
+     * call the <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases if an exception occurs it is
+     * undefined whether or not the message was successfully sent.
+     *
+     * <p>
+     * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages then JMS message
+     * ordering requirements must be satisfied. This applies even if a combination of synchronous and asynchronous sends has
+     * been performed. The application is not required to wait for an asynchronous send to complete before sending the next
+     * message.
+     *
+     * <p>
+     * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the <tt>MessageProducer</tt> or its
+     * <tt>Session</tt> or <tt>Connection</tt> then the JMS provider must block until any incomplete send operations have
+     * been completed and all {@code CompletionListener} callbacks have returned before closing the object and returning. If
+     * the session is transacted (uses a local transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
+     * <tt>rollback</tt> method is called the JMS provider must block until any incomplete send operations have been
+     * completed and all {@code CompletionListener} callbacks have returned before performing the commit or rollback.
+     * Incomplete sends should be allowed to complete normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>Connection</tt>,
+     * <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on its own
+     * <tt>Session</tt>. Doing so will cause the <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> to throw an
+     * <tt>IllegalStateException</tt>.
+     *
+     * <p>
+     * <b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web container. Doing so may
+     * cause a {@code JMSException} to be thrown though this is not guaranteed.
+     *
+     * <p>
+     * <b>Message headers</b> JMS defines a number of message header fields and message properties which must be set by the
+     * "JMS provider on send". If the send is asynchronous these fields and properties may be accessed on the sending client
+     * only after the <tt>CompletionListener</tt> has been invoked. If the <tt>CompletionListener</tt>'s
+     * <tt>onException</tt> method is called then the state of these message header fields and properties is undefined.
+     *
+     * <p>
+     * <b>Restrictions on threading</b>: Applications that perform an asynchronous send must confirm to the threading
+     * restrictions defined in JMS. This means that the session may be used by only one thread at a time.
+     *
+     * <p>
+     * Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the thread of control which calls
+     * the <tt>CompletionListener</tt>. The application thread may therefore continue to use the session after performing an
+     * asynchronous send. However the <tt>CompletionListener</tt>'s callback methods must not use the session if an
+     * application thread might be using the session at the same time.
+     *
+     * <p>
+     * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only invoke one
+     * <tt>CompletionListener</tt> callback method at a time. For a given <tt>MessageProducer</tt>, callbacks (both
+     * {@code onCompletion} and {@code onException}) will be performed in the same order as the corresponding calls to the
+     * asynchronous send method. A JMS provider must not invoke the <tt>CompletionListener</tt> from the thread that is
+     * calling the asynchronous <tt>send</tt> method.
+     *
+     * <p>
+     * <b>Restrictions on the use of the Message object</b>: Applications which perform an asynchronous send must take
+     * account of the restriction that a <tt>Message</tt> object is designed to be accessed by one logical thread of control
+     * at a time and does not support concurrent use.
+     *
+     * <p>
+     * After the <tt>send</tt> method has returned, the application must not attempt to read the headers, properties or body
+     * of the <tt>Message</tt> object until the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt>
+     * method has been called. This is because the JMS provider may be modifying the <tt>Message</tt> object in another
+     * thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the application attempts to access or
+     * modify the <tt>Message</tt> object after the <tt>send</tt> method has returned and before the
+     * <tt>CompletionListener</tt> has been invoked. If the JMS provider does not throw an exception then the behaviour is
+     * undefined.
+     *
+     * @param destination the destination to send this message to
+     * @param message the message to send
+     * @param completionListener a {@code CompletionListener} to be notified when the send has completed
+     *
+     * @exception JMSException if an internal error occurs
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid destination
+     * @exception java.lang.IllegalArgumentException if the specified {@code CompletionListener} is null
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * specified a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @see javax.jms.CompletionListener
+     *
+     * @since JMS 2.0
+     */
+    void send(Destination destination, Message message, CompletionListener completionListener) throws JMSException;
 
-	/**
-	 * Closes the message producer.
-	 * 
-	 * <P>
-	 * Since a provider may allocate some resources on behalf of a
-	 * {@code MessageProducer} outside the Java virtual machine, clients
-	 * should close them when they are not needed. Relying on garbage collection
-	 * to eventually reclaim these resources may not be timely enough.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>MessageProducer</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>MessageProducer</tt>. Doing so will cause an
-	 * <tt>IllegalStateException</tt> to be thrown.
-	 * <p>
-	 * 
-	 * @exception IllegalStateException
-	 *                this method has
-	 *                been called by a <tt>CompletionListener</tt> callback
-	 *                method on its own <tt>MessageProducer</tt>
-	 * @exception JMSException
-	 *                if the JMS provider fails to close the producer due to
-	 *                some internal error.
-	 */
-
-	void close() throws JMSException;
-
-	/**
-	 * Sends a message using the {@code MessageProducer}'s default delivery
-	 * mode, priority, and time to live.
-	 * 
-	 * @param message
-	 *            the message to send
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to send the message due to some
-	 *                internal error.
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} with an invalid destination.
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that did not specify a
-	 *                destination at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * 
-	 * @since JMS 1.1
-	 */
-
-	void send(Message message) throws JMSException;
-
-	/**
-	 * Sends a message, specifying delivery mode, priority, and time to live.
-	 * 
-	 * @param message
-	 *            the message to send
-	 * @param deliveryMode
-	 *            the delivery mode to use
-	 * @param priority
-	 *            the priority for this message
-	 * @param timeToLive
-	 *            the message's lifetime (in milliseconds)
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to send the message due to some
-	 *                internal error.
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} with an invalid destination.
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that did not specify a
-	 *                destination at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * @since JMS 1.1
-	 */
-
-	void send(Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
-
-	/**
-	 * Sends a message to a destination for an unidentified message producer
-	 * using the {@code MessageProducer}'s default delivery mode, priority,
-	 * and time to live.
-	 * 
-	 * <P>
-	 * Typically, a message producer is assigned a destination at creation time;
-	 * however, the JMS API also supports unidentified message producers, which
-	 * require that the destination be supplied every time a message is sent.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param message
-	 *            the message to send
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to send the message due to some
-	 *                internal error.
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with an invalid destination.
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that specified a destination
-	 *                at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * @since JMS 1.1
-	 */
-
-	void send(Destination destination, Message message) throws JMSException;
-
-	/**
-	 * Sends a message to a destination for an unidentified message producer,
-	 * specifying delivery mode, priority and time to live.
-	 * 
-	 * <P>
-	 * Typically, a message producer is assigned a destination at creation time;
-	 * however, the JMS API also supports unidentified message producers, which
-	 * require that the destination be supplied every time a message is sent.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param message
-	 *            the message to send
-	 * @param deliveryMode
-	 *            the delivery mode to use
-	 * @param priority
-	 *            the priority for this message
-	 * @param timeToLive
-	 *            the message's lifetime (in milliseconds)
-	 * 
-	 * @exception JMSException
-	 *                if the JMS provider fails to send the message due to some
-	 *                internal error.
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with an invalid destination.
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that specified a destination
-	 *                at creation time.
-	 *                
-	 * @see javax.jms.Session#createProducer
-	 * @since JMS 1.1
-	 */
-
-	void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive)
-			throws JMSException;
-
-	/**
-	 * Sends a message using the {@code MessageProducer}'s default delivery
-	 * mode, priority, and time to live, performing part of the work involved in
-	 * sending the message in a separate thread and notifying the specified
-	 * <tt>CompletionListener</tt> when the operation has completed. JMS refers
-	 * to this as an "asynchronous send".
-	 * <p>
-	 * When the message has been successfully sent the JMS provider invokes the
-	 * callback method <tt>onCompletion</tt> on an application-specified
-	 * <tt>CompletionListener</tt> object. Only when that callback has been
-	 * invoked can the application be sure that the message has been
-	 * successfully sent with the same degree of confidence as if a normal
-	 * synchronous send had been performed. An application which requires this
-	 * degree of confidence must therefore wait for the callback to be invoked
-	 * before continuing.
-	 * <p>
-	 * The following information is intended to give an indication of how an
-	 * asynchronous send would typically be implemented.
-	 * <p>
-	 * In some JMS providers, a normal synchronous send involves sending the
-	 * message to a remote JMS server and then waiting for an acknowledgement to
-	 * be received before returning. It is expected that such a provider would
-	 * implement an asynchronous send by sending the message to the remote JMS
-	 * server and then returning without waiting for an acknowledgement. When
-	 * the acknowledgement is received, the JMS provider would notify the
-	 * application by invoking the <tt>onCompletion</tt> method on the
-	 * application-specified <tt>CompletionListener</tt> object. If for some
-	 * reason the acknowledgement is not received the JMS provider would notify
-	 * the application by invoking the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method.
-	 * <p>
-	 * In those cases where the JMS specification permits a lower level of
-	 * reliability, a normal synchronous send might not wait for an
-	 * acknowledgement. In that case it is expected that an asynchronous send
-	 * would be similar to a synchronous send: the JMS provider would send the
-	 * message to the remote JMS server and then return without waiting for an
-	 * acknowledgement. However the JMS provider would still notify the
-	 * application that the send had completed by invoking the
-	 * <tt>onCompletion</tt> method on the application-specified
-	 * <tt>CompletionListener</tt> object.
-	 * <p>
-	 * It is up to the JMS provider to decide exactly what is performed in the
-	 * calling thread and what, if anything, is performed asynchronously, so
-	 * long as it satisfies the requirements given below:
-	 * <p>
-	 * <b>Quality of service</b>: After the send operation has completed
-	 * successfully, which means that the message has been successfully sent
-	 * with the same degree of confidence as if a normal synchronous send had
-	 * been performed, the JMS provider must invoke the
-	 * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The
-	 * <tt>CompletionListener</tt> must not be invoked earlier than this.
-	 * <p>
-	 * <b>Exceptions</b>: If an exception is encountered during the call to the
-	 * <tt>send</tt> method then an appropriate exception should be thrown in
-	 * the thread that is calling the <tt>send</tt> method. In this case the JMS provider
-	 * must not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt>
-	 * or <tt>onException</tt> method. If an exception is encountered which
-	 * cannot be thrown in the thread that is calling the <tt>send</tt> method then the
-	 * JMS provider must call the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method. In both cases if an exception occurs it is
-	 * undefined whether or not the message was successfully sent.
-	 * <p>
-	 * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to
-	 * send multiple messages then JMS message ordering requirements must be
-	 * satisfied. This applies even if a combination of synchronous and
-	 * asynchronous sends has been performed. The application is not required to
-	 * wait for an asynchronous send to complete before sending the next
-	 * message.
-	 * <p>
-	 * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called
-	 * on the <tt>MessageProducer</tt> or its <tt>Session</tt> or
-	 * <tt>Connection</tt> then the JMS provider must block until any incomplete
-	 * send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before closing
-	 * the object and returning. If the session is transacted (uses a local
-	 * transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
-	 * <tt>rollback</tt> method is called the JMS provider must block until any
-	 * incomplete send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before performing
-	 * the commit or rollback. Incomplete sends should be allowed to complete
-	 * normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>Connection</tt>, <tt>Session</tt> or
-	 * <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on
-	 * its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-	 * <tt>commit</tt> or <tt>rollback</tt> to throw an
-	 * <tt>IllegalStateException</tt>.
-	 * <p>
-	 * <b>Restrictions on usage in Java EE</b> This method must not be used in a
-	 * Java EE EJB or web container. Doing so may cause a {@code JMSException} 
-	 * to be thrown though this is not guaranteed.
-	 * <p>
-	 * <b>Message headers</b> JMS defines a number of message header fields and
-	 * message properties which must be set by the "JMS provider on send". If
-	 * the send is asynchronous these fields and properties may be accessed on
-	 * the sending client only after the <tt>CompletionListener</tt> has been
-	 * invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method
-	 * is called then the state of these message header fields and properties is
-	 * undefined.
-	 * <p>
-	 * <b>Restrictions on threading</b>: Applications that perform an
-	 * asynchronous send must confirm to the threading restrictions defined in
-	 * JMS. This means that the session may be used by only one thread at a
-	 * time.
-	 * <p>
-	 * Setting a <tt>CompletionListener</tt> does not cause the session to be
-	 * dedicated to the thread of control which calls the
-	 * <tt>CompletionListener</tt>. The application thread may therefore
-	 * continue to use the session after performing an asynchronous send.
-	 * However the <tt>CompletionListener</tt>'s callback methods must not use
-	 * the session if an application thread might be using the session at the
-	 * same time.
-	 * <p>
-	 * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A
-	 * session will only invoke one <tt>CompletionListener</tt> callback method
-	 * at a time. For a given <tt>MessageProducer</tt>, callbacks (both
-	 * {@code onCompletion} and {@code onException}) will be performed
-	 * in the same order as the corresponding calls to the asynchronous send
-	 * method.
-	 * A JMS provider must not invoke the <tt>CompletionListener</tt> from the
-	 * thread that is calling the asynchronous <tt>send</tt> method.
-	 * <p>
-	 * <b>Restrictions on the use of the Message object</b>: Applications which
-	 * perform an asynchronous send must take account of the restriction that a
-	 * <tt>Message</tt> object is designed to be accessed by one logical thread
-	 * of control at a time and does not support concurrent use.
-	 * <p>
-	 * After the <tt>send</tt> method has returned, the application must not
-	 * attempt to read the headers, properties or body of the
-	 * <tt>Message</tt> object until the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method has been called.
-	 * This is because the JMS provider may be modifying the <tt>Message</tt>
-	 * object in another thread during this time. The JMS provider may throw an
-	 * <tt>JMSException</tt> if the application attempts to access or modify the
-	 * <tt>Message</tt> object after the <tt>send</tt> method has returned and
-	 * before the <tt>CompletionListener</tt> has been invoked. If the JMS
-	 * provider does not throw an exception then the behaviour is undefined.
-	 * 
-	 * @param message
-	 *            the message to send
-	 * @param completionListener
-	 *            a {@code CompletionListener} to be notified when the send
-	 *            has completed
-	 * 
-	 * @exception JMSException
-	 *                if an internal error occurs 
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} with an invalid destination.
-	 * @exception java.lang.IllegalArgumentException
-	 *                if the specified {@code CompletionListener} is null
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that did not specify a
-	 *                destination at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * @see javax.jms.CompletionListener
-	 * 
-	 * @since JMS 2.0
-	 */
-	void send(Message message, CompletionListener completionListener) throws JMSException;
-	
-	/**
-	 * Sends a message, specifying delivery mode, priority and time to live,
-	 * performing part of the work involved in sending the message in a separate
-	 * thread and notifying the specified <tt>CompletionListener</tt> when the
-	 * operation has completed. JMS refers to this as an "asynchronous send".
-	 * <p>
-	 * When the message has been successfully sent the JMS provider invokes the
-	 * callback method <tt>onCompletion</tt> on an application-specified
-	 * <tt>CompletionListener</tt> object. Only when that callback has been
-	 * invoked can the application be sure that the message has been
-	 * successfully sent with the same degree of confidence as if a normal
-	 * synchronous send had been performed. An application which requires this
-	 * degree of confidence must therefore wait for the callback to be invoked
-	 * before continuing.
-	 * <p>
-	 * The following information is intended to give an indication of how an
-	 * asynchronous send would typically be implemented.
-	 * <p>
-	 * In some JMS providers, a normal synchronous send involves sending the
-	 * message to a remote JMS server and then waiting for an acknowledgement to
-	 * be received before returning. It is expected that such a provider would
-	 * implement an asynchronous send by sending the message to the remote JMS
-	 * server and then returning without waiting for an acknowledgement. When
-	 * the acknowledgement is received, the JMS provider would notify the
-	 * application by invoking the <tt>onCompletion</tt> method on the
-	 * application-specified <tt>CompletionListener</tt> object. If for some
-	 * reason the acknowledgement is not received the JMS provider would notify
-	 * the application by invoking the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method.
-	 * <p>
-	 * In those cases where the JMS specification permits a lower level of
-	 * reliability, a normal synchronous send might not wait for an
-	 * acknowledgement. In that case it is expected that an asynchronous send
-	 * would be similar to a synchronous send: the JMS provider would send the
-	 * message to the remote JMS server and then return without waiting for an
-	 * acknowledgement. However the JMS provider would still notify the
-	 * application that the send had completed by invoking the
-	 * <tt>onCompletion</tt> method on the application-specified
-	 * <tt>CompletionListener</tt> object.
-	 * <p>
-	 * It is up to the JMS provider to decide exactly what is performed in the
-	 * calling thread and what, if anything, is performed asynchronously, so
-	 * long as it satisfies the requirements given below:
-	 * <p>
-	 * <b>Quality of service</b>: After the send operation has completed
-	 * successfully, which means that the message has been successfully sent
-	 * with the same degree of confidence as if a normal synchronous send had
-	 * been performed, the JMS provider must invoke the
-	 * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The
-	 * <tt>CompletionListener</tt> must not be invoked earlier than this.
-	 * <p>
-	 * <b>Exceptions</b>: If an exception is encountered during the call to the
-	 * <tt>send</tt> method then an appropriate exception should be thrown in
-	 * the thread that is calling the <tt>send</tt> method. In this case the JMS provider
-	 * must not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt>
-	 * or <tt>onException</tt> method. If an exception is encountered which
-	 * cannot be thrown in the thread that is calling the <tt>send</tt> method then the
-	 * JMS provider must call the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method. In both cases if an exception occurs it is
-	 * undefined whether or not the message was successfully sent.
-	 * <p>
-	 * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to
-	 * send multiple messages then JMS message ordering requirements must be
-	 * satisfied. This applies even if a combination of synchronous and
-	 * asynchronous sends has been performed. The application is not required to
-	 * wait for an asynchronous send to complete before sending the next
-	 * message.
-	 * <p>
-	 * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called
-	 * on the <tt>MessageProducer</tt> or its <tt>Session</tt> or
-	 * <tt>Connection</tt> then the JMS provider must block until any incomplete
-	 * send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before closing
-	 * the object and returning. If the session is transacted (uses a local
-	 * transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
-	 * <tt>rollback</tt> method is called the JMS provider must block until any
-	 * incomplete send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before performing
-	 * the commit or rollback. Incomplete sends should be allowed to complete
-	 * normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>Connection</tt>, <tt>Session</tt> or
-	 * <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on
-	 * its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-	 * <tt>commit</tt> or <tt>rollback</tt> to throw an
-	 * <tt>IllegalStateException</tt>.
-	 * <p> 
-	 * <b>Restrictions on usage in Java EE</b> This method must not be used in a
-	 * Java EE EJB or web container. Doing so may cause a {@code JMSException} 
-	 * to be thrown though this is not guaranteed.
-	 * <p>
-	 * <b>Message headers</b> JMS defines a number of message header fields and
-	 * message properties which must be set by the "JMS provider on send". If
-	 * the send is asynchronous these fields and properties may be accessed on
-	 * the sending client only after the <tt>CompletionListener</tt> has been
-	 * invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method
-	 * is called then the state of these message header fields and properties is
-	 * undefined.
-	 * <p>
-	 * <b>Restrictions on threading</b>: Applications that perform an
-	 * asynchronous send must confirm to the threading restrictions defined in
-	 * JMS. This means that the session may be used by only one thread at a
-	 * time.
-	 * <p>
-	 * Setting a <tt>CompletionListener</tt> does not cause the session to be
-	 * dedicated to the thread of control which calls the
-	 * <tt>CompletionListener</tt>. The application thread may therefore
-	 * continue to use the session after performing an asynchronous send.
-	 * However the <tt>CompletionListener</tt>'s callback methods must not use
-	 * the session if an application thread might be using the session at the
-	 * same time.
-	 * <p>
-	 * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A
-	 * session will only invoke one <tt>CompletionListener</tt> callback method
-	 * at a time. For a given <tt>MessageProducer</tt>, callbacks (both
-	 * {@code onCompletion} and {@code onException}) will be performed
-	 * in the same order as the corresponding calls to the asynchronous send
-	 * method.
-	 * A JMS provider must not invoke the <tt>CompletionListener</tt> from the
-	 * thread that is calling the asynchronous <tt>send</tt> method.
-	 * <p>
-	 * <b>Restrictions on the use of the Message object</b>: Applications which
-	 * perform an asynchronous send must take account of the restriction that a
-	 * <tt>Message</tt> object is designed to be accessed by one logical thread
-	 * of control at a time and does not support concurrent use.
-	 * <p>
-	 * After the <tt>send</tt> method has returned, the application must not
-	 * attempt to read the headers, properties or body of the
-	 * <tt>Message</tt> object until the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method has been called.
-	 * This is because the JMS provider may be modifying the <tt>Message</tt>
-	 * object in another thread during this time. The JMS provider may throw an
-	 * <tt>JMSException</tt> if the application attempts to access or modify the
-	 * <tt>Message</tt> object after the <tt>send</tt> method has returned and
-	 * before the <tt>CompletionListener</tt> has been invoked. If the JMS
-	 * provider does not throw an exception then the behaviour is undefined.
-	 * 
-	 * @param message
-	 *            the message to send
-	 * @param deliveryMode
-	 *            the delivery mode to use
-	 * @param priority
-	 *            the priority for this message
-	 * @param timeToLive
-	 *            the message's lifetime (in milliseconds)
-	 * @param completionListener
-	 *            a {@code CompletionListener} to be notified when the send
-	 *            has completed
-	 * 
-	 * @exception JMSException
-	 *                if an internal error occurs 
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} with an invalid destination.
-	 * @exception java.lang.IllegalArgumentException
-	 *                if the specified {@code CompletionListener} is null
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that did not specify a
-	 *                destination at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * @see javax.jms.CompletionListener
-	 * 
-	 * @since JMS 2.0
-	 */
-
-	void send(Message message, int deliveryMode, int priority, long timeToLive, CompletionListener completionListener)
-			throws JMSException;
-
-	/**
-	 * Sends a message to a destination for an unidentified message producer,
-	 * using the {@code MessageProducer}'s default delivery mode, priority,
-	 * and time to live, performing part of the work involved in sending the
-	 * message in a separate thread and notifying the specified
-	 * <tt>CompletionListener</tt> when the operation has completed. JMS refers
-	 * to this as an "asynchronous send".
-	 * <p>
-	 * Typically, a message producer is assigned a destination at creation time;
-	 * however, the JMS API also supports unidentified message producers, which
-	 * require that the destination be supplied every time a message is sent.
-	 * <p>
-	 * When the message has been successfully sent the JMS provider invokes the
-	 * callback method <tt>onCompletion</tt> on an application-specified
-	 * <tt>CompletionListener</tt> object. Only when that callback has been
-	 * invoked can the application be sure that the message has been
-	 * successfully sent with the same degree of confidence as if a normal
-	 * synchronous send had been performed. An application which requires this
-	 * degree of confidence must therefore wait for the callback to be invoked
-	 * before continuing.
-	 * <p>
-	 * The following information is intended to give an indication of how an
-	 * asynchronous send would typically be implemented.
-	 * <p>
-	 * In some JMS providers, a normal synchronous send involves sending the
-	 * message to a remote JMS server and then waiting for an acknowledgement to
-	 * be received before returning. It is expected that such a provider would
-	 * implement an asynchronous send by sending the message to the remote JMS
-	 * server and then returning without waiting for an acknowledgement. When
-	 * the acknowledgement is received, the JMS provider would notify the
-	 * application by invoking the <tt>onCompletion</tt> method on the
-	 * application-specified <tt>CompletionListener</tt> object. If for some
-	 * reason the acknowledgement is not received the JMS provider would notify
-	 * the application by invoking the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method.
-	 * <p>
-	 * In those cases where the JMS specification permits a lower level of
-	 * reliability, a normal synchronous send might not wait for an
-	 * acknowledgement. In that case it is expected that an asynchronous send
-	 * would be similar to a synchronous send: the JMS provider would send the
-	 * message to the remote JMS server and then return without waiting for an
-	 * acknowledgement. However the JMS provider would still notify the
-	 * application that the send had completed by invoking the
-	 * <tt>onCompletion</tt> method on the application-specified
-	 * <tt>CompletionListener</tt> object.
-	 * <p>
-	 * It is up to the JMS provider to decide exactly what is performed in the
-	 * calling thread and what, if anything, is performed asynchronously, so
-	 * long as it satisfies the requirements given below:
-	 * <p>
-	 * <b>Quality of service</b>: After the send operation has completed
-	 * successfully, which means that the message has been successfully sent
-	 * with the same degree of confidence as if a normal synchronous send had
-	 * been performed, the JMS provider must invoke the
-	 * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The
-	 * <tt>CompletionListener</tt> must not be invoked earlier than this.
-	 * <p>
-	 * <b>Exceptions</b>: If an exception is encountered during the call to the
-	 * <tt>send</tt> method then an appropriate exception should be thrown in
-	 * the thread that is calling the <tt>send</tt> method. In this case the JMS
-	 * provider must not invoke the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
-	 * encountered which cannot be thrown in the thread that is calling the
-	 * <tt>send</tt> method then the JMS provider must call the
-	 * <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases
-	 * if an exception occurs it is undefined whether or not the message was
-	 * successfully sent.
-	 * <p>
-	 * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to
-	 * send multiple messages then JMS message ordering requirements must be
-	 * satisfied. This applies even if a combination of synchronous and
-	 * asynchronous sends has been performed. The application is not required to
-	 * wait for an asynchronous send to complete before sending the next
-	 * message.
-	 * <p>
-	 * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called
-	 * on the <tt>MessageProducer</tt> or its <tt>Session</tt> or
-	 * <tt>Connection</tt> then the JMS provider must block until any incomplete
-	 * send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before closing
-	 * the object and returning. If the session is transacted (uses a local
-	 * transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
-	 * <tt>rollback</tt> method is called the JMS provider must block until any
-	 * incomplete send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before performing
-	 * the commit or rollback. Incomplete sends should be allowed to complete
-	 * normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>Connection</tt>, <tt>Session</tt> or
-	 * <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on
-	 * its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-	 * <tt>commit</tt> or <tt>rollback</tt> to throw an
-	 * <tt>IllegalStateException</tt>.
-	 * <p>
-	 * <b>Restrictions on usage in Java EE</b> This method must not be used in a
-	 * Java EE EJB or web container. Doing so may cause a {@code JMSException} 
-	 * to be thrown though this is not guaranteed.
-	 * <p>
-	 * <b>Message headers</b> JMS defines a number of message header fields and
-	 * message properties which must be set by the "JMS provider on send". If
-	 * the send is asynchronous these fields and properties may be accessed on
-	 * the sending client only after the <tt>CompletionListener</tt> has been
-	 * invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method
-	 * is called then the state of these message header fields and properties is
-	 * undefined.
-	 * <p>
-	 * <b>Restrictions on threading</b>: Applications that perform an
-	 * asynchronous send must confirm to the threading restrictions defined in
-	 * JMS. This means that the session may be used by only one thread at a
-	 * time.
-	 * <p>
-	 * Setting a <tt>CompletionListener</tt> does not cause the session to be
-	 * dedicated to the thread of control which calls the
-	 * <tt>CompletionListener</tt>. The application thread may therefore
-	 * continue to use the session after performing an asynchronous send.
-	 * However the <tt>CompletionListener</tt>'s callback methods must not use
-	 * the session if an application thread might be using the session at the
-	 * same time.
-	 * <p>
-	 * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A
-	 * session will only invoke one <tt>CompletionListener</tt> callback method
-	 * at a time. For a given <tt>MessageProducer</tt>, callbacks (both
-	 * {@code onCompletion} and {@code onException}) will be performed
-	 * in the same order as the corresponding calls to the asynchronous send
-	 * method. A JMS provider must not invoke the <tt>CompletionListener</tt>
-	 * from the thread that is calling the asynchronous <tt>send</tt> method.
-	 * <p>
-	 * <b>Restrictions on the use of the Message object</b>: Applications which
-	 * perform an asynchronous send must take account of the restriction that a
-	 * <tt>Message</tt> object is designed to be accessed by one logical thread
-	 * of control at a time and does not support concurrent use.
-	 * <p>
-	 * After the <tt>send</tt> method has returned, the application must not
-	 * attempt to read the headers, properties or body of the
-	 * <tt>Message</tt> object until the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method has been called.
-	 * This is because the JMS provider may be modifying the <tt>Message</tt>
-	 * object in another thread during this time. The JMS provider may throw an
-	 * <tt>JMSException</tt> if the application attempts to access or modify the
-	 * <tt>Message</tt> object after the <tt>send</tt> method has returned and
-	 * before the <tt>CompletionListener</tt> has been invoked. If the JMS
-	 * provider does not throw an exception then the behaviour is undefined.
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param message
-	 *            the message to send
-	 * @param completionListener
-	 *            a {@code CompletionListener} to be notified when the send
-	 *            has completed
-	 * 
-	 * @exception JMSException
-	 *                if an internal error occurs
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with an invalid destination
-	 * @exception java.lang.IllegalArgumentException
-	 *                if the specified {@code CompletionListener} is null
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that specified a destination
-	 *                at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * @see javax.jms.CompletionListener
-	 * 
-	 * @since JMS 2.0
-	 */
-
-	void send(Destination destination, Message message, CompletionListener completionListener) throws JMSException;
-	
-	/**
-	 * Sends a message to a destination for an unidentified message producer,
-	 * specifying delivery mode, priority and time to live, performing part of
-	 * the work involved in sending the message in a separate thread and
-	 * notifying the specified <tt>CompletionListener</tt> when the operation
-	 * has completed. JMS refers to this as an "asynchronous send".
-	 * <p>
-	 * Typically, a message producer is assigned a destination at creation time;
-	 * however, the JMS API also supports unidentified message producers, which
-	 * require that the destination be supplied every time a message is sent.
-	 * <p>
-	 * When the message has been successfully sent the JMS provider invokes the
-	 * callback method <tt>onCompletion</tt> on an application-specified
-	 * <tt>CompletionListener</tt> object. Only when that callback has been
-	 * invoked can the application be sure that the message has been
-	 * successfully sent with the same degree of confidence as if a normal
-	 * synchronous send had been performed. An application which requires this
-	 * degree of confidence must therefore wait for the callback to be invoked
-	 * before continuing.
-	 * <p>
-	 * The following information is intended to give an indication of how an
-	 * asynchronous send would typically be implemented.
-	 * <p>
-	 * In some JMS providers, a normal synchronous send involves sending the
-	 * message to a remote JMS server and then waiting for an acknowledgement to
-	 * be received before returning. It is expected that such a provider would
-	 * implement an asynchronous send by sending the message to the remote JMS
-	 * server and then returning without waiting for an acknowledgement. When
-	 * the acknowledgement is received, the JMS provider would notify the
-	 * application by invoking the <tt>onCompletion</tt> method on the
-	 * application-specified <tt>CompletionListener</tt> object. If for some
-	 * reason the acknowledgement is not received the JMS provider would notify
-	 * the application by invoking the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method.
-	 * <p>
-	 * In those cases where the JMS specification permits a lower level of
-	 * reliability, a normal synchronous send might not wait for an
-	 * acknowledgement. In that case it is expected that an asynchronous send
-	 * would be similar to a synchronous send: the JMS provider would send the
-	 * message to the remote JMS server and then return without waiting for an
-	 * acknowledgement. However the JMS provider would still notify the
-	 * application that the send had completed by invoking the
-	 * <tt>onCompletion</tt> method on the application-specified
-	 * <tt>CompletionListener</tt> object.
-	 * <p>
-	 * It is up to the JMS provider to decide exactly what is performed in the
-	 * calling thread and what, if anything, is performed asynchronously, so
-	 * long as it satisfies the requirements given below:
-	 * <p>
-	 * <b>Quality of service</b>: After the send operation has completed
-	 * successfully, which means that the message has been successfully sent
-	 * with the same degree of confidence as if a normal synchronous send had
-	 * been performed, the JMS provider must invoke the
-	 * <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The
-	 * <tt>CompletionListener</tt> must not be invoked earlier than this.
-	 * <p>
-	 * <b>Exceptions</b>: If an exception is encountered during the call to the
-	 * <tt>send</tt> method then an appropriate exception should be thrown in
-	 * the thread that is calling the <tt>send</tt> method. In this case the JMS provider
-	 * must not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt>
-	 * or <tt>onException</tt> method. If an exception is encountered which
-	 * cannot be thrown in the thread that is calling the <tt>send</tt> method then the
-	 * JMS provider must call the <tt>CompletionListener</tt>'s
-	 * <tt>onException</tt> method. In both cases if an exception occurs it is
-	 * undefined whether or not the message was successfully sent.
-	 * <p>
-	 * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to
-	 * send multiple messages then JMS message ordering requirements must be
-	 * satisfied. This applies even if a combination of synchronous and
-	 * asynchronous sends has been performed. The application is not required to
-	 * wait for an asynchronous send to complete before sending the next
-	 * message.
-	 * <p>
-	 * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called
-	 * on the <tt>MessageProducer</tt> or its <tt>Session</tt> or
-	 * <tt>Connection</tt> then the JMS provider must block until any incomplete
-	 * send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before closing
-	 * the object and returning. If the session is transacted (uses a local
-	 * transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
-	 * <tt>rollback</tt> method is called the JMS provider must block until any
-	 * incomplete send operations have been completed and all
-	 * {@code CompletionListener} callbacks have returned before performing
-	 * the commit or rollback. Incomplete sends should be allowed to complete
-	 * normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>Connection</tt>, <tt>Session</tt> or
-	 * <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on
-	 * its own <tt>Session</tt>. Doing so will cause the <tt>close</tt>,
-	 * <tt>commit</tt> or <tt>rollback</tt> to throw an
-	 * <tt>IllegalStateException</tt>.
-	 * <p>
-	 * <b>Restrictions on usage in Java EE</b> This method must not be used in a
-	 * Java EE EJB or web container. Doing so may cause a {@code JMSException} 
-	 * to be thrown though this is not guaranteed.
-	 * <p>
-	 * <b>Message headers</b> JMS defines a number of message header fields and
-	 * message properties which must be set by the "JMS provider on send". If
-	 * the send is asynchronous these fields and properties may be accessed on
-	 * the sending client only after the <tt>CompletionListener</tt> has been
-	 * invoked. If the <tt>CompletionListener</tt>'s <tt>onException</tt> method
-	 * is called then the state of these message header fields and properties is
-	 * undefined.
-	 * <p>
-	 * <b>Restrictions on threading</b>: Applications that perform an
-	 * asynchronous send must confirm to the threading restrictions defined in
-	 * JMS. This means that the session may be used by only one thread at a
-	 * time.
-	 * <p>
-	 * Setting a <tt>CompletionListener</tt> does not cause the session to be
-	 * dedicated to the thread of control which calls the
-	 * <tt>CompletionListener</tt>. The application thread may therefore
-	 * continue to use the session after performing an asynchronous send.
-	 * However the <tt>CompletionListener</tt>'s callback methods must not use
-	 * the session if an application thread might be using the session at the
-	 * same time.
-	 * <p>
-	 * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A
-	 * session will only invoke one <tt>CompletionListener</tt> callback method
-	 * at a time. For a given <tt>MessageProducer</tt>, callbacks (both
-	 * {@code onCompletion} and {@code onException}) will be performed
-	 * in the same order as the corresponding calls to the asynchronous send
-	 * method.
-	 * A JMS provider must not invoke the <tt>CompletionListener</tt> from the
-	 * thread that is calling the asynchronous <tt>send</tt> method.
-	 * <p>
-	 * <b>Restrictions on the use of the Message object</b>: Applications which
-	 * perform an asynchronous send must take account of the restriction that a
-	 * <tt>Message</tt> object is designed to be accessed by one logical thread
-	 * of control at a time and does not support concurrent use.
-	 * <p>
-	 * After the <tt>send</tt> method has returned, the application must not
-	 * attempt to read the headers, properties or body of the
-	 * <tt>Message</tt> object until the <tt>CompletionListener</tt>'s
-	 * <tt>onCompletion</tt> or <tt>onException</tt> method has been called.
-	 * This is because the JMS provider may be modifying the <tt>Message</tt>
-	 * object in another thread during this time. The JMS provider may throw an
-	 * <tt>JMSException</tt> if the application attempts to access or modify the
-	 * <tt>Message</tt> object after the <tt>send</tt> method has returned and
-	 * before the <tt>CompletionListener</tt> has been invoked. If the JMS
-	 * provider does not throw an exception then the behaviour is undefined.
-	 * 
-	 * 
-	 * @param destination
-	 *            the destination to send this message to
-	 * @param message
-	 *            the message to send
-	 * @param deliveryMode
-	 *            the delivery mode to use
-	 * @param priority
-	 *            the priority for this message
-	 * @param timeToLive
-	 *            the message's lifetime (in milliseconds)
-	 * @param completionListener
-	 *            a {@code CompletionListener} to be notified when the send
-	 *            has completed
-	 * 
-	 * @exception JMSException
-	 *                if an internal error occurs
-	 * @exception MessageFormatException
-	 *                if an invalid message is specified.
-	 * @exception InvalidDestinationException
-	 *                if a client uses this method with an invalid destination.
-	 * @exception java.lang.IllegalArgumentException
-	 *                if the specified {@code CompletionListener} is null
-	 * @exception java.lang.UnsupportedOperationException
-	 *                if a client uses this method with a
-	 *                {@code MessageProducer} that specified a destination
-	 *                at creation time.
-	 * 
-	 * @see javax.jms.Session#createProducer
-	 * @see javax.jms.CompletionListener
-	 * 
-	 * @since JMS 2.0
-	 */
-
-	void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive,
-			CompletionListener completionListener) throws JMSException;
+    /**
+     * Sends a message to a destination for an unidentified message producer, specifying delivery mode, priority and time to
+     * live, performing part of the work involved in sending the message in a separate thread and notifying the specified
+     * <tt>CompletionListener</tt> when the operation has completed. JMS refers to this as an "asynchronous send".
+     *
+     * <p>
+     * Typically, a message producer is assigned a destination at creation time; however, the JMS API also supports
+     * unidentified message producers, which require that the destination be supplied every time a message is sent.
+     *
+     * <p>
+     * When the message has been successfully sent the JMS provider invokes the callback method <tt>onCompletion</tt> on an
+     * application-specified <tt>CompletionListener</tt> object. Only when that callback has been invoked can the
+     * application be sure that the message has been successfully sent with the same degree of confidence as if a normal
+     * synchronous send had been performed. An application which requires this degree of confidence must therefore wait for
+     * the callback to be invoked before continuing.
+     *
+     * <p>
+     * The following information is intended to give an indication of how an asynchronous send would typically be
+     * implemented.
+     *
+     * <p>
+     * In some JMS providers, a normal synchronous send involves sending the message to a remote JMS server and then waiting
+     * for an acknowledgement to be received before returning. It is expected that such a provider would implement an
+     * asynchronous send by sending the message to the remote JMS server and then returning without waiting for an
+     * acknowledgement. When the acknowledgement is received, the JMS provider would notify the application by invoking the
+     * <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object. If for some reason the
+     * acknowledgement is not received the JMS provider would notify the application by invoking the
+     * <tt>CompletionListener</tt>'s <tt>onException</tt> method.
+     *
+     * <p>
+     * In those cases where the JMS specification permits a lower level of reliability, a normal synchronous send might not
+     * wait for an acknowledgement. In that case it is expected that an asynchronous send would be similar to a synchronous
+     * send: the JMS provider would send the message to the remote JMS server and then return without waiting for an
+     * acknowledgement. However the JMS provider would still notify the application that the send had completed by invoking
+     * the <tt>onCompletion</tt> method on the application-specified <tt>CompletionListener</tt> object.
+     *
+     * <p>
+     * It is up to the JMS provider to decide exactly what is performed in the calling thread and what, if anything, is
+     * performed asynchronously, so long as it satisfies the requirements given below:
+     *
+     * <p>
+     * <b>Quality of service</b>: After the send operation has completed successfully, which means that the message has been
+     * successfully sent with the same degree of confidence as if a normal synchronous send had been performed, the JMS
+     * provider must invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> method. The <tt>CompletionListener</tt>
+     * must not be invoked earlier than this.
+     *
+     * <p>
+     * <b>Exceptions</b>: If an exception is encountered during the call to the <tt>send</tt> method then an appropriate
+     * exception should be thrown in the thread that is calling the <tt>send</tt> method. In this case the JMS provider must
+     * not invoke the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt> method. If an exception is
+     * encountered which cannot be thrown in the thread that is calling the <tt>send</tt> method then the JMS provider must
+     * call the <tt>CompletionListener</tt>'s <tt>onException</tt> method. In both cases if an exception occurs it is
+     * undefined whether or not the message was successfully sent.
+     *
+     * <p>
+     * <b>Message order</b>: If the same <tt>MessageProducer</tt> is used to send multiple messages then JMS message
+     * ordering requirements must be satisfied. This applies even if a combination of synchronous and asynchronous sends has
+     * been performed. The application is not required to wait for an asynchronous send to complete before sending the next
+     * message.
+     *
+     * <p>
+     * <b>Close, commit or rollback</b>: If the <tt>close</tt> method is called on the <tt>MessageProducer</tt> or its
+     * <tt>Session</tt> or <tt>Connection</tt> then the JMS provider must block until any incomplete send operations have
+     * been completed and all {@code CompletionListener} callbacks have returned before closing the object and returning. If
+     * the session is transacted (uses a local transaction) then when the <tt>Session</tt>'s <tt>commit</tt> or
+     * <tt>rollback</tt> method is called the JMS provider must block until any incomplete send operations have been
+     * completed and all {@code CompletionListener} callbacks have returned before performing the commit or rollback.
+     * Incomplete sends should be allowed to complete normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>Connection</tt>,
+     * <tt>Session</tt> or <tt>MessageProducer</tt> or call <tt>commit</tt> or <tt>rollback</tt> on its own
+     * <tt>Session</tt>. Doing so will cause the <tt>close</tt>, <tt>commit</tt> or <tt>rollback</tt> to throw an
+     * <tt>IllegalStateException</tt>.
+     *
+     * <p>
+     * <b>Restrictions on usage in Java EE</b> This method must not be used in a Java EE EJB or web container. Doing so may
+     * cause a {@code JMSException} to be thrown though this is not guaranteed.
+     *
+     * <p>
+     * <b>Message headers</b> JMS defines a number of message header fields and message properties which must be set by the
+     * "JMS provider on send". If the send is asynchronous these fields and properties may be accessed on the sending client
+     * only after the <tt>CompletionListener</tt> has been invoked. If the <tt>CompletionListener</tt>'s
+     * <tt>onException</tt> method is called then the state of these message header fields and properties is undefined.
+     *
+     * <p>
+     * <b>Restrictions on threading</b>: Applications that perform an asynchronous send must confirm to the threading
+     * restrictions defined in JMS. This means that the session may be used by only one thread at a time.
+     *
+     * <p>
+     * Setting a <tt>CompletionListener</tt> does not cause the session to be dedicated to the thread of control which calls
+     * the <tt>CompletionListener</tt>. The application thread may therefore continue to use the session after performing an
+     * asynchronous send. However the <tt>CompletionListener</tt>'s callback methods must not use the session if an
+     * application thread might be using the session at the same time.
+     *
+     * <p>
+     * <b>Use of the <tt>CompletionListener</tt> by the JMS provider</b>: A session will only invoke one
+     * <tt>CompletionListener</tt> callback method at a time. For a given <tt>MessageProducer</tt>, callbacks (both
+     * {@code onCompletion} and {@code onException}) will be performed in the same order as the corresponding calls to the
+     * asynchronous send method. A JMS provider must not invoke the <tt>CompletionListener</tt> from the thread that is
+     * calling the asynchronous <tt>send</tt> method.
+     *
+     * <p>
+     * <b>Restrictions on the use of the Message object</b>: Applications which perform an asynchronous send must take
+     * account of the restriction that a <tt>Message</tt> object is designed to be accessed by one logical thread of control
+     * at a time and does not support concurrent use.
+     *
+     * <p>
+     * After the <tt>send</tt> method has returned, the application must not attempt to read the headers, properties or body
+     * of the <tt>Message</tt> object until the <tt>CompletionListener</tt>'s <tt>onCompletion</tt> or <tt>onException</tt>
+     * method has been called. This is because the JMS provider may be modifying the <tt>Message</tt> object in another
+     * thread during this time. The JMS provider may throw an <tt>JMSException</tt> if the application attempts to access or
+     * modify the <tt>Message</tt> object after the <tt>send</tt> method has returned and before the
+     * <tt>CompletionListener</tt> has been invoked. If the JMS provider does not throw an exception then the behaviour is
+     * undefined.
+     *
+     * @param destination the destination to send this message to
+     * @param message the message to send
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     * @param completionListener a {@code CompletionListener} to be notified when the send has completed
+     *
+     * @exception JMSException if an internal error occurs
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid destination.
+     * @exception java.lang.IllegalArgumentException if the specified {@code CompletionListener} is null
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code MessageProducer} that
+     * specified a destination at creation time.
+     *
+     * @see javax.jms.Session#createProducer
+     * @see javax.jms.CompletionListener
+     *
+     * @since JMS 2.0
+     */
+    void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive, CompletionListener completionListener)
+            throws JMSException;
 
 }

--- a/src/main/java/javax/jms/MessageProperty.java
+++ b/src/main/java/javax/jms/MessageProperty.java
@@ -16,30 +16,29 @@
 
 package javax.jms;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies that a callback method parameter must be set to the specified
- * message property value. This annotation may be applied to parameters on a
- * callback method on a JMS message-driven bean that has been annotated with the
- * {@code JMSQueueListener} , {@code JMSNonDurableTopicListener} or
- * {@code JMSDurableTopicListener} annotation.
+ * Specifies that a callback method parameter must be set to the specified message property value. This annotation may
+ * be applied to parameters on a callback method on a JMS message-driven bean that has been annotated with the
+ * {@code JMSQueueListener} , {@code JMSNonDurableTopicListener} or {@code JMSDurableTopicListener} annotation.
+ *
  * <p>
  * The parameter must have a type appropriate to the specified property.
+ *
  * <p>
- * The method that will be used by the application server or resource adapter to
- * obtain the property value will depend on the parameter type. The table below
- * defines the method that will be used to obtain the value of a parameter
+ * The method that will be used by the application server or resource adapter to obtain the property value will depend
+ * on the parameter type. The table below defines the method that will be used to obtain the value of a parameter
  * annotated with {@code @MessageProperty("foo")}.
+ *
  * <p>
- * If the method parameter is not one of the types listed then deployment must
- * fail.
- * <p>
- * 
- * <PRE>
+ * If the method parameter is not one of the types listed then deployment must fail.
+ *
+ * <pre>
  * +-------------------------------------------------------+
  * | Parameter | Set to                                    |
  * | type      |                                           |
@@ -60,27 +59,28 @@ import java.lang.annotation.Target;
  * | Double    | (Double)message.getObjectProperty("foo")  |
  * | String    | message.getStringProperty("foo")          |
  * |-------------------------------------------------------+
- * </PRE>
+ * </pre>
+ *
  * <p>
- * Note that only {@code getObjectProperty} and {@code getStringObject} can
- * return a null value. This means that if the specified property is not set
- * then the parameter must be an object type ({@code Boolean}, {@code Byte},
- * {@code Short}, {@code Integer}, {@code Long}, {@code Float}, {@code Double}
- * or {@code String}), in which case the parameter will be set to null. *
- * 
+ * Note that only {@code getObjectProperty} and {@code getStringObject} can return a null value. This means that if the
+ * specified property is not set then the parameter must be an object type ({@code Boolean}, {@code Byte},
+ * {@code Short}, {@code Integer}, {@code Long}, {@code Float}, {@code Double} or {@code String}), in which case the
+ * parameter will be set to null. *
+ *
  * @see MessageHeader
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
-@Target({ ElementType.PARAMETER })
-@Retention(RetentionPolicy.RUNTIME)
+@Target(PARAMETER)
+@Retention(RUNTIME)
 public @interface MessageProperty {
 
-	/**
-	 * Specifies the name of the message property to be used
-	 */
-	String value();
+    /**
+     * Specifies the name of the message property to be used
+     *
+     * @return The name of the message property to be used
+     */
+    String value();
 
 }

--- a/src/main/java/javax/jms/MessageSelector.java
+++ b/src/main/java/javax/jms/MessageSelector.java
@@ -24,36 +24,37 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies that a callback method on a JMS message-driven bean
- * must use the specified message selector. It may be specified either on the
- * callback method or on the message-driven bean class.
+ * This annotation specifies that a callback method on a JMS message-driven bean must use the specified message
+ * selector. It may be specified either on the callback method or on the message-driven bean class.
+ *
  * <p>
- * If this annotation is specified on a method of a message-driven bean class
- * then that method must also be annotated with {@code QueueListener} or
- * {@code TopicListener}. If it is not then deployment will fail.
+ * If this annotation is specified on a method of a message-driven bean class then that method must also be annotated
+ * with {@code QueueListener} or {@code TopicListener}. If it is not then deployment will fail.
+ *
  * <p>
- * If this annotation is specified on the message-driven bean class then at
- * least one method must be annotated with {@code QueueListener} or
- * {@code TopicListener}. If no method is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
+ * If this annotation is specified on the message-driven bean class then at least one method must be annotated with
+ * {@code QueueListener} or {@code TopicListener}. If no method is annotated with {@code QueueListener} or
+ * {@code TopicListener} then deployment will fail.
+ *
  * <p>
- * If this annotation is specified on both a method of a message-driven bean
- * class and on the message-driven bean class itself then deployment will fail.
- * 
+ * If this annotation is specified on both a method of a message-driven bean class and on the message-driven bean class
+ * itself then deployment will fail.
+ *
  * @see QueueListener
  * @see TopicListener
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
 @Retention(RUNTIME)
 @Target({ METHOD, TYPE })
 public @interface MessageSelector {
 
-	/**
-	 * The message selector that will be used.
-	 */
-	String value();
+    /**
+     * The message selector that will be used.
+     *
+     * @return The message selector that will be used.
+     */
+    String value();
 
 }

--- a/src/main/java/javax/jms/ObjectMessage.java
+++ b/src/main/java/javax/jms/ObjectMessage.java
@@ -18,65 +18,53 @@ package javax.jms;
 
 import java.io.Serializable;
 
-/** An {@code ObjectMessage} object is used to send a message that contains
-  * a serializable object in the Java programming language ("Java object").
-  * It inherits from the {@code Message} interface and adds a body
-  * containing a single reference to an object. Only {@code Serializable} 
-  * Java objects can be used.
-  *
-  * <P>If a collection of Java objects must be sent, one of the 
-  * {@code Collection} classes provided since JDK 1.2 can be used.
-  *
-  * <P>When a client receives an {@code ObjectMessage}, it is in read-only 
-  * mode. If a client attempts to write to the message at this point, a 
-  * {@code MessageNotWriteableException} is thrown. If 
-  * {@code clearBody} is called, the message can now be both read from and 
-  * written to.
-  * 
-  * @see         javax.jms.Session#createObjectMessage()
-  * @see         javax.jms.Session#createObjectMessage(Serializable)
-  * @see         javax.jms.BytesMessage
-  * @see         javax.jms.MapMessage
-  * @see         javax.jms.Message
-  * @see         javax.jms.StreamMessage
-  * @see         javax.jms.TextMessage
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * An {@code ObjectMessage} object is used to send a message that contains a serializable object in the Java programming
+ * language ("Java object"). It inherits from the {@code Message} interface and adds a body containing a single
+ * reference to an object. Only {@code Serializable} Java objects can be used.
+ *
+ * <p>
+ * If a collection of Java objects must be sent, one of the {@code Collection} classes provided since JDK 1.2 can be
+ * used.
+ *
+ * <p>
+ * When a client receives an {@code ObjectMessage}, it is in read-only mode. If a client attempts to write to the
+ * message at this point, a {@code MessageNotWriteableException} is thrown. If {@code clearBody} is called, the message
+ * can now be both read from and written to.
+ *
+ * @see javax.jms.Session#createObjectMessage()
+ * @see javax.jms.Session#createObjectMessage(Serializable)
+ * @see javax.jms.BytesMessage
+ * @see javax.jms.MapMessage
+ * @see javax.jms.Message
+ * @see javax.jms.StreamMessage
+ * @see javax.jms.TextMessage
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface ObjectMessage extends Message {
 
-    /** Sets the serializable object containing this message's data.
-      * It is important to note that an {@code ObjectMessage}
-      * contains a snapshot of the object at the time {@code setObject()}
-      * is called; subsequent modifications of the object will have no 
-      * effect on the {@code ObjectMessage} body.
-      *
-      * @param object the message's data
-      *  
-      * @exception JMSException if the JMS provider fails to set the object
-      *                         due to some internal error.
-      * @exception MessageFormatException if object serialization fails.
-      * @exception MessageNotWriteableException if the message is in read-only
-      *                                         mode.
-      */
+    /**
+     * Sets the serializable object containing this message's data. It is important to note that an {@code ObjectMessage}
+     * contains a snapshot of the object at the time {@code setObject()} is called; subsequent modifications of the object
+     * will have no effect on the {@code ObjectMessage} body.
+     *
+     * @param object the message's data
+     *
+     * @exception JMSException if the JMS provider fails to set the object due to some internal error.
+     * @exception MessageFormatException if object serialization fails.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setObject(Serializable object) throws JMSException;
 
-    void 
-    setObject(Serializable object) throws JMSException;
-
-
-    /** Gets the serializable object containing this message's data. The 
-      * default value is null.
-      *
-      * @return the serializable object containing this message's data
-      *  
-      * @exception JMSException if the JMS provider fails to get the object
-      *                         due to some internal error.
-      * @exception MessageFormatException if object deserialization fails.
-      */
-
-    Serializable 
-    getObject() throws JMSException;
+    /**
+     * Gets the serializable object containing this message's data. The default value is null.
+     *
+     * @return the serializable object containing this message's data
+     *
+     * @exception JMSException if the JMS provider fails to get the object due to some internal error.
+     * @exception MessageFormatException if object deserialization fails.
+     */
+    Serializable getObject() throws JMSException;
 }

--- a/src/main/java/javax/jms/Queue.java
+++ b/src/main/java/javax/jms/Queue.java
@@ -16,55 +16,51 @@
 
 package javax.jms;
 
+/**
+ * A {@code Queue} object encapsulates a provider-specific queue name.
+ *
+ * <p>
+ * It is the way a client specifies the identity of a queue to JMS API methods. For those methods that use a
+ * {@code Destination} as a parameter, a {@code Queue} object used as an argument. For example, a queue can be used to
+ * create a {@code MessageConsumer} and a {@code MessageProducer} by calling:
+ *
+ * <ul>
+ * <li>{@code Session.CreateConsumer(Destination destination)}
+ * <li>{@code Session.CreateProducer(Destination destination)}
+ * </ul>
+ *
+ * <p>
+ * The actual length of time messages are held by a queue and the consequences of resource overflow are not defined by
+ * the JMS API.
+ *
+ * @see Session#createConsumer(Destination)
+ * @see Session#createProducer(Destination)
+ * @see Session#createQueue(String)
+ * @see QueueSession#createQueue(String)
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
+public interface Queue extends Destination {
 
-/** A {@code Queue} object encapsulates a provider-specific queue name. 
-  * It is the way a client specifies the identity of a queue to JMS API methods.
-  * For those methods that use a {@code Destination} as a parameter, a 
-  * {@code Queue} object used as an argument. For example, a queue can
-  * be used  to create a {@code MessageConsumer} and a 
-  * {@code MessageProducer}  by calling:
-  *<UL>
-  *<LI> {@code Session.CreateConsumer(Destination destination)}
-  *<LI> {@code Session.CreateProducer(Destination destination)}
-  *
-  *</UL>
-  *
-  * <P>The actual length of time messages are held by a queue and the 
-  * consequences of resource overflow are not defined by the JMS API.
-  *
-  * @see Session#createConsumer(Destination)
-  * @see Session#createProducer(Destination)
-  * @see Session#createQueue(String)
-  * @see QueueSession#createQueue(String)
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
- 
-public interface Queue extends Destination { 
+    /**
+     * Gets the name of this queue.
+     *
+     * <p>
+     * Clients that depend upon the name are not portable.
+     *
+     * @return the queue name
+     *
+     * @exception JMSException if the JMS provider implementation of {@code Queue} fails to return the queue name due to
+     * some internal error.
+     */
+    String getQueueName() throws JMSException;
 
-    /** Gets the name of this queue.
-      *  
-      * <P>Clients that depend upon the name are not portable.
-      *  
-      * @return the queue name
-      *  
-      * @exception JMSException if the JMS provider implementation of 
-      *                         {@code Queue} fails to return the queue
-      *                         name due to some internal
-      *                         error.
-      */ 
- 
-    String
-    getQueueName() throws JMSException;  
-
-
-    /** Returns a string representation of this object.
-      *
-      * @return the provider-specific identity values for this queue
-      */
- 
-    String
-    toString();
+    /**
+     * Returns a string representation of this object.
+     *
+     * @return the provider-specific identity values for this queue
+     */
+    @Override
+    String toString();
 }

--- a/src/main/java/javax/jms/QueueBrowser.java
+++ b/src/main/java/javax/jms/QueueBrowser.java
@@ -18,91 +18,73 @@ package javax.jms;
 
 import java.util.Enumeration;
 
-/** A client uses a {@code QueueBrowser} object to look at messages on a 
-  * queue without removing them.
-  *
-  * <P>The {@code getEnumeration} method returns a 
-  * {@code java.util.Enumeration} that is used to scan 
-  * the queue's messages. It may be an enumeration of the entire content of a 
-  * queue, or it may contain only the messages matching a message selector.
-  *
-  * <P>Messages may be arriving and expiring while the scan is done. The JMS API
-  * does 
-  * not require the content of an enumeration to be a static snapshot of queue 
-  * content. Whether these changes are visible or not depends on the JMS 
-  * provider.
-  * <p>
-  * A message must not be returned by a {@code QueueBrowser} before its delivery time has been reached.
-  *
-  *<P>A {@code QueueBrowser} can be created from either a 
-  * {@code Session} or a {@code  QueueSession}. 
-  * 
-  * @see         javax.jms.Session#createBrowser
-  * @see         javax.jms.QueueSession#createBrowser
-  * @see         javax.jms.QueueReceiver
-  *
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A client uses a {@code QueueBrowser} object to look at messages on a queue without removing them.
+ *
+ * <p>
+ * The {@code getEnumeration} method returns a {@code java.util.Enumeration} that is used to scan the queue's messages.
+ * It may be an enumeration of the entire content of a queue, or it may contain only the messages matching a message
+ * selector.
+ *
+ * <p>
+ * Messages may be arriving and expiring while the scan is done. The JMS API does not require the content of an
+ * enumeration to be a static snapshot of queue content. Whether these changes are visible or not depends on the JMS
+ * provider.
+ * <p>
+ * A message must not be returned by a {@code QueueBrowser} before its delivery time has been reached.
+ *
+ * <p>
+ * A {@code QueueBrowser} can be created from either a {@code Session} or a {@code  QueueSession}.
+ *
+ * @see javax.jms.Session#createBrowser
+ * @see javax.jms.QueueSession#createBrowser
+ * @see javax.jms.QueueReceiver
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface QueueBrowser extends AutoCloseable {
 
-    /** Gets the queue associated with this queue browser.
-      * 
-      * @return the queue
-      *  
-      * @exception JMSException if the JMS provider fails to get the
-      *                         queue associated with this browser
-      *                         due to some internal error.
-      */
+    /**
+     * Gets the queue associated with this queue browser.
+     *
+     * @return the queue
+     *
+     * @exception JMSException if the JMS provider fails to get the queue associated with this browser due to some internal
+     * error.
+     */
+    Queue getQueue() throws JMSException;
 
-    Queue 
-    getQueue() throws JMSException;
+    /**
+     * Gets this queue browser's message selector expression.
+     *
+     * @return this queue browser's message selector, or null if no message selector exists for the message consumer (that
+     * is, if the message selector was not set or was set to null or the empty string)
+     *
+     * @exception JMSException if the JMS provider fails to get the message selector for this browser due to some internal
+     * error.
+     */
+    String getMessageSelector() throws JMSException;
 
+    /**
+     * Gets an enumeration for browsing the current queue messages in the order they would be received.
+     *
+     * @return an enumeration for browsing the messages
+     *
+     * @exception JMSException if the JMS provider fails to get the enumeration for this browser due to some internal error.
+     */
+    Enumeration getEnumeration() throws JMSException;
 
-    /** Gets this queue browser's message selector expression.
-      *  
-      * @return this queue browser's message selector, or null if no
-      *         message selector exists for the message consumer (that is, if 
-      *         the message selector was not set or was set to null or the 
-      *         empty string)
-      *
-      * @exception JMSException if the JMS provider fails to get the
-      *                         message selector for this browser
-      *                         due to some internal error.
-      */
-
-    String
-    getMessageSelector() throws JMSException;
-
-
-    /** Gets an enumeration for browsing the current queue messages in the
-      * order they would be received.
-      *
-      * @return an enumeration for browsing the messages
-      *  
-      * @exception JMSException if the JMS provider fails to get the
-      *                         enumeration for this browser
-      *                         due to some internal error.
-      */
-
-    Enumeration 
-    getEnumeration() throws JMSException;
-
-
-    /** Closes the {@code QueueBrowser}.
-      *
-      * <P>Since a provider may allocate some resources on behalf of a 
-      * QueueBrowser outside the Java virtual machine, clients should close them
-      * when they 
-      * are not needed. Relying on garbage collection to eventually reclaim 
-      * these resources may not be timely enough.
-      *
-      * @exception JMSException if the JMS provider fails to close this
-      *                         browser due to some internal error.
-      */
-
-    void 
-    close() throws JMSException;
+    /**
+     * Closes the {@code QueueBrowser}.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a QueueBrowser outside the Java virtual machine, clients
+     * should close them when they are not needed. Relying on garbage collection to eventually reclaim these resources may
+     * not be timely enough.
+     *
+     * @exception JMSException if the JMS provider fails to close this browser due to some internal error.
+     */
+    @Override
+    void close() throws JMSException;
 }

--- a/src/main/java/javax/jms/QueueConnection.java
+++ b/src/main/java/javax/jms/QueueConnection.java
@@ -16,167 +16,133 @@
 
 package javax.jms;
 
-/** A {@code QueueConnection} object is an active connection to a 
-  * point-to-point JMS provider. A client uses a {@code QueueConnection} 
-  * object to create one or more {@code QueueSession} objects
-  * for producing and consuming messages.
-  *
-  *<P>A {@code QueueConnection} can be used to create a
-  * {@code QueueSession}, from which specialized  queue-related objects
-  * can be created.
-  * A more general, and recommended, approach is to use the 
-  * {@code Connection} object.
-  * 
-  *
-  * <P>The {@code QueueConnection} object
-  * should be used to support existing code that has already used it.
-  *
-  * <P>A {@code QueueConnection} cannot be used to create objects 
-  * specific to the   publish/subscribe domain. The
-  * {@code createDurableConnectionConsumer} method inherits
-  * from  {@code Connection}, but must throw an 
-  * {@code IllegalStateException}
-  * if used from {@code QueueConnection}.
-  *
-  * @see javax.jms.Connection
-  * @see javax.jms.ConnectionFactory
-  * @see javax.jms.QueueConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A {@code QueueConnection} object is an active connection to a point-to-point JMS provider. A client uses a
+ * {@code QueueConnection} object to create one or more {@code QueueSession} objects for producing and consuming
+ * messages.
+ *
+ * <p>
+ * A {@code QueueConnection} can be used to create a {@code QueueSession}, from which specialized queue-related objects
+ * can be created. A more general, and recommended, approach is to use the {@code Connection} object.
+ *
+ *
+ * <p>
+ * The {@code QueueConnection} object should be used to support existing code that has already used it.
+ *
+ * <p>
+ * A {@code QueueConnection} cannot be used to create objects specific to the publish/subscribe domain. The
+ * {@code createDurableConnectionConsumer} method inherits from {@code Connection}, but must throw an
+ * {@code IllegalStateException} if used from {@code QueueConnection}.
+ *
+ * @see javax.jms.Connection
+ * @see javax.jms.ConnectionFactory
+ * @see javax.jms.QueueConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface QueueConnection extends Connection {
 
-    /** 
-     * Creates a {@code QueueSession} object, 
-     * specifying {@code transacted} and {@code acknowledgeMode}.
-     * <p> 
-     * The effect of setting the {@code transacted} and {@code acknowledgeMode} 
-     * arguments depends on whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * effect of setting the transacted} and {@code acknowledgeMode} 
-     * arguments also depends on whether or not there is an active JTA transaction 
-     * in progress.  
+    /**
+     * Creates a {@code QueueSession} object, specifying {@code transacted} and {@code acknowledgeMode}.
+     *
+     * <p>
+     * The effect of setting the {@code transacted} and {@code acknowledgeMode} arguments depends on whether this method is
+     * called in a Java SE environment, in the Java EE application client container, or in the Java EE web or EJB container.
+     * If this method is called in the Java EE web or EJB container then the effect of setting the transacted} and
+     * {@code acknowledgeMode} arguments also depends on whether or not there is an active JTA transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
+     *
      * <ul>
-     * <li>If {@code transacted} is set to {@code true} then the session 
-     * will use a local transaction which may subsequently be committed or rolled back 
-     * by calling the session's {@code commit} or {@code rollback} methods. 
-     * The argument {@code acknowledgeMode} is ignored.
-     * <li>If {@code transacted} is set to {@code false} then the session 
-     * will be non-transacted. In this case the argument {@code acknowledgeMode}
-     * is used to specify how messages received by this session will be acknowledged.
-     * The permitted values are 
-     * {@code Session.CLIENT_ACKNOWLEDGE}, 
-     * {@code Session.AUTO_ACKNOWLEDGE} and
-     * {@code Session.DUPS_OK_ACKNOWLEDGE}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
+     * <li>If {@code transacted} is set to {@code true} then the session will use a local transaction which may subsequently
+     * be committed or rolled back by calling the session's {@code commit} or {@code rollback} methods. The argument
+     * {@code acknowledgeMode} is ignored.
+     * <li>If {@code transacted} is set to {@code false} then the session will be non-transacted. In this case the argument
+     * {@code acknowledgeMode} is used to specify how messages received by this session will be acknowledged. The permitted
+     * values are {@code Session.CLIENT_ACKNOWLEDGE}, {@code Session.AUTO_ACKNOWLEDGE} and
+     * {@code Session.DUPS_OK_ACKNOWLEDGE}. For a definition of the meaning of these acknowledgement modes see the links
+     * below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
+     *
      * <ul>
-     * <li>Both arguments {@code transacted} and {@code acknowledgeMode} are ignored.
-     * The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the session's {@code commit} or {@code rollback} methods.
-     * Since both arguments are ignored, developers are recommended to use 
-     * {@code createSession()}, which has no arguments, instead of this method.
+     * <li>Both arguments {@code transacted} and {@code acknowledgeMode} are ignored. The session will participate in the
+     * JTA transaction and will be committed or rolled back when that transaction is committed or rolled back, not by
+     * calling the session's {@code commit} or {@code rollback} methods. Since both arguments are ignored, developers are
+     * recommended to use {@code createSession()}, which has no arguments, instead of this method.
      * </ul>
+     *
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
+     *
      * <ul>
-     * <li>
-     * If {@code transacted} is set to false and {@code acknowledgeMode} is set to
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} then the
-     * session will be non-transacted and messages will be acknowledged according
-     * to the value of {@code acknowledgeMode}.
-     * <li>
-     * If {@code transacted} is set to false and {@code acknowledgeMode} is set to
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE} then the JMS provider is recommended to
-     * ignore the specified parameters and instead provide a non-transacted,
-     * auto-acknowledged session. However the JMS provider may alternatively
-     * provide a non-transacted session with client acknowledgement.
-     * <li>
-     * If {@code transacted} is set to true, then the JMS provider is recommended to
-     * ignore the specified parameters and instead provide a non-transacted,
-     * auto-acknowledged session. However the JMS provider may alternatively
-     * provide a local transacted session.
-     * <li>
-     * Applications are recommended to set {@code transacted} to false and
-     * {@code acknowledgeMode} to {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code Session.DUPS_OK_ACKNOWLEDGE} since since applications which set
-     * {@code transacted} to false and set {@code acknowledgeMode} to
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, or which set {@code transacted} 
-     * to true, may not be portable. 
-     * </ul> 
+     * <li>If {@code transacted} is set to false and {@code acknowledgeMode} is set to {@code JMSContext.AUTO_ACKNOWLEDGE}
+     * or {@code Session.DUPS_OK_ACKNOWLEDGE} then the session will be non-transacted and messages will be acknowledged
+     * according to the value of {@code acknowledgeMode}.
+     * <li>If {@code transacted} is set to false and {@code acknowledgeMode} is set to {@code JMSContext.CLIENT_ACKNOWLEDGE}
+     * then the JMS provider is recommended to ignore the specified parameters and instead provide a non-transacted,
+     * auto-acknowledged session. However the JMS provider may alternatively provide a non-transacted session with client
+     * acknowledgement.
+     * <li>If {@code transacted} is set to true, then the JMS provider is recommended to ignore the specified parameters and
+     * instead provide a non-transacted, auto-acknowledged session. However the JMS provider may alternatively provide a
+     * local transacted session.
+     * <li>Applications are recommended to set {@code transacted} to false and {@code acknowledgeMode} to
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} since since applications which set
+     * {@code transacted} to false and set {@code acknowledgeMode} to {@code JMSContext.CLIENT_ACKNOWLEDGE}, or which set
+     * {@code transacted} to true, may not be portable.
+     * </ul>
+     *
      * <p>
-     * Applications running in the Java EE web and EJB containers must not attempt 
-     * to create more than one active (not closed) {@code Session} object per connection. 
-     * If this method is called in a Java EE web or EJB container when an active
-     * {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
-     * 
-     * @param transacted indicates whether the session will use a local transaction,
-     * except in the cases described above when this value is ignored.
-     * 
-     * @param acknowledgeMode when transacted is false, indicates how messages received
-     * by the session will be acknowledged, except in the cases described above
+     * Applications running in the Java EE web and EJB containers must not attempt to create more than one active (not
+     * closed) {@code Session} object per connection. If this method is called in a Java EE web or EJB container when an
+     * active {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
+     *
+     * @param transacted indicates whether the session will use a local transaction, except in the cases described above
      * when this value is ignored.
-     * 
+     *
+     * @param acknowledgeMode when transacted is false, indicates how messages received by the session will be acknowledged,
+     * except in the cases described above when this value is ignored.
+     *
      * @return a newly created {@code QueueSession}
-     *  
-     * @exception JMSException if the {@code QueueConnection} object fails
-     *                         to create a {@code QueueSession} due to 
-     *                         <ul>
-     *                         <li>some internal error, 
-     *                         <li>lack of support for the specific transaction and acknowledgement mode, or
-     *                         <li>because this method is being called in a Java EE web or EJB application 
-     *                         and an active session already exists for this connection.
-     *                         </ul>
+     *
+     * @exception JMSException if the {@code QueueConnection} object fails to create a {@code QueueSession} due to
+     * <ul>
+     * <li>some internal error,
+     * <li>lack of support for the specific transaction and acknowledgement mode, or
+     * <li>because this method is being called in a Java EE web or EJB application and an active session already exists for
+     * this connection.
+     * </ul>
+     *
      * @since JMS 1.1
      *
-     * @see Session#AUTO_ACKNOWLEDGE 
-     * @see Session#CLIENT_ACKNOWLEDGE 
-     * @see Session#DUPS_OK_ACKNOWLEDGE 
-     * 
-     */ 
-    QueueSession
-    createQueueSession(boolean transacted,
-                       int acknowledgeMode) throws JMSException;
+     * @see Session#AUTO_ACKNOWLEDGE
+     * @see Session#CLIENT_ACKNOWLEDGE
+     * @see Session#DUPS_OK_ACKNOWLEDGE
+     */
+    QueueSession createQueueSession(boolean transacted, int acknowledgeMode) throws JMSException;
 
-
-    /** Creates a connection consumer for this connection (optional operation).
-      * This is an expert facility not used by regular JMS clients.
-      *
-      * @param queue the queue to access
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered. A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer.
-      * @param sessionPool the server session pool to associate with this 
-      * connection consumer
-      * @param maxMessages the maximum number of messages that can be
-      * assigned to a server session at one time
-      *
-      * @return the connection consumer
-      *  
-      * @exception JMSException if the {@code QueueConnection} object fails
-      *                         to create a connection consumer due to some
-      *                         internal error or invalid arguments for 
-      *                         {@code sessionPool} and 
-      *                         {@code messageSelector}.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      * @exception InvalidSelectorException if the message selector is invalid.
-      * @see javax.jms.ConnectionConsumer
-      */ 
-
-    ConnectionConsumer
-    createConnectionConsumer(Queue queue,
-                             String messageSelector,
-                             ServerSessionPool sessionPool,
-			     int maxMessages)
-			   throws JMSException;
+    /**
+     * Creates a connection consumer for this connection (optional operation). This is an expert facility not used by
+     * regular JMS clients.
+     *
+     * @param queue the queue to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the connection consumer
+     *
+     * @exception JMSException if the {@code QueueConnection} object fails to create a connection consumer due to some
+     * internal error or invalid arguments for {@code sessionPool} and {@code messageSelector}.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     * @see javax.jms.ConnectionConsumer
+     */
+    ConnectionConsumer createConnectionConsumer(Queue queue, String messageSelector, ServerSessionPool sessionPool, int maxMessages) throws JMSException;
 }

--- a/src/main/java/javax/jms/QueueConnectionFactory.java
+++ b/src/main/java/javax/jms/QueueConnectionFactory.java
@@ -16,62 +16,47 @@
 
 package javax.jms;
 
-/** A client uses a {@code QueueConnectionFactory} object to create 
-  * {@code QueueConnection} objects with a point-to-point JMS provider.
-  *
-  * <P>{@code QueueConnectionFactory} can be used to create a 
-  * {@code QueueConnection}, from which specialized queue-related objects
-  * can be  created. A more general, and recommended,  approach 
-  * is to use the {@code ConnectionFactory} object.
-  *
-  *<P> The {@code QueueConnectionFactory} object
-  * can be used to support existing code that already uses it.
-  *
-  * @see javax.jms.ConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A client uses a {@code QueueConnectionFactory} object to create {@code QueueConnection} objects with a point-to-point
+ * JMS provider.
+ *
+ * <p>
+ * {@code QueueConnectionFactory} can be used to create a {@code QueueConnection}, from which specialized queue-related
+ * objects can be created. A more general, and recommended, approach is to use the {@code ConnectionFactory} object.
+ *
+ * <p>
+ * The {@code QueueConnectionFactory} object can be used to support existing code that already uses it.
+ *
+ * @see javax.jms.ConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ *
+ */
 public interface QueueConnectionFactory extends ConnectionFactory {
 
-    /** Creates a queue connection with the default user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *
-      .
-      *
-      * @return a newly created queue connection
-      *
-      * @exception JMSException if the JMS provider fails to create the queue 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      */ 
+    /**
+     * Creates a queue connection with the default user identity. The connection is created in stopped mode. No messages
+     * will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @return a newly created queue connection
+     *
+     * @exception JMSException if the JMS provider fails to create the queue connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    QueueConnection createQueueConnection() throws JMSException;
 
-    QueueConnection
-    createQueueConnection() throws JMSException;
-
-
-    /** Creates a queue connection with the specified user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *  
-      * @param userName the caller's user name
-      * @param password the caller's password
-      *  
-      * @return a newly created queue connection
-      *
-      * @exception JMSException if the JMS provider fails to create the queue 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      */ 
-
-    QueueConnection
-    createQueueConnection(String userName, String password) 
-					     throws JMSException;
+    /**
+     * Creates a queue connection with the specified user identity. The connection is created in stopped mode. No messages
+     * will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @param userName the caller's user name
+     * @param password the caller's password
+     *
+     * @return a newly created queue connection
+     *
+     * @exception JMSException if the JMS provider fails to create the queue connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    QueueConnection createQueueConnection(String userName, String password) throws JMSException;
 }

--- a/src/main/java/javax/jms/QueueListener.java
+++ b/src/main/java/javax/jms/QueueListener.java
@@ -23,34 +23,33 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation designates a callback method on a JMS message-driven bean
- * that will receive messages from a queue, and specifies the queue from which
- * messages will be received.
+ * This annotation designates a callback method on a JMS message-driven bean that will receive messages from a queue,
+ * and specifies the queue from which messages will be received.
+ *
  * <p>
- * This annotation may only be used if the JMS message-driven bean implements
- * the {@code JMSMessageDrivenBean} marker interface and does not implement the
- * {@code MessageListener} interface. If this annotation is used on a JMS
- * message-driven bean that implements the {@code MessageListener} interface
- * then deployment will fail.
+ * This annotation may only be used if the JMS message-driven bean implements the {@code JMSMessageDrivenBean} marker
+ * interface and does not implement the {@code MessageListener} interface. If this annotation is used on a JMS
+ * message-driven bean that implements the {@code MessageListener} interface then deployment will fail.
+ *
  * <p>
- * Only one method may be designated as a callback method. If more than one
- * method on a JMS message-driven bean is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
- * 
+ * Only one method may be designated as a callback method. If more than one method on a JMS message-driven bean is
+ * annotated with {@code QueueListener} or {@code TopicListener} then deployment will fail.
+ *
  * @see JMSMessageDrivenBean
  * @see TopicListener
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
 @Retention(RUNTIME)
-@Target({ METHOD })
+@Target(METHOD)
 public @interface QueueListener {
 
-	/**
-	 * Lookup name of the Queue from which messages will be received.
-	 */
-	String value();
+    /**
+     * Lookup name of the Queue from which messages will be received.
+     *
+     * @return The lookup name of the Queue.
+     */
+    String value();
 
 }

--- a/src/main/java/javax/jms/QueueReceiver.java
+++ b/src/main/java/javax/jms/QueueReceiver.java
@@ -16,49 +16,43 @@
 
 package javax.jms;
 
-
-/** A client uses a {@code QueueReceiver} object to receive messages that 
-  * have been delivered to a queue.
-  *
-  * <P>Although it is possible to have multiple {@code QueueReceiver}s 
-  * for the same queue, the JMS API does not define how messages are 
-  * distributed between the {@code QueueReceiver}s.
-  *
-  * <P>If a {@code QueueReceiver} specifies a message selector, the 
-  * messages that are not selected remain on the queue. By definition, a message
-  * selector allows a {@code QueueReceiver} to skip messages. This 
-  * means that when the skipped messages are eventually read, the total ordering
-  * of the reads does not retain the partial order defined by each message 
-  * producer. Only {@code QueueReceiver}s without a message selector
-  * will read messages in message producer order.
-  *
-  * <P>Creating a {@code MessageConsumer} provides the same features as
-  * creating a {@code QueueReceiver}. A {@code MessageConsumer} object is 
-  * recommended for creating new code. The  {@code QueueReceiver} is
-  * provided to support existing code.
-  *
-  * @see         javax.jms.Session#createConsumer(Destination, String)
-  * @see         javax.jms.Session#createConsumer(Destination)
-  * @see         javax.jms.QueueSession#createReceiver(Queue, String)
-  * @see         javax.jms.QueueSession#createReceiver(Queue)
-  * @see         javax.jms.MessageConsumer
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  *
-  */
-
+/**
+ * A client uses a {@code QueueReceiver} object to receive messages that have been delivered to a queue.
+ *
+ * <p>
+ * Although it is possible to have multiple {@code QueueReceiver}s for the same queue, the JMS API does not define how
+ * messages are distributed between the {@code QueueReceiver}s.
+ *
+ * <p>
+ * If a {@code QueueReceiver} specifies a message selector, the messages that are not selected remain on the queue. By
+ * definition, a message selector allows a {@code QueueReceiver} to skip messages. This means that when the skipped
+ * messages are eventually read, the total ordering of the reads does not retain the partial order defined by each
+ * message producer. Only {@code QueueReceiver}s without a message selector will read messages in message producer
+ * order.
+ *
+ * <p>
+ * Creating a {@code MessageConsumer} provides the same features as creating a {@code QueueReceiver}. A
+ * {@code MessageConsumer} object is recommended for creating new code. The {@code QueueReceiver} is provided to support
+ * existing code.
+ *
+ * @see javax.jms.Session#createConsumer(Destination, String)
+ * @see javax.jms.Session#createConsumer(Destination)
+ * @see javax.jms.QueueSession#createReceiver(Queue, String)
+ * @see javax.jms.QueueSession#createReceiver(Queue)
+ * @see javax.jms.MessageConsumer
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface QueueReceiver extends MessageConsumer {
 
-    /** Gets the {@code Queue} associated with this queue receiver.
-      *  
-      * @return this receiver's {@code Queue} 
-      *  
-      * @exception JMSException if the JMS provider fails to get the queue for
-      *                         this queue receiver
-      *                         due to some internal error.
-      */ 
- 
-    Queue
-    getQueue() throws JMSException;
+    /**
+     * Gets the {@code Queue} associated with this queue receiver.
+     *
+     * @return this receiver's {@code Queue}
+     *
+     * @exception JMSException if the JMS provider fails to get the queue for this queue receiver due to some internal
+     * error.
+     */
+    Queue getQueue() throws JMSException;
 }

--- a/src/main/java/javax/jms/QueueRequestor.java
+++ b/src/main/java/javax/jms/QueueRequestor.java
@@ -16,103 +16,88 @@
 
 package javax.jms;
 
-/** The {@code QueueRequestor} helper class simplifies
-  * making service requests.
-  *
-  * <P>The {@code QueueRequestor} constructor is given a non-transacted 
-  * {@code QueueSession} and a destination {@code Queue}. It creates a
-  * {@code TemporaryQueue} for the responses and provides a 
-  * {@code request} method that sends the request message and waits 
-  * for its reply.
-  * <p>
-  * This is a very basic request/reply abstraction which assumes the session 
-  * is non-transacted with a delivery mode of either AUTO_ACKNOWLEDGE or 
-  * DUPS_OK_ACKNOWLEDGE. It is expected that most applications will create 
-  * less basic implementations.
-  *
-  * @see javax.jms.TopicRequestor
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * The {@code QueueRequestor} helper class simplifies making service requests.
+ *
+ * <p>
+ * The {@code QueueRequestor} constructor is given a non-transacted {@code QueueSession} and a destination
+ * {@code Queue}. It creates a {@code TemporaryQueue} for the responses and provides a {@code request} method that sends
+ * the request message and waits for its reply.
+ *
+ * <p>
+ * This is a very basic request/reply abstraction which assumes the session is non-transacted with a delivery mode of
+ * either AUTO_ACKNOWLEDGE or DUPS_OK_ACKNOWLEDGE. It is expected that most applications will create less basic
+ * implementations.
+ *
+ * @see javax.jms.TopicRequestor
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public class QueueRequestor {
 
-    QueueSession   session;     // The queue session the queue belongs to.
+    QueueSession session; // The queue session the queue belongs to.
     TemporaryQueue tempQueue;
-    QueueSender    sender;
-    QueueReceiver  receiver;
+    QueueSender sender;
+    QueueReceiver receiver;
 
+    /**
+     * Constructor for the {@code QueueRequestor} class.
+     *
+     * <p>
+     * This implementation assumes the session parameter to be non-transacted, with a delivery mode of either
+     * {@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}.
+     *
+     * @param session the {@code QueueSession} the queue belongs to
+     * @param queue the queue to perform the request/reply call on
+     *
+     * @exception JMSException if the JMS provider fails to create the {@code QueueRequestor} due to some internal error.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     */
+    public QueueRequestor(QueueSession session, Queue queue) throws JMSException {
+        if (queue == null) {
+            throw new InvalidDestinationException("queue==null");
+        }
 
-    /** Constructor for the {@code QueueRequestor} class.
-      *  
-      * <P>This implementation assumes the session parameter to be non-transacted,
-      * with a delivery mode of either {@code AUTO_ACKNOWLEDGE} or 
-      * {@code DUPS_OK_ACKNOWLEDGE}.
-      *
-      * @param session the {@code QueueSession} the queue belongs to
-      * @param queue the queue to perform the request/reply call on
-      *  
-      * @exception JMSException if the JMS provider fails to create the
-      *                         {@code QueueRequestor} due to some internal
-      *                         error.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      */ 
-
-    public
-    QueueRequestor(QueueSession session, Queue queue) throws JMSException {
-    	
-    	if (queue==null) throw new InvalidDestinationException("queue==null");
-    	
         this.session = session;
-        tempQueue    = session.createTemporaryQueue();
-        sender       = session.createSender(queue);
-        receiver     = session.createReceiver(tempQueue);
+        tempQueue = session.createTemporaryQueue();
+        sender = session.createSender(queue);
+        receiver = session.createReceiver(tempQueue);
     }
 
-
-    /** Sends a request and waits for a reply. The temporary queue is used for
-      * the {@code JMSReplyTo} destination, and only one reply per request 
-      * is expected.
-      *  
-      * @param message the message to send
-      *  
-      * @return the reply message
-      *  
-      * @exception JMSException if the JMS provider fails to complete the
-      *                         request due to some internal error.
-      */
-
-    public Message
-    request(Message message) throws JMSException {
-	message.setJMSReplyTo(tempQueue);
-	sender.send(message);
-	return (receiver.receive());
+    /**
+     * Sends a request and waits for a reply. The temporary queue is used for the {@code JMSReplyTo} destination, and only
+     * one reply per request is expected.
+     *
+     * @param message the message to send
+     *
+     * @return the reply message
+     *
+     * @exception JMSException if the JMS provider fails to complete the request due to some internal error.
+     */
+    public Message request(Message message) throws JMSException {
+        message.setJMSReplyTo(tempQueue);
+        sender.send(message);
+        return (receiver.receive());
     }
 
+    /**
+     * Closes the {@code QueueRequestor} and its session.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a {@code QueueRequestor} outside the Java virtual machine,
+     * clients should close them when they are not needed. Relying on garbage collection to eventually reclaim these
+     * resources may not be timely enough.
+     *
+     * <p>
+     * Note that this method closes the {@code QueueSession} object passed to the {@code QueueRequestor} constructor.
+     *
+     * @exception JMSException if the JMS provider fails to close the {@code QueueRequestor} due to some internal error.
+     */
+    public void close() throws JMSException {
 
-    /** Closes the {@code QueueRequestor} and its session.
-      *
-      * <P>Since a provider may allocate some resources on behalf of a 
-      * {@code QueueRequestor} outside the Java virtual machine, clients 
-      * should close them when they 
-      * are not needed. Relying on garbage collection to eventually reclaim 
-      * these resources may not be timely enough.
-      *  
-      * <P>Note that this method closes the {@code QueueSession} object 
-      * passed to the {@code QueueRequestor} constructor.
-      *
-      * @exception JMSException if the JMS provider fails to close the
-      *                         {@code QueueRequestor} due to some internal
-      *                         error.
-      */
-
-    public void
-    close() throws JMSException {
-
-	// publisher and consumer created by constructor are implicitly closed.
-	session.close();
+        // publisher and consumer created by constructor are implicitly closed.
+        session.close();
         tempQueue.delete();
     }
 }

--- a/src/main/java/javax/jms/QueueSender.java
+++ b/src/main/java/javax/jms/QueueSender.java
@@ -16,172 +16,130 @@
 
 package javax.jms;
 
-/** A client uses a {@code QueueSender} object to send messages to a queue.
-  * 
-  * <P>Normally, the {@code Queue} is specified when a 
-  * {@code QueueSender} is created.  In this case, an attempt to use
-  * the {@code send} methods for an unidentified 
-  * {@code QueueSender} will throw a 
-  * {@code java.lang.UnsupportedOperationException}.
-  * 
-  * <P>If the {@code QueueSender} is created with an unidentified 
-  * {@code Queue}, an attempt to use the {@code send} methods that 
-  * assume that the {@code Queue} has been identified will throw a
-  * {@code java.lang.UnsupportedOperationException}.
-  *
-  * <P>During the execution of its {@code send} method, a message 
-  * must not be changed by other threads within the client. 
-  * If the message is modified, the result of the {@code send} is 
-  * undefined.
-  * 
-  * <P>After sending a message, a client may retain and modify it
-  * without affecting the message that has been sent. The same message
-  * object may be sent multiple times.
-  * 
-  * <P>The following message headers are set as part of sending a 
-  * message: {@code JMSDestination}, {@code JMSDeliveryMode}, 
-  * {@code JMSExpiration}, {@code JMSPriority}, 
-  * {@code JMSMessageID} and {@code JMSTimeStamp}.
-  * When the message is sent, the values of these headers are ignored. 
-  * After the completion of the {@code send}, the headers hold the values 
-  * specified by the method sending the message. It is possible for the 
-  * {@code send} method not to set {@code JMSMessageID} and 
-  * {@code JMSTimeStamp} if the 
-  * setting of these headers is explicitly disabled by the 
-  * {@code MessageProducer.setDisableMessageID} or
-  * {@code MessageProducer.setDisableMessageTimestamp} method.
-  *
-  * <P>Creating a {@code MessageProducer} provides the same features as
-  * creating a {@code QueueSender}. A {@code MessageProducer} object is 
-  * recommended when creating new code. The  {@code QueueSender} is
-  * provided to support existing code.
-  *
-  * @see javax.jms.MessageProducer
-  * @see javax.jms.Session#createProducer(Destination)
-  * @see javax.jms.QueueSession#createSender(Queue)
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A client uses a {@code QueueSender} object to send messages to a queue.
+ *
+ * <p>
+ * Normally, the {@code Queue} is specified when a {@code QueueSender} is created. In this case, an attempt to use the
+ * {@code send} methods for an unidentified {@code QueueSender} will throw a
+ * {@code java.lang.UnsupportedOperationException}.
+ *
+ * <p>
+ * If the {@code QueueSender} is created with an unidentified {@code Queue}, an attempt to use the {@code send} methods
+ * that assume that the {@code Queue} has been identified will throw a {@code java.lang.UnsupportedOperationException}.
+ *
+ * <p>
+ * During the execution of its {@code send} method, a message must not be changed by other threads within the client. If
+ * the message is modified, the result of the {@code send} is undefined.
+ *
+ * <p>
+ * After sending a message, a client may retain and modify it without affecting the message that has been sent. The same
+ * message object may be sent multiple times.
+ *
+ * <p>
+ * The following message headers are set as part of sending a message: {@code JMSDestination}, {@code JMSDeliveryMode},
+ * {@code JMSExpiration}, {@code JMSPriority}, {@code JMSMessageID} and {@code JMSTimeStamp}. When the message is sent,
+ * the values of these headers are ignored. After the completion of the {@code send}, the headers hold the values
+ * specified by the method sending the message. It is possible for the {@code send} method not to set
+ * {@code JMSMessageID} and {@code JMSTimeStamp} if the setting of these headers is explicitly disabled by the
+ * {@code MessageProducer.setDisableMessageID} or {@code MessageProducer.setDisableMessageTimestamp} method.
+ *
+ * <p>
+ * Creating a {@code MessageProducer} provides the same features as creating a {@code QueueSender}. A
+ * {@code MessageProducer} object is recommended when creating new code. The {@code QueueSender} is provided to support
+ * existing code.
+ *
+ * @see javax.jms.MessageProducer
+ * @see javax.jms.Session#createProducer(Destination)
+ * @see javax.jms.QueueSession#createSender(Queue)
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface QueueSender extends MessageProducer {
 
-    /** Gets the queue associated with this {@code QueueSender}.
-      *  
-      * @return this sender's queue 
-      *  
-      * @exception JMSException if the JMS provider fails to get the queue for
-      *                         this {@code QueueSender}
-      *                         due to some internal error.
-      */ 
- 
-    Queue
-    getQueue() throws JMSException;
+    /**
+     * Gets the queue associated with this {@code QueueSender}.
+     *
+     * @return this sender's queue
+     *
+     * @exception JMSException if the JMS provider fails to get the queue for this {@code QueueSender} due to some internal
+     * error.
+     */
+    Queue getQueue() throws JMSException;
 
+    /**
+     * Sends a message to the queue. Uses the {@code QueueSender}'s default delivery mode, priority, and time to live.
+     *
+     * @param message the message to send
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code QueueSender} with an invalid queue.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code QueueSender} that did
+     * not specify a queue at creation time.
+     *
+     * @see javax.jms.MessageProducer#getDeliveryMode()
+     * @see javax.jms.MessageProducer#getTimeToLive()
+     * @see javax.jms.MessageProducer#getPriority()
+     */
+    @Override
+    void send(Message message) throws JMSException;
 
-    /** Sends a message to the queue. Uses the {@code QueueSender}'s 
-      * default delivery mode, priority, and time to live.
-      *
-      * @param message the message to send 
-      *  
-      * @exception JMSException if the JMS provider fails to send the message 
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses
-      *                         this method with a {@code QueueSender} with
-      *                         an invalid queue.
-      * @exception java.lang.UnsupportedOperationException if a client uses this
-      *                         method with a {@code QueueSender} that did
-      *                         not specify a queue at creation time.
-      * 
-      * @see javax.jms.MessageProducer#getDeliveryMode()
-      * @see javax.jms.MessageProducer#getTimeToLive()
-      * @see javax.jms.MessageProducer#getPriority()
-      */
+    /**
+     * Sends a message to the queue, specifying delivery mode, priority, and time to live.
+     *
+     * @param message the message to send
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code QueueSender} with an invalid queue.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code QueueSender} that did
+     * not specify a queue at creation time.
+     */
+    @Override
+    void send(Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
 
-    void 
-    send(Message message) throws JMSException;
+    /**
+     * Sends a message to a queue for an unidentified message producer. Uses the {@code QueueSender}'s default delivery
+     * mode, priority, and time to live.
+     *
+     * <p>
+     * Typically, a message producer is assigned a queue at creation time; however, the JMS API also supports unidentified
+     * message producers, which require that the queue be supplied every time a message is sent.
+     *
+     * @param queue the queue to send this message to
+     * @param message the message to send
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid queue.
+     *
+     * @see javax.jms.MessageProducer#getDeliveryMode()
+     * @see javax.jms.MessageProducer#getTimeToLive()
+     * @see javax.jms.MessageProducer#getPriority()
+     */
+    void send(Queue queue, Message message) throws JMSException;
 
-
-    /** Sends a message to the queue, specifying delivery mode, priority, and 
-      * time to live.
-      *
-      * @param message the message to send
-      * @param deliveryMode the delivery mode to use
-      * @param priority the priority for this message
-      * @param timeToLive the message's lifetime (in milliseconds)
-      *  
-      * @exception JMSException if the JMS provider fails to send the message 
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses
-      *                         this method with a {@code QueueSender} with
-      *                         an invalid queue.
-      * @exception java.lang.UnsupportedOperationException if a client uses this
-      *                         method with a {@code QueueSender} that did
-      *                         not specify a queue at creation time.
-      */
-
-    void 
-    send(Message message, 
-	 int deliveryMode, 
-	 int priority,
-	 long timeToLive) throws JMSException;
-
-
-    /** Sends a message to a queue for an unidentified message producer.
-      * Uses the {@code QueueSender}'s default delivery mode, priority,
-      * and time to live.
-      *
-      * <P>Typically, a message producer is assigned a queue at creation 
-      * time; however, the JMS API also supports unidentified message producers,
-      * which require that the queue be supplied every time a message is
-      * sent.
-      *  
-      * @param queue the queue to send this message to
-      * @param message the message to send
-      *  
-      * @exception JMSException if the JMS provider fails to send the message 
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses
-      *                         this method with an invalid queue.
-      * 
-      * @see javax.jms.MessageProducer#getDeliveryMode()
-      * @see javax.jms.MessageProducer#getTimeToLive()
-      * @see javax.jms.MessageProducer#getPriority()
-      */ 
- 
-    void
-    send(Queue queue, Message message) throws JMSException;
- 
- 
-    /** Sends a message to a queue for an unidentified message producer, 
-      * specifying delivery mode, priority and time to live.
-      *  
-      * <P>Typically, a message producer is assigned a queue at creation 
-      * time; however, the JMS API also supports unidentified message producers,
-      * which require that the queue be supplied every time a message is
-      * sent.
-      *  
-      * @param queue the queue to send this message to
-      * @param message the message to send
-      * @param deliveryMode the delivery mode to use
-      * @param priority the priority for this message
-      * @param timeToLive the message's lifetime (in milliseconds)
-      *  
-      * @exception JMSException if the JMS provider fails to send the message 
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses
-      *                         this method with an invalid queue.
-      */ 
-
-    void
-    send(Queue queue, 
-	 Message message, 
-	 int deliveryMode, 
-	 int priority,
-	 long timeToLive) throws JMSException;
+    /**
+     * Sends a message to a queue for an unidentified message producer, specifying delivery mode, priority and time to live.
+     *
+     * <p>
+     * Typically, a message producer is assigned a queue at creation time; however, the JMS API also supports unidentified
+     * message producers, which require that the queue be supplied every time a message is sent.
+     *
+     * @param queue the queue to send this message to
+     * @param message the message to send
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     *
+     * @exception JMSException if the JMS provider fails to send the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid queue.
+     */
+    void send(Queue queue, Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
 }

--- a/src/main/java/javax/jms/QueueSession.java
+++ b/src/main/java/javax/jms/QueueSession.java
@@ -16,165 +16,141 @@
 
 package javax.jms;
 
-/** A {@code QueueSession} object provides methods for creating 
-  * {@code QueueReceiver}, {@code QueueSender}, 
-  * {@code QueueBrowser}, and {@code TemporaryQueue} objects.
-  *
-  * <P>If there are messages that have been received but not acknowledged 
-  * when a {@code QueueSession} terminates, these messages will be retained 
-  * and redelivered when a consumer next accesses the queue.
-  *
-  *<P>A {@code QueueSession} is used for creating Point-to-Point specific
-  * objects. In general, use the {@code Session} object. 
-  * The {@code QueueSession} is used to support
-  * existing code. Using the {@code Session} object simplifies the 
-  * programming model, and allows transactions to be used across the two 
-  * messaging domains.
-  * 
-  * <P>A {@code QueueSession} cannot be used to create objects specific to the 
-  * publish/subscribe domain. The following methods inherit from 
-  * {@code Session}, but must throw an
-  * {@code IllegalStateException} 
-  * if they are used from {@code QueueSession}:
-  *<UL>
-  *   <LI>{@code createDurableSubscriber}
-  *   <LI>{@code createDurableConsumer}
-  *   <LI>{@code createSharedConsumer}
-  *   <LI>{@code createSharedDurableConsumer}
-  *   <LI>{@code createTemporaryTopic}
-  *   <LI>{@code createTopic}
-  *   <LI>{@code unsubscribe}
-  * </UL>
-  *
-  * @see         javax.jms.Session
-  * @see         javax.jms.QueueConnection#createQueueSession(boolean, int)
-  * @see         javax.jms.XAQueueSession#getQueueSession()
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code QueueSession} object provides methods for creating {@code QueueReceiver}, {@code QueueSender},
+ * {@code QueueBrowser}, and {@code TemporaryQueue} objects.
+ *
+ * <p>
+ * If there are messages that have been received but not acknowledged when a {@code QueueSession} terminates, these
+ * messages will be retained and redelivered when a consumer next accesses the queue.
+ *
+ * <p>
+ * A {@code QueueSession} is used for creating Point-to-Point specific objects. In general, use the {@code Session}
+ * object. The {@code QueueSession} is used to support existing code. Using the {@code Session} object simplifies the
+ * programming model, and allows transactions to be used across the two messaging domains.
+ *
+ * <p>
+ * A {@code QueueSession} cannot be used to create objects specific to the publish/subscribe domain. The following
+ * methods inherit from {@code Session}, but must throw an {@code IllegalStateException} if they are used from
+ * {@code QueueSession}:
+ *
+ * <ul>
+ * <li>{@code createDurableSubscriber}
+ * <li>{@code createDurableConsumer}
+ * <li>{@code createSharedConsumer}
+ * <li>{@code createSharedDurableConsumer}
+ * <li>{@code createTemporaryTopic}
+ * <li>{@code createTopic}
+ * <li>{@code unsubscribe}
+ * </ul>
+ *
+ * @see javax.jms.Session
+ * @see javax.jms.QueueConnection#createQueueSession(boolean, int)
+ * @see javax.jms.XAQueueSession#getQueueSession()
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface QueueSession extends Session {
 
-    /** Creates a queue identity given a {@code Queue} name.
-      *
-      * <P>This facility is provided for the rare cases where clients need to
-      * dynamically manipulate queue identity. It allows the creation of a
-      * queue identity with a provider-specific name. Clients that depend 
-      * on this ability are not portable.
-      *
-      * <P>Note that this method is not for creating the physical queue. 
-      * The physical creation of queues is an administrative task and is not
-      * to be initiated by the JMS API. The one exception is the
-      * creation of temporary queues, which is accomplished with the 
-      * {@code createTemporaryQueue} method.
-      *
-      * @param queueName the name of this {@code Queue}
-      *
-      * @return a {@code Queue} with the given name
-      *
-      * @exception JMSException if the session fails to create a queue
-      *                         due to some internal error.
-      */ 
- 
-    Queue
-    createQueue(String queueName) throws JMSException;
+    /**
+     * Creates a queue identity given a {@code Queue} name.
+     *
+     * <p>
+     * This facility is provided for the rare cases where clients need to dynamically manipulate queue identity. It allows
+     * the creation of a queue identity with a provider-specific name. Clients that depend on this ability are not portable.
+     *
+     * <p>
+     * Note that this method is not for creating the physical queue. The physical creation of queues is an administrative
+     * task and is not to be initiated by the JMS API. The one exception is the creation of temporary queues, which is
+     * accomplished with the {@code createTemporaryQueue} method.
+     *
+     * @param queueName the name of this {@code Queue}
+     *
+     * @return a {@code Queue} with the given name
+     *
+     * @exception JMSException if the session fails to create a queue due to some internal error.
+     */
+    @Override
+    Queue createQueue(String queueName) throws JMSException;
 
+    /**
+     * Creates a {@code QueueReceiver} object to receive messages from the specified queue.
+     *
+     * @param queue the {@code Queue} to access
+     *
+     * @return A {@code QueueReceiver} object to receive messages from the specified queue
+     *
+     * @exception JMSException if the session fails to create a receiver due to some internal error.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     */
+    QueueReceiver createReceiver(Queue queue) throws JMSException;
 
-    /** Creates a {@code QueueReceiver} object to receive messages from the
-      * specified queue.
-      *
-      * @param queue the {@code Queue} to access
-      *
-      * @exception JMSException if the session fails to create a receiver
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      */
+    /**
+     * Creates a {@code QueueReceiver} object to receive messages from the specified queue using a message selector.
+     *
+     * @param queue the {@code Queue} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     *
+     * @return A {@code QueueReceiver} object to receive messages from the specified queue
+     *
+     * @exception JMSException if the session fails to create a receiver due to some internal error.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     */
+    QueueReceiver createReceiver(Queue queue, String messageSelector) throws JMSException;
 
-    QueueReceiver
-    createReceiver(Queue queue) throws JMSException;
+    /**
+     * Creates a {@code QueueSender} object to send messages to the specified queue.
+     *
+     * @param queue the {@code Queue} to access, or null if this is an unidentified producer
+     *
+     * @return A {@code QueueSender} object to send messages to the specified queue.
+     *
+     * @exception JMSException if the session fails to create a sender due to some internal error.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     */
+    QueueSender createSender(Queue queue) throws JMSException;
 
+    /**
+     * Creates a {@code QueueBrowser} object to peek at the messages on the specified queue.
+     *
+     * @param queue the {@code Queue} to access
+     *
+     * @return A {@code QueueBrowser} object to peek at the messages.
+     *
+     * @exception JMSException if the session fails to create a browser due to some internal error.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     */
+    @Override
+    QueueBrowser createBrowser(Queue queue) throws JMSException;
 
-    /** Creates a {@code QueueReceiver} object to receive messages from the 
-      * specified queue using a message selector.
-      *  
-      * @param queue the {@code Queue} to access
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered. A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer.
-      *  
-      * @exception JMSException if the session fails to create a receiver
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      * @exception InvalidSelectorException if the message selector is invalid.
-      *
-      */ 
+    /**
+     * Creates a {@code QueueBrowser} object to peek at the messages on the specified queue using a message selector.
+     *
+     * @param queue the {@code Queue} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     *
+     * @return A {@code QueueBrowser} object to peek at the messages on the specified queue.
+     *
+     * @exception JMSException if the session fails to create a browser due to some internal error.
+     * @exception InvalidDestinationException if an invalid queue is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     */
+    @Override
+    QueueBrowser createBrowser(Queue queue, String messageSelector) throws JMSException;
 
-    QueueReceiver
-    createReceiver(Queue queue, 
-		   String messageSelector) throws JMSException;
-
-
-    /** Creates a {@code QueueSender} object to send messages to the 
-      * specified queue.
-      *
-      * @param queue the {@code Queue} to access, or null if this is an 
-      * unidentified producer
-      *
-      * @exception JMSException if the session fails to create a sender
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      */
- 
-    QueueSender
-    createSender(Queue queue) throws JMSException;
-
-
-    /** Creates a {@code QueueBrowser} object to peek at the messages on 
-      * the specified queue.
-      *
-      * @param queue the {@code Queue} to access
-      *
-      * @exception JMSException if the session fails to create a browser
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      */
-
-    QueueBrowser 
-    createBrowser(Queue queue) throws JMSException;
-
-
-    /** Creates a {@code QueueBrowser} object to peek at the messages on 
-      * the specified queue using a message selector.
-      *  
-      * @param queue the {@code Queue} to access
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered. A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer.
-      *  
-      * @exception JMSException if the session fails to create a browser
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid queue is specified.
-      * @exception InvalidSelectorException if the message selector is invalid.
-      */ 
-
-    QueueBrowser
-    createBrowser(Queue queue,
-		  String messageSelector) throws JMSException;
-
-
-    /** Creates a {@code TemporaryQueue} object. Its lifetime will be that 
-      * of the {@code QueueConnection} unless it is deleted earlier.
-      *
-      * @return a temporary queue identity
-      *
-      * @exception JMSException if the session fails to create a temporary queue
-      *                         due to some internal error.
-      */
-
-    TemporaryQueue
-    createTemporaryQueue() throws JMSException;
+    /**
+     * Creates a {@code TemporaryQueue} object. Its lifetime will be that of the {@code QueueConnection} unless it is
+     * deleted earlier.
+     *
+     * @return a temporary queue identity
+     *
+     * @exception JMSException if the session fails to create a temporary queue due to some internal error.
+     */
+    @Override
+    TemporaryQueue createTemporaryQueue() throws JMSException;
 }

--- a/src/main/java/javax/jms/ResourceAllocationException.java
+++ b/src/main/java/javax/jms/ResourceAllocationException.java
@@ -17,45 +17,40 @@
 package javax.jms;
 
 /**
- * <P>This exception is thrown when a provider is unable to allocate the 
- *    resources required by a method. For example, this exception should be 
- *    thrown when a call to 
- *    {@code TopicConnectionFactory.createTopicConnection} fails due to a
- *    lack of JMS provider resources.
- * 
+ * This exception is thrown when a provider is unable to allocate the resources required by a method.
+ *
+ * <p>
+ * For example, this exception should be thrown when a call to {@code TopicConnectionFactory.createTopicConnection}
+ * fails due to a lack of JMS provider resources.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  **/
-
 public class ResourceAllocationException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -1172695755360706776L;
 
-  /** Constructs a {@code ResourceAllocationException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  ResourceAllocationException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -1172695755360706776L;
 
-  /** Constructs a {@code ResourceAllocationException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  ResourceAllocationException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code ResourceAllocationException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public ResourceAllocationException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code ResourceAllocationException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public ResourceAllocationException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/ResourceAllocationRuntimeException.java
+++ b/src/main/java/javax/jms/ResourceAllocationRuntimeException.java
@@ -17,60 +17,51 @@
 package javax.jms;
 
 /**
- * <P>This unchecked exception is thrown when a provider is unable to allocate the 
- *    resources required by a method. For example, this exception should be 
- *    thrown when a call to 
- *    {@code ConnectionFactory.createContext} fails due to a
- *    lack of JMS provider resources.
- * 
+ * This unchecked exception is thrown when a provider is unable to allocate the resources required by a method.
+ *
+ * <p>
+ * For example, this exception should be thrown when a call to {@code ConnectionFactory.createContext} fails due to a
+ * lack of JMS provider resources.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
  **/
-
 public class ResourceAllocationRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = -1306897975610715374L;
 
-  /** Constructs a {@code ResourceAllocationRuntimeException} with the specified 
-   *  reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  ResourceAllocationRuntimeException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = -1306897975610715374L;
 
-  /** Constructs a {@code ResourceAllocationRuntimeException} with the specified 
-   *  reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  ResourceAllocationRuntimeException(String reason) {
-    super(reason);
-  }
-  
-	/**
-	 * Constructs a {@code ResourceAllocationRuntimeException} with the specified detail message,
-	 * error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public ResourceAllocationRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage,errorCode,cause);
-	}
+    /**
+     * Constructs a {@code ResourceAllocationRuntimeException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public ResourceAllocationRuntimeException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code ResourceAllocationRuntimeException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public ResourceAllocationRuntimeException(String reason) {
+        super(reason);
+    }
+
+    /**
+     * Constructs a {@code ResourceAllocationRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public ResourceAllocationRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
 
 }

--- a/src/main/java/javax/jms/ServerSession.java
+++ b/src/main/java/javax/jms/ServerSession.java
@@ -16,79 +16,63 @@
 
 package javax.jms;
 
-/** A {@code ServerSession} object is an application server object that 
-  * is used by a server to associate a thread with a JMS session (optional).
-  *
-  * <P>A {@code ServerSession} implements two methods:
-  *
-  * <UL>
-  *   <LI>{@code getSession} - returns the {@code ServerSession}'s 
-  *       JMS session.
-  *   <LI>{@code start} - starts the execution of the 
-  *       {@code ServerSession} 
-  *       thread and results in the execution of the JMS session's 
-  *       {@code run} method.
-  * </UL>
-  *
-  * <P>A {@code ConnectionConsumer} implemented by a JMS provider uses a 
-  * {@code ServerSession} to process one or more messages that have 
-  * arrived. It does this by getting a {@code ServerSession} from the 
-  * {@code ConnectionConsumer}'s {@code ServerSessionPool}; getting 
-  * the {@code ServerSession}'s JMS session; loading it with the messages; 
-  * and then starting the {@code ServerSession}.
-  *
-  * <P>In most cases the {@code ServerSession} will register some object 
-  * it provides as the {@code ServerSession}'s thread run object. The 
-  * {@code ServerSession}'s {@code start} method will call the 
-  * thread's {@code start} method, which will start the new thread, and 
-  * from it, call the {@code run} method of the 
-  * {@code ServerSession}'s run object. This object will do some 
-  * housekeeping and then call the {@code Session}'s {@code run} 
-  * method. When {@code run} returns, the {@code ServerSession}'s run 
-  * object can return the {@code ServerSession} to the 
-  * {@code ServerSessionPool}, and the cycle starts again.
-  *
-  * <P>Note that the JMS API does not architect how the 
-  * {@code ConnectionConsumer} loads the {@code Session} with 
-  * messages. Since both the {@code ConnectionConsumer} and 
-  * {@code Session} are implemented by the same JMS provider, they can 
-  * accomplish the load using a private mechanism.
-  *
-  * @see         javax.jms.ServerSessionPool
-  * @see         javax.jms.ConnectionConsumer
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code ServerSession} object is an application server object that is used by a server to associate a thread with a
+ * JMS session (optional).
+ *
+ * <p>
+ * A {@code ServerSession} implements two methods:
+ *
+ * <ul>
+ * <li>{@code getSession} - returns the {@code ServerSession}'s JMS session.
+ * <li>{@code start} - starts the execution of the {@code ServerSession} thread and results in the execution of the JMS
+ * session's {@code run} method.
+ * </ul>
+ *
+ * <p>
+ * A {@code ConnectionConsumer} implemented by a JMS provider uses a {@code ServerSession} to process one or more
+ * messages that have arrived. It does this by getting a {@code ServerSession} from the {@code ConnectionConsumer}'s
+ * {@code ServerSessionPool}; getting the {@code ServerSession}'s JMS session; loading it with the messages; and then
+ * starting the {@code ServerSession}.
+ *
+ * <p>
+ * In most cases the {@code ServerSession} will register some object it provides as the {@code ServerSession}'s thread
+ * run object. The {@code ServerSession}'s {@code start} method will call the thread's {@code start} method, which will
+ * start the new thread, and from it, call the {@code run} method of the {@code ServerSession}'s run object. This object
+ * will do some housekeeping and then call the {@code Session}'s {@code run} method. When {@code run} returns, the
+ * {@code ServerSession}'s run object can return the {@code ServerSession} to the {@code ServerSessionPool}, and the
+ * cycle starts again.
+ *
+ * <p>
+ * Note that the JMS API does not architect how the {@code ConnectionConsumer} loads the {@code Session} with messages.
+ * Since both the {@code ConnectionConsumer} and {@code Session} are implemented by the same JMS provider, they can
+ * accomplish the load using a private mechanism.
+ *
+ * @see javax.jms.ServerSessionPool
+ * @see javax.jms.ConnectionConsumer
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface ServerSession {
 
-    /** Return the {@code ServerSession}'s {@code Session}. This must 
-      * be a {@code Session} created by the same {@code Connection} 
-      * that will be dispatching messages to it. The provider will assign one or
-      * more messages to the {@code Session} 
-      * and then call {@code start} on the {@code ServerSession}.
-      *
-      * @return the server session's session
-      *  
-      * @exception JMSException if the JMS provider fails to get the associated
-      *                         session for this {@code ServerSession} due
-      *                         to some internal error.
-      **/
+    /**
+     * Return the {@code ServerSession}'s {@code Session}. This must be a {@code Session} created by the same
+     * {@code Connection} that will be dispatching messages to it. The provider will assign one or more messages to the
+     * {@code Session} and then call {@code start} on the {@code ServerSession}.
+     *
+     * @return the server session's session
+     *
+     * @exception JMSException if the JMS provider fails to get the associated session for this {@code ServerSession} due to
+     * some internal error.
+     **/
+    Session getSession() throws JMSException;
 
-    Session
-    getSession() throws JMSException;
-
-
-    /** Cause the {@code Session}'s {@code run} method to be called 
-      * to process messages that were just assigned to it.
-      *  
-      * @exception JMSException if the JMS provider fails to start the server
-      *                         session to process messages due to some internal
-      *                         error.
-      */
-
-    void 
-    start() throws JMSException; 
+    /**
+     * Cause the {@code Session}'s {@code run} method to be called to process messages that were just assigned to it.
+     *
+     * @exception JMSException if the JMS provider fails to start the server session to process messages due to some
+     * internal error.
+     */
+    void start() throws JMSException;
 }

--- a/src/main/java/javax/jms/ServerSessionPool.java
+++ b/src/main/java/javax/jms/ServerSessionPool.java
@@ -16,40 +16,34 @@
 
 package javax.jms;
 
-/** A {@code ServerSessionPool} object is an object implemented by an 
-  * application server to provide a pool of {@code ServerSession} objects 
-  * for processing the messages of a {@code ConnectionConsumer} (optional).
-  *
-  * <P>Its only method is {@code getServerSession}. The JMS API does not 
-  * architect how the pool is implemented. It could be a static pool of 
-  * {@code ServerSession} objects, or it could use a sophisticated 
-  * algorithm to dynamically create {@code ServerSession} objects as 
-  * needed.
-  *
-  * <P>If the {@code ServerSessionPool} is out of 
-  * {@code ServerSession} objects, the {@code getServerSession} call 
-  * may block. If a {@code ConnectionConsumer} is blocked, it cannot 
-  * deliver new messages until a {@code ServerSession} is 
-  * eventually returned.
-  *
-  * @see javax.jms.ServerSession
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code ServerSessionPool} object is an object implemented by an application server to provide a pool of
+ * {@code ServerSession} objects for processing the messages of a {@code ConnectionConsumer} (optional).
+ *
+ * <p>
+ * Its only method is {@code getServerSession}. The JMS API does not architect how the pool is implemented. It could be
+ * a static pool of {@code ServerSession} objects, or it could use a sophisticated algorithm to dynamically create
+ * {@code ServerSession} objects as needed.
+ *
+ * <p>
+ * If the {@code ServerSessionPool} is out of {@code ServerSession} objects, the {@code getServerSession} call may
+ * block. If a {@code ConnectionConsumer} is blocked, it cannot deliver new messages until a {@code ServerSession} is
+ * eventually returned.
+ *
+ * @see javax.jms.ServerSession
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface ServerSessionPool {
 
-    /** Return a server session from the pool.
-      *
-      * @return a server session from the pool
-      *  
-      * @exception JMSException if an application server fails to
-      *                         return a {@code ServerSession} out of its
-      *                         server session pool.
-      */ 
-
-    ServerSession
-    getServerSession() throws JMSException;
+    /**
+     * Return a server session from the pool.
+     *
+     * @return a server session from the pool
+     *
+     * @exception JMSException if an application server fails to return a {@code ServerSession} out of its server session
+     * pool.
+     */
+    ServerSession getServerSession() throws JMSException;
 }

--- a/src/main/java/javax/jms/Session.java
+++ b/src/main/java/javax/jms/Session.java
@@ -18,1502 +18,1262 @@ package javax.jms;
 
 import java.io.Serializable;
 
-/** <P>A {@code Session} object is a single-threaded context for producing and consuming 
-  * messages. Although it may allocate provider resources outside the Java 
-  * virtual machine (JVM), it is considered a lightweight JMS object.
-  *
-  * <P>A session serves several purposes:
-  *
-  * <UL>
-  *   <LI>It is a factory for its message producers and consumers.
-  *   <LI>It supplies provider-optimized message factories.
-  *   <LI>It is a factory for {@code TemporaryTopics} and 
-  *        {@code TemporaryQueues}. 
-  *   <LI> It provides a way to create {@code Queue} or {@code Topic}
-  *      objects for those clients that need to dynamically manipulate 
-  *      provider-specific destination names.
-  *   <LI>It supports a single series of transactions that combine work 
-  *       spanning its producers and consumers into atomic units.
-  *   <LI>It defines a serial order for the messages it consumes and 
-  *       the messages it produces.
-  *   <LI>It retains messages it consumes until they have been 
-  *       acknowledged.
-  *   <LI>It serializes execution of message listeners registered with 
-  *       its message consumers.
-  *   <LI> It is a factory for {@code QueueBrowsers}.
-  * </UL>
-  *
-  * <P>A session can create and service multiple message producers and 
-  * consumers.
-  *
-  * <P>One typical use is to have a thread block on a synchronous 
-  * {@code MessageConsumer} until a message arrives. The thread may then
-  * use one or more of the {@code Session}'s {@code MessageProducer}s.
-  *
-  * <P>If a client desires to have one thread produce messages while others 
-  * consume them, the client should use a separate session for its producing 
-  * thread.
-  *
-  * <P>Once a connection has been started, any session with one or more 
-  * registered message listeners is dedicated to the thread of control that 
-  * delivers messages to it. It is erroneous for client code to use this session
-  * or any of its constituent objects from another thread of control. The
-  * only exception to this rule is the use of the session or message consumer 
-  * {@code close} method.
-  *
-  * <P>It should be easy for most clients to partition their work naturally
-  * into sessions. This model allows clients to start simply and incrementally
-  * add message processing complexity as their need for concurrency grows.
-  *
-  * <P>The {@code close} method is the only session method that can be 
-  * called while some other session method is being executed in another thread.
-  *
-  * <P>A session may be specified as transacted. Each transacted 
-  * session supports a single series of transactions. Each transaction groups 
-  * a set of message sends and a set of message receives into an atomic unit 
-  * of work. In effect, transactions organize a session's input message 
-  * stream and output message stream into series of atomic units. When a 
-  * transaction commits, its atomic unit of input is acknowledged and its 
-  * associated atomic unit of output is sent. If a transaction rollback is 
-  * done, the transaction's sent messages are destroyed and the session's input 
-  * is automatically recovered.
-  *
-  * <P>The content of a transaction's input and output units is simply those 
-  * messages that have been produced and consumed within the session's current 
-  * transaction.
-  *
-  * <P>A transaction is completed using either its session's {@code commit}
-  * method or its session's {@code rollback} method. The completion of a
-  * session's current transaction automatically begins the next. The result is
-  * that a transacted session always has a current transaction within which its 
-  * work is done.  
-  *
-  * <P>The Java Transaction Service (JTS) or some other transaction monitor may 
-  * be used to combine a session's transaction with transactions on other 
-  * resources (databases, other JMS sessions, etc.). Since Java distributed 
-  * transactions are controlled via the Java Transaction API (JTA), use of the 
-  * session's {@code commit} and {@code rollback} methods in 
-  * this context is prohibited.
-  *
-  * <P>The JMS API does not require support for JTA; however, it does define 
-  * how a provider supplies this support.
-  *
-  * <P>Although it is also possible for a JMS client to handle distributed 
-  * transactions directly, it is unlikely that many JMS clients will do this.
-  * Support for JTA in the JMS API is targeted at systems vendors who will be 
-  * integrating the JMS API into their application server products.
-  * 
-  * @see         javax.jms.QueueSession
-  * @see         javax.jms.TopicSession
-  * @see         javax.jms.XASession
-  *
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */ 
- 
+/**
+ * A {@code Session} object is a single-threaded context for producing and consuming messages. Although it may allocate
+ * provider resources outside the Java virtual machine (JVM), it is considered a lightweight JMS object.
+ *
+ * <p>
+ * A session serves several purposes:
+ *
+ * <ul>
+ * <li>It is a factory for its message producers and consumers.
+ * <li>It supplies provider-optimized message factories.
+ * <li>It is a factory for {@code TemporaryTopics} and {@code TemporaryQueues}.
+ * <li>It provides a way to create {@code Queue} or {@code Topic} objects for those clients that need to dynamically
+ * manipulate provider-specific destination names.
+ * <li>It supports a single series of transactions that combine work spanning its producers and consumers into atomic
+ * units.
+ * <li>It defines a serial order for the messages it consumes and the messages it produces.
+ * <li>It retains messages it consumes until they have been acknowledged.
+ * <li>It serializes execution of message listeners registered with its message consumers.
+ * <li>It is a factory for {@code QueueBrowsers}.
+ * </ul>
+ *
+ * <p>
+ * A session can create and service multiple message producers and consumers.
+ *
+ * <p>
+ * One typical use is to have a thread block on a synchronous {@code MessageConsumer} until a message arrives. The
+ * thread may then use one or more of the {@code Session}'s {@code MessageProducer}s.
+ *
+ * <p>
+ * If a client desires to have one thread produce messages while others consume them, the client should use a separate
+ * session for its producing thread.
+ *
+ * <p>
+ * Once a connection has been started, any session with one or more registered message listeners is dedicated to the
+ * thread of control that delivers messages to it. It is erroneous for client code to use this session or any of its
+ * constituent objects from another thread of control. The only exception to this rule is the use of the session or
+ * message consumer {@code close} method.
+ *
+ * <p>
+ * It should be easy for most clients to partition their work naturally into sessions. This model allows clients to
+ * start simply and incrementally add message processing complexity as their need for concurrency grows.
+ *
+ * <p>
+ * The {@code close} method is the only session method that can be called while some other session method is being
+ * executed in another thread.
+ *
+ * <p>
+ * A session may be specified as transacted. Each transacted session supports a single series of transactions. Each
+ * transaction groups a set of message sends and a set of message receives into an atomic unit of work. In effect,
+ * transactions organize a session's input message stream and output message stream into series of atomic units. When a
+ * transaction commits, its atomic unit of input is acknowledged and its associated atomic unit of output is sent. If a
+ * transaction rollback is done, the transaction's sent messages are destroyed and the session's input is automatically
+ * recovered.
+ *
+ * <p>
+ * The content of a transaction's input and output units is simply those messages that have been produced and consumed
+ * within the session's current transaction.
+ *
+ * <p>
+ * A transaction is completed using either its session's {@code commit} method or its session's {@code rollback} method.
+ * The completion of a session's current transaction automatically begins the next. The result is that a transacted
+ * session always has a current transaction within which its work is done.
+ *
+ * <p>
+ * The Java Transaction Service (JTS) or some other transaction monitor may be used to combine a session's transaction
+ * with transactions on other resources (databases, other JMS sessions, etc.). Since Java distributed transactions are
+ * controlled via the Java Transaction API (JTA), use of the session's {@code commit} and {@code rollback} methods in
+ * this context is prohibited.
+ *
+ * <p>
+ * The JMS API does not require support for JTA; however, it does define how a provider supplies this support.
+ *
+ * <p>
+ * Although it is also possible for a JMS client to handle distributed transactions directly, it is unlikely that many
+ * JMS clients will do this. Support for JTA in the JMS API is targeted at systems vendors who will be integrating the
+ * JMS API into their application server products.
+ *
+ * @see javax.jms.QueueSession
+ * @see javax.jms.TopicSession
+ * @see javax.jms.XASession
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface Session extends Runnable, AutoCloseable {
 
-    /** With this acknowledgment mode, the session automatically acknowledges
-      * a client's receipt of a message either when the session has successfully 
-      * returned from a call to {@code receive} or when the message 
-      * listener the session has called to process the message successfully 
-      * returns.
-      */ 
+    /**
+     * With this acknowledgment mode, the session automatically acknowledges a client's receipt of a message either when the
+     * session has successfully returned from a call to {@code receive} or when the message listener the session has called
+     * to process the message successfully returns.
+     */
+    int AUTO_ACKNOWLEDGE = 1;
 
-    static final int AUTO_ACKNOWLEDGE = 1;
-
-    /** With this acknowledgment mode, the client acknowledges a consumed 
-      * message by calling the message's {@code acknowledge} method. 
-      * Acknowledging a consumed message acknowledges all messages that the 
-      * session has consumed.
-      *
-      * <P>When client acknowledgment mode is used, a client may build up a 
-      * large number of unacknowledged messages while attempting to process 
-      * them. A JMS provider should provide administrators with a way to 
-      * limit client overrun so that clients are not driven to resource 
-      * exhaustion and ensuing failure when some resource they are using 
-      * is temporarily blocked.
-      *
-      * @see javax.jms.Message#acknowledge()
-      */ 
-
-    static final int CLIENT_ACKNOWLEDGE = 2;
-
-    /** This acknowledgment mode instructs the session to lazily acknowledge 
-      * the delivery of messages. This is likely to result in the delivery of 
-      * some duplicate messages if the JMS provider fails, so it should only be 
-      * used by consumers that can tolerate duplicate messages. Use of this  
-      * mode can reduce session overhead by minimizing the work the 
-      * session does to prevent duplicates.
-      */
-
-    static final int DUPS_OK_ACKNOWLEDGE = 3;
-    
-    /** This value may be passed as the argument to the 
-     * method {@code createSession(int sessionMode)}
-     * on the {@code Connection} object
-     * to specify that the session should use a local transaction.
+    /**
+     * With this acknowledgment mode, the client acknowledges a consumed message by calling the message's
+     * {@code acknowledge} method. Acknowledging a consumed message acknowledges all messages that the session has consumed.
+     *
      * <p>
-     * This value is returned from the method 
-     * {@code getAcknowledgeMode} if the session is using a local transaction,
-     * irrespective of whether the session was created by calling the
-     * method {@code createSession(int sessionMode)} or the 
+     * When client acknowledgment mode is used, a client may build up a large number of unacknowledged messages while
+     * attempting to process them. A JMS provider should provide administrators with a way to limit client overrun so that
+     * clients are not driven to resource exhaustion and ensuing failure when some resource they are using is temporarily
+     * blocked.
+     *
+     * @see javax.jms.Message#acknowledge()
+     */
+    int CLIENT_ACKNOWLEDGE = 2;
+
+    /**
+     * This acknowledgment mode instructs the session to lazily acknowledge the delivery of messages. This is likely to
+     * result in the delivery of some duplicate messages if the JMS provider fails, so it should only be used by consumers
+     * that can tolerate duplicate messages. Use of this mode can reduce session overhead by minimizing the work the session
+     * does to prevent duplicates.
+     */
+
+    int DUPS_OK_ACKNOWLEDGE = 3;
+
+    /**
+     * This value may be passed as the argument to the method {@code createSession(int sessionMode)} on the
+     * {@code Connection} object to specify that the session should use a local transaction.
+     *
+     * <p>
+     * This value is returned from the method {@code getAcknowledgeMode} if the session is using a local transaction,
+     * irrespective of whether the session was created by calling the method {@code createSession(int sessionMode)} or the
      * method {@code createSession(boolean transacted, int acknowledgeMode)}.
-     * 
+     *
      * @since JMS 1.1
      */
-    static final int SESSION_TRANSACTED = 0;
+    int SESSION_TRANSACTED = 0;
 
-    /** Creates a {@code BytesMessage} object. A {@code BytesMessage} 
-      * object is used to send a message containing a stream of uninterpreted 
-      * bytes.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      *  
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-    BytesMessage 
-    createBytesMessage() throws JMSException; 
-
- 
-    /** Creates a {@code MapMessage} object. A {@code MapMessage} 
-      * object is used to send a self-defining set of name-value pairs, where 
-      * names are {@code String} objects and values are primitive values 
-      * in the Java programming language.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      *  
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-
-    MapMessage 
-    createMapMessage() throws JMSException; 
-
- 
-    /** Creates a {@code Message} object. The {@code Message} 
-      * interface is the root interface of all JMS messages. A 
-      * {@code Message} object holds all the 
-      * standard message header information. It can be sent when a message 
-      * containing only header information is sufficient.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      *  
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-
-    Message
-    createMessage() throws JMSException;
-
-
-    /** Creates an {@code ObjectMessage} object. An 
-      * {@code ObjectMessage} object is used to send a message 
-      * that contains a serializable Java object.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      *  
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-
-    ObjectMessage
-    createObjectMessage() throws JMSException; 
-
-
-    /** Creates an initialized {@code ObjectMessage} object. An 
-      * {@code ObjectMessage} object is used 
-      * to send a message that contains a serializable Java object.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      *  
-      * @param object the object to use to initialize this message
-      *
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-
-    ObjectMessage
-    createObjectMessage(Serializable object) throws JMSException;
-
- 
-    /** Creates a {@code StreamMessage} object. A 
-      * {@code StreamMessage} object is used to send a 
-      * self-defining stream of primitive values in the Java programming 
-      * language.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      * 
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */
-
-    StreamMessage 
-    createStreamMessage() throws JMSException;  
-
- 
-    /** Creates a {@code TextMessage} object. A {@code TextMessage} 
-      * object is used to send a message containing a {@code String}
-      * object.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      * 
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-
-    TextMessage 
-    createTextMessage() throws JMSException; 
-
-
-    /** Creates an initialized {@code TextMessage} object. A 
-      * {@code TextMessage} object is used to send 
-      * a message containing a {@code String}.
-      * <p>
-      * The message object returned may be sent using any {@code Session} or {@code JMSContext}. 
-      * It is not restricted to being sent using the {@code JMSContext} used to create it.
-      * <p>
-      * The message object returned may be optimised for use with the JMS provider
-      * used to create it. However it can be sent using any JMS provider, not just the 
-      * JMS provider used to create it.
-      * 
-      * @param text the string used to initialize this message
-      *
-      * @exception JMSException if the JMS provider fails to create this message
-      *                         due to some internal error.
-      */ 
-
-    TextMessage
-    createTextMessage(String text) throws JMSException;
-
-
-    /** Indicates whether the session is in transacted mode.
-      *  
-      * @return true if the session is in transacted mode
-      *  
-      * @exception JMSException if the JMS provider fails to return the 
-      *                         transaction mode due to some internal error.
-      */ 
-
-    boolean
-    getTransacted() throws JMSException;
-    
-    /** Returns the acknowledgement mode of the session. The acknowledgement
-     * mode is set at the time that the session is created. If the session is
-     * transacted, the acknowledgement mode is ignored.
+    /**
+     * Creates a {@code BytesMessage} object. A {@code BytesMessage} object is used to send a message containing a stream of
+     * uninterpreted bytes.
      *
-     * @return          If the session is not transacted, returns the 
-     *                  current acknowledgement mode for the session.
-     *                  If the session
-     *                  is transacted, returns SESSION_TRANSACTED.
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
      *
-     * @exception JMSException   if the JMS provider fails to return the 
-     *                         acknowledgment mode due to some internal error.
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return A {@code BytesMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    BytesMessage createBytesMessage() throws JMSException;
+
+    /**
+     * Creates a {@code MapMessage} object. A {@code MapMessage} object is used to send a self-defining set of name-value
+     * pairs, where names are {@code String} objects and values are primitive values in the Java programming language.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return A {@code MapMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    MapMessage createMapMessage() throws JMSException;
+
+    /**
+     * Creates a {@code Message} object. The {@code Message} interface is the root interface of all JMS messages. A
+     * {@code Message} object holds all the standard message header information. It can be sent when a message containing
+     * only header information is sufficient.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return A {@code Message} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    Message createMessage() throws JMSException;
+
+    /**
+     * Creates an {@code ObjectMessage} object. An {@code ObjectMessage} object is used to send a message that contains a
+     * serializable Java object.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return A {@code ObjectMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    ObjectMessage createObjectMessage() throws JMSException;
+
+    /**
+     * Creates an initialized {@code ObjectMessage} object. An {@code ObjectMessage} object is used to send a message that
+     * contains a serializable Java object.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @param object the object to use to initialize this message
+     *
+     * @return A {@code ObjectMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    ObjectMessage createObjectMessage(Serializable object) throws JMSException;
+
+    /**
+     * Creates a {@code StreamMessage} object. A {@code StreamMessage} object is used to send a self-defining stream of
+     * primitive values in the Java programming language.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return A {@code StreamMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    StreamMessage createStreamMessage() throws JMSException;
+
+    /**
+     * Creates a {@code TextMessage} object. A {@code TextMessage} object is used to send a message containing a
+     * {@code String} object.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @return A {@code TextMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    TextMessage createTextMessage() throws JMSException;
+
+    /**
+     * Creates an initialized {@code TextMessage} object. A {@code TextMessage} object is used to send a message containing
+     * a {@code String}.
+     *
+     * <p>
+     * The message object returned may be sent using any {@code Session} or {@code JMSContext}. It is not restricted to
+     * being sent using the {@code JMSContext} used to create it.
+     *
+     * <p>
+     * The message object returned may be optimised for use with the JMS provider used to create it. However it can be sent
+     * using any JMS provider, not just the JMS provider used to create it.
+     *
+     * @param text the string used to initialize this message
+     *
+     * @return A {@code TextMessage} object.
+     *
+     * @exception JMSException if the JMS provider fails to create this message due to some internal error.
+     */
+    TextMessage createTextMessage(String text) throws JMSException;
+
+    /**
+     * Indicates whether the session is in transacted mode.
+     *
+     * @return true if the session is in transacted mode
+     *
+     * @exception JMSException if the JMS provider fails to return the transaction mode due to some internal error.
+     */
+    boolean getTransacted() throws JMSException;
+
+    /**
+     * Returns the acknowledgement mode of the session. The acknowledgement mode is set at the time that the session is
+     * created. If the session is transacted, the acknowledgement mode is ignored.
+     *
+     * @return If the session is not transacted, returns the current acknowledgement mode for the session. If the session is
+     * transacted, returns SESSION_TRANSACTED.
+     *
+     * @exception JMSException if the JMS provider fails to return the acknowledgment mode due to some internal error.
      *
      * @see Connection#createSession
-     * 
-     * @since JMS 1.1
-     * 
-     */
-    int 
-    getAcknowledgeMode() throws JMSException;
-
-
-    /**
-	 * Commits all messages done in this transaction and releases any locks
-	 * currently held.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>Session</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>commit</tt> on its own <tt>Session</tt>. Doing so will cause an
-	 * <tt>IllegalStateException</tt> to be thrown.
-	 * <p>
-	 * 
-	 * @exception IllegalStateException
-	 *                <ul>
-	 *                <li>the session is not using a local transaction
-	 *                <li>this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>Session</tt></li>
-	 *                </ul>
-	 * @exception JMSException
-	 *                if the JMS provider fails to commit the transaction due to
-	 *                some internal error.
-	 * @exception TransactionRolledBackException
-	 *                if the transaction is rolled back due to some internal
-	 *                error during commit.
-	 */
-
-    void
-    commit() throws JMSException;
-
-
-    /** Rolls back any messages done in this transaction and releases any locks 
-      * currently held.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>Session</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	  * A <tt>CompletionListener</tt> callback method must not call
-	  * <tt>commit</tt> on its own <tt>Session</tt>. Doing so will cause an
-	  * <tt>IllegalStateException</tt> to be thrown.
-	  * <p>
-	  * 
-	  * @exception IllegalStateException
-	  *                <ul>
-	  *                <li>the session is not using a local transaction
-	  *                <li>this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>Session</tt></li>
-	  *                </ul>
-      * @exception JMSException if the JMS provider fails to roll back the
-      *                         transaction due to some internal error.
-      *                                     
-      */
-
-    void
-    rollback() throws JMSException;
-
-
-    /**
-	 * Closes the session.
-	 * 
-	 * <P>
-	 * Since a provider may allocate some resources on behalf of a session
-	 * outside the JVM, clients should close the resources when they are not
-	 * needed. Relying on garbage collection to eventually reclaim these
-	 * resources may not be timely enough.
-	 * 
-	 * <P>
-	 * There is no need to close the producers and consumers of a closed
-	 * session.
-	 * 
-	 * <P>
-	 * This call will block until a {@code receive} call or message
-	 * listener in progress has completed. A blocked message consumer
-	 * {@code receive} call returns {@code null} when this session is
-	 * closed.
-	 * <p>
-	 * However if the close method is called from a message listener 
-	 * on its own {@code Session}, then it will either fail and throw a 
-	 * {@code javax.jms.IllegalStateException}, or it will succeed and 
-	 * close the {@code Session}, blocking until any pending receive call in progress
-	 * has completed. If close succeeds and the acknowledge mode of the
-	 * {@code Session} is set to {@code AUTO_ACKNOWLEDGE}, the current message will still
-	 * be acknowledged automatically when the {@code onMessage} call completes.
-	 * <p>
-	 * Since two alternative behaviors are permitted in this case, 
-	 * applications should avoid calling close from a message listener on 
-	 * its own {@code Session} because this is not portable.
-	 * <p>
-	 * This method must not return until any incomplete asynchronous send
-	 * operations for this <tt>Session</tt> have been completed and any
-	 * <tt>CompletionListener</tt> callbacks have returned. Incomplete sends
-	 * should be allowed to complete normally unless an error occurs.
-	 * <p>
-	 * For the avoidance of doubt, if an exception listener for this session's
-	 * connection is running when {@code close} is invoked, there is no
-	 * requirement for the {@code close} call to wait until the exception
-	 * listener has returned before it may return.
-	 * 
-	 * <P>
-	 * Closing a transacted session must roll back the transaction in progress.
-	 * 
-	 * <P>
-	 * This method is the only {@code Session} method that can be called
-	 * concurrently.
-	 * <p>
-	 * A <tt>CompletionListener</tt> callback method must not call
-	 * <tt>close</tt> on its own <tt>Session</tt>. Doing so will cause an
-	 * <tt>IllegalStateException</tt> to be thrown.
-	 * <p>
-	 * Invoking any other {@code Session} method on a closed session must
-	 * throw a {@code IllegalStateException}. Closing a closed
-	 * session must <I>not</I> throw an exception.
-	 * 
-	 * @exception IllegalStateException
-	 *                <ul>
-	 *                <li>this method has been called by a <tt>MessageListener
-	 *                </tt> on its own <tt>Session</tt></li> 
-	 *                <li>this method has
-	 *                been called by a <tt>CompletionListener</tt> callback
-	 *                method on its own <tt>Session</tt></li>
-	 *                </ul>
-	 * @exception JMSException
-	 *                if the JMS provider fails to close the session due to some
-	 *                internal error.
-	 * 
-	 */
-
-    void
-    close() throws JMSException;
-
-
-    /** Stops message delivery in this session, and restarts message delivery
-      * with the oldest unacknowledged message.
-      *  
-      * <P>All consumers deliver messages in a serial order.
-      * Acknowledging a received message automatically acknowledges all 
-      * messages that have been delivered to the client.
-      *
-      * <P>Restarting a session causes it to take the following actions:
-      *
-      * <UL>
-      *   <LI>Stop message delivery
-      *   <LI>Mark all messages that might have been delivered but not 
-      *       acknowledged as "redelivered"
-      *   <LI>Restart the delivery sequence including all unacknowledged 
-      *       messages that had been previously delivered. Redelivered messages
-      *       do not have to be delivered in 
-      *       exactly their original delivery order.
-      * </UL>
-      *
-      * @exception JMSException if the JMS provider fails to stop and restart
-      *                         message delivery due to some internal error.
-      * @exception IllegalStateException if the method is called by a 
-      *                         transacted session.
-      */ 
-
-    void
-    recover() throws JMSException;
-
-
-    /** Returns the session's distinguished message listener (optional).
-     * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSException} to be thrown though this is not guaranteed.
-      * 
-      * @return the distinguished message listener associated with this session
-      *
-      * @exception JMSException if the JMS provider fails to get the session's distinguished message  
-      *                         listener for one of the following reasons:
-      *                         <ul>
-      *                         <li>an internal error has occurred
-      *                         <li>this method has been called in a Java EE web or EJB application 
-      *                         (though it is not guaranteed that an exception is thrown in this case)
-      *                         </ul>
-      *      
-      * @see javax.jms.Session#setMessageListener
-      * @see javax.jms.ServerSessionPool
-      * @see javax.jms.ServerSession
-      */
-    MessageListener getMessageListener() throws JMSException; 
-    
-    /** Sets the session's distinguished message listener (optional).
      *
-     * <P>When the distinguished message listener is set, no other form of 
-     * message receipt in the session can 
-     * be used; however, all forms of sending messages are still supported.
-     * 
-     * <P>This is an expert facility not used by ordinary JMS clients.
+     * @since JMS 1.1
+     */
+    int getAcknowledgeMode() throws JMSException;
+
+    /**
+     * Commits all messages done in this transaction and releases any locks currently held.
+     *
      * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSException} to be thrown though this is not guaranteed.
-     * 
+     * This method must not return until any incomplete asynchronous send operations for this <tt>Session</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>commit</tt> on its own <tt>Session</tt>. Doing so
+     * will cause an <tt>IllegalStateException</tt> to be thrown.
+     *
+     * @exception IllegalStateException
+     * <ul>
+     * <li>the session is not using a local transaction
+     * <li>this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>Session</tt></li>
+     * </ul>
+     * @exception JMSException if the JMS provider fails to commit the transaction due to some internal error.
+     * @exception TransactionRolledBackException if the transaction is rolled back due to some internal error during commit.
+     */
+    void commit() throws JMSException;
+
+    /**
+     * Rolls back any messages done in this transaction and releases any locks currently held.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>Session</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>commit</tt> on its own <tt>Session</tt>. Doing so
+     * will cause an <tt>IllegalStateException</tt> to be thrown.
+     *
+     * @exception IllegalStateException
+     * <ul>
+     * <li>the session is not using a local transaction
+     * <li>this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>Session</tt></li>
+     * </ul>
+     * @exception JMSException if the JMS provider fails to roll back the transaction due to some internal error.
+     */
+    void rollback() throws JMSException;
+
+    /**
+     * Closes the session.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a session outside the JVM, clients should close the
+     * resources when they are not needed. Relying on garbage collection to eventually reclaim these resources may not be
+     * timely enough.
+     *
+     * <p>
+     * There is no need to close the producers and consumers of a closed session.
+     *
+     * <p>
+     * This call will block until a {@code receive} call or message listener in progress has completed. A blocked message
+     * consumer {@code receive} call returns {@code null} when this session is closed.
+     *
+     * <p>
+     * However if the close method is called from a message listener on its own {@code Session}, then it will either fail
+     * and throw a {@code javax.jms.IllegalStateException}, or it will succeed and close the {@code Session}, blocking until
+     * any pending receive call in progress has completed. If close succeeds and the acknowledge mode of the {@code Session}
+     * is set to {@code AUTO_ACKNOWLEDGE}, the current message will still be acknowledged automatically when the
+     * {@code onMessage} call completes.
+     *
+     * <p>
+     * Since two alternative behaviors are permitted in this case, applications should avoid calling close from a message
+     * listener on its own {@code Session} because this is not portable.
+     *
+     * <p>
+     * This method must not return until any incomplete asynchronous send operations for this <tt>Session</tt> have been
+     * completed and any <tt>CompletionListener</tt> callbacks have returned. Incomplete sends should be allowed to complete
+     * normally unless an error occurs.
+     *
+     * <p>
+     * For the avoidance of doubt, if an exception listener for this session's connection is running when {@code close} is
+     * invoked, there is no requirement for the {@code close} call to wait until the exception listener has returned before
+     * it may return.
+     *
+     * <p>
+     * Closing a transacted session must roll back the transaction in progress.
+     *
+     * <p>
+     * This method is the only {@code Session} method that can be called concurrently.
+     *
+     * <p>
+     * A <tt>CompletionListener</tt> callback method must not call <tt>close</tt> on its own <tt>Session</tt>. Doing so will
+     * cause an <tt>IllegalStateException</tt> to be thrown.
+     *
+     * <p>
+     * Invoking any other {@code Session} method on a closed session must throw a {@code IllegalStateException}. Closing a
+     * closed session must <I>not</I> throw an exception.
+     *
+     * @exception IllegalStateException
+     * <ul>
+     * <li>this method has been called by a <tt>MessageListener
+     *                </tt> on its own <tt>Session</tt></li>
+     * <li>this method has been called by a <tt>CompletionListener</tt> callback method on its own <tt>Session</tt></li>
+     * </ul>
+     * @exception JMSException if the JMS provider fails to close the session due to some internal error.
+     */
+    @Override
+    void close() throws JMSException;
+
+    /**
+     * Stops message delivery in this session, and restarts message delivery with the oldest unacknowledged message.
+     *
+     * <p>
+     * All consumers deliver messages in a serial order. Acknowledging a received message automatically acknowledges all
+     * messages that have been delivered to the client.
+     *
+     * <p>
+     * Restarting a session causes it to take the following actions:
+     *
+     * <ul>
+     * <li>Stop message delivery
+     * <li>Mark all messages that might have been delivered but not acknowledged as "redelivered"
+     * <li>Restart the delivery sequence including all unacknowledged messages that had been previously delivered.
+     * Redelivered messages do not have to be delivered in exactly their original delivery order.
+     * </ul>
+     *
+     * @exception JMSException if the JMS provider fails to stop and restart message delivery due to some internal error.
+     * @exception IllegalStateException if the method is called by a transacted session.
+     */
+    void recover() throws JMSException;
+
+    /**
+     * Returns the session's distinguished message listener (optional).
+     *
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
+     * @return the distinguished message listener associated with this session
+     *
+     * @exception JMSException if the JMS provider fails to get the session's distinguished message listener for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
+     *
+     * @see javax.jms.Session#setMessageListener
+     * @see javax.jms.ServerSessionPool
+     * @see javax.jms.ServerSession
+     */
+    MessageListener getMessageListener() throws JMSException;
+
+    /**
+     * Sets the session's distinguished message listener (optional).
+     *
+     * <p>
+     * When the distinguished message listener is set, no other form of message receipt in the session can be used; however,
+     * all forms of sending messages are still supported.
+     *
+     * <p>
+     * This is an expert facility not used by ordinary JMS clients.
+     * <p>
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSException} to be
+     * thrown though this is not guaranteed.
+     *
      * @param listener the message listener to associate with this session
      *
-     * @exception JMSException if the JMS provider fails to set the session's distinguished message  
-     *                         listener for one of the following reasons:
-     *                         <ul>
-     *                         <li>an internal error has occurred
-     *                         <li>this method has been called in a Java EE web or EJB application 
-     *                         (though it is not guaranteed that an exception is thrown in this case)
-     *                         </ul>
+     * @exception JMSException if the JMS provider fails to set the session's distinguished message listener for one of the
+     * following reasons:
+     * <ul>
+     * <li>an internal error has occurred
+     * <li>this method has been called in a Java EE web or EJB application (though it is not guaranteed that an exception is
+     * thrown in this case)
+     * </ul>
      *
      * @see javax.jms.Session#getMessageListener
      * @see javax.jms.ServerSessionPool
      * @see javax.jms.ServerSession
      */
     void setMessageListener(MessageListener listener) throws JMSException;
-    
+
     /**
-     * Optional operation, intended to be used only by Application Servers,
-     * not by ordinary JMS clients.
+     * Optional operation, intended to be used only by Application Servers, not by ordinary JMS clients.
+     *
      * <p>
-     * This method must not be used in a Java EE web or EJB application. 
-     * Doing so may cause a {@code JMSRuntimeException} to be thrown though this is not guaranteed.
-     * 
-      * @exception JMSRuntimeException if this method has been called in a Java EE web or EJB application 
-      *                         (though it is not guaranteed that an exception is thrown in this case)
-      *                           
+     * This method must not be used in a Java EE web or EJB application. Doing so may cause a {@code JMSRuntimeException} to
+     * be thrown though this is not guaranteed.
+     *
+     * @exception JMSRuntimeException if this method has been called in a Java EE web or EJB application (though it is not
+     * guaranteed that an exception is thrown in this case)
+     *
      * @see javax.jms.ServerSession
      */
-    public void run();
-    
-    /** Creates a {@code MessageProducer} to send messages to the specified 
-      * destination.
-      *
-      * <P>A client uses a {@code MessageProducer} object to send 
-      * messages to a destination. Since {@code Queue} and {@code Topic} 
-      * both inherit from {@code Destination}, they can be used in
-      * the destination parameter to create a {@code MessageProducer} object.
-      * 
-      * @param destination the {@code Destination} to send to, 
-      * or null if this is a producer which does not have a specified 
-      * destination.
-      *
-      * @exception JMSException if the session fails to create a MessageProducer
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid destination
-      * is specified.
-      *
-      * @since JMS 1.1 
-      * 
+    @Override
+    void run();
+
+    /**
+     * Creates a {@code MessageProducer} to send messages to the specified destination.
+     *
+     * <p>
+     * A client uses a {@code MessageProducer} object to send messages to a destination. Since {@code Queue} and
+     * {@code Topic} both inherit from {@code Destination}, they can be used in the destination parameter to create a
+     * {@code MessageProducer} object.
+     *
+     * @param destination the {@code Destination} to send to, or null if this is a producer which does not have a specified
+     * destination.
+     *
+     * @return A {@code MessageProducer} to send messages.
+     *
+     * @exception JMSException if the session fails to create a MessageProducer due to some internal error.
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     *
+     * @since JMS 1.1
      */
+    MessageProducer createProducer(Destination destination) throws JMSException;
 
-    MessageProducer
-    createProducer(Destination destination) throws JMSException;
-    
-    
-       /** Creates a {@code MessageConsumer} for the specified destination.
-      * Since {@code Queue} and {@code Topic} 
-      * both inherit from {@code Destination}, they can be used in
-      * the destination parameter to create a {@code MessageConsumer}.
-      *
-      * @param destination the {@code Destination} to access. 
-      *
-      * @exception JMSException if the session fails to create a consumer
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid destination 
-      *                         is specified.
-      *
-      * @since JMS 1.1 
-      */
+    /**
+     * Creates a {@code MessageConsumer} for the specified destination. Since {@code Queue} and {@code Topic} both inherit
+     * from {@code Destination}, they can be used in the destination parameter to create a {@code MessageConsumer}.
+     *
+     * @param destination the {@code Destination} to access.
+     *
+     * @return A {@code MessageConsumer} for the specified destination.
+     *
+     * @exception JMSException if the session fails to create a consumer due to some internal error.
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     *
+     * @since JMS 1.1
+     */
+    MessageConsumer createConsumer(Destination destination) throws JMSException;
 
-    MessageConsumer
-    createConsumer(Destination destination) throws JMSException;
+    /**
+     * Creates a {@code MessageConsumer} for the specified destination, using a message selector. Since {@code Queue} and
+     * {@code Topic} both inherit from {@code Destination}, they can be used in the destination parameter to create a
+     * {@code MessageConsumer}.
+     *
+     * <p>
+     * A client uses a {@code MessageConsumer} object to receive messages that have been sent to a destination.
+     *
+     * @param destination the {@code Destination} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     *
+     * @return A {@code MessageConsumer} for the specified destination.
+     *
+     * @exception JMSException if the session fails to create a MessageConsumer due to some internal error.
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     *
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     * @since JMS 1.1
+     */
+    MessageConsumer createConsumer(Destination destination, java.lang.String messageSelector) throws JMSException;
 
-       /** Creates a {@code MessageConsumer} for the specified destination, 
-      * using a message selector. 
-      * Since {@code Queue} and {@code Topic} 
-      * both inherit from {@code Destination}, they can be used in
-      * the destination parameter to create a {@code MessageConsumer}.
-      *
-      * <P>A client uses a {@code MessageConsumer} object to receive 
-      * messages that have been sent to a destination.
-      *  
-      *       
-      * @param destination the {@code Destination} to access
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered. A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer. 
-      * 
-      *  
-      * @exception JMSException if the session fails to create a MessageConsumer
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid destination
-       * is specified.
-     
-      * @exception InvalidSelectorException if the message selector is invalid.
-      *
-      * @since JMS 1.1 
-      * 
-      */
-    MessageConsumer     
-    createConsumer(Destination destination, java.lang.String messageSelector) 
-    throws JMSException;
-    
-    
-     /** Creates a {@code MessageConsumer} for the specified destination, specifying a
-      * message selector and the {@code noLocal} parameter.
-      *<P> Since {@code Queue} and {@code Topic} 
-      * both inherit from {@code Destination}, they can be used in
-      * the destination parameter to create a {@code MessageConsumer}.
-      * <P>A client uses a {@code MessageConsumer} object to receive 
-      * messages that have been published to a destination. 
-      *               
-      * <P>The {@code noLocal} argument is for use when the
-      * destination is a topic and the session's connection 
-      * is also being used to publish messages to that topic. 
-      * If {@code noLocal} is set to true then the 
-      * {@code MessageConsumer} will not receive messages published
-      * to the topic by its own connection. The default value of this 
-      * argument is false. If the destination is a queue
-      * then the effect of setting {@code noLocal}
-      * to true is not specified.
-      *
-      * @param destination the {@code Destination} to access 
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered. A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer.
-      * @param noLocal  - if true, and the destination is a topic,
-      *                   then the {@code MessageConsumer} will 
-      *                   not receive messages published to the topic
-      *                   by its own connection. 
-      * 
-      * @exception JMSException if the session fails to create a MessageConsumer
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid destination
-      * is specified.
-      *     
-      * @exception InvalidSelectorException if the message selector is invalid.
-      *
-      * @since JMS 1.1 
-      *
-      */
-    MessageConsumer     
-    createConsumer(Destination destination, java.lang.String messageSelector, 
-    boolean noLocal)   throws JMSException;
-    
-	/**
-	 * Creates a shared non-durable subscription with the specified name on the
-	 * specified topic (if one does not already exist) and creates a consumer on
-	 * that subscription. This method creates the non-durable subscription
-	 * without a message selector.
-	 * <p>
-	 * If a shared non-durable subscription already exists with the same name
-	 * and client identifier (if set), and the same topic and message selector 
-	 * value has been specified, then this method creates a
-	 * {@code MessageConsumer} on the existing subscription.
-	 * <p>
-	 * A non-durable shared subscription is used by a client which needs to be
-	 * able to share the work of receiving messages from a topic subscription
-	 * amongst multiple consumers. A non-durable shared subscription may
-	 * therefore have more than one consumer. Each message from the subscription
-	 * will be delivered to only one of the consumers on that subscription. Such
-	 * a subscription is not persisted and will be deleted (together with any
-	 * undelivered messages associated with it) when there are no consumers on
-	 * it. The term "consumer" here means a {@code MessageConsumer} or
-	 * {@code  JMSConsumer} object in any client.
-	 * <p>
-	 * A shared non-durable subscription is identified by a name specified by
-	 * the client and by the client identifier (which may be unset). An
-	 * application which subsequently wishes to create a consumer on that shared
-	 * non-durable subscription must use the same client identifier.
-	 * <p>
-	 * If a shared non-durable subscription already exists with the same name
-	 * and client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the subscription, then a {@code JMSException}
-	 * will be thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * 
-	 * @param topic
-	 *            the {@code Topic} to subscribe to
-	 * @param sharedSubscriptionName
-	 *            the name used to identify the shared non-durable subscription
-	 * 
-	 * @throws JMSException
-	 *             if the session fails to create the shared non-durable
-	 *             subscription and {@code MessageConsumer} due to some internal
-	 *             error.
-	 * @throws InvalidDestinationException
-	 *             if an invalid topic is specified.
-	 * @throws InvalidSelectorException
-	 *             if the message selector is invalid.
-	 * 
-	 * @since JMS 2.0
-	 */
-	MessageConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName) throws JMSException;
+    /**
+     * Creates a {@code MessageConsumer} for the specified destination, specifying a message selector and the
+     * {@code noLocal} parameter.
+     *
+     * <p>
+     * Since {@code Queue} and {@code Topic} both inherit from {@code Destination}, they can be used in the destination
+     * parameter to create a {@code MessageConsumer}.
+     *
+     * <p>
+     * A client uses a {@code MessageConsumer} object to receive messages that have been published to a destination.
+     *
+     * <p>
+     * The {@code noLocal} argument is for use when the destination is a topic and the session's connection is also being
+     * used to publish messages to that topic. If {@code noLocal} is set to true then the {@code MessageConsumer} will not
+     * receive messages published to the topic by its own connection. The default value of this argument is false. If the
+     * destination is a queue then the effect of setting {@code noLocal} to true is not specified.
+     *
+     * @param destination the {@code Destination} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param noLocal - if true, and the destination is a topic, then the {@code MessageConsumer} will not receive messages
+     * published to the topic by its own connection.
+     *
+     * @return A {@code MessageConsumer} for the specified destination.
+     *
+     * @exception JMSException if the session fails to create a MessageConsumer due to some internal error.
+     * @exception InvalidDestinationException if an invalid destination is specified.
+     *
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     * @since JMS 1.1
+     */
+    MessageConsumer createConsumer(Destination destination, java.lang.String messageSelector, boolean noLocal) throws JMSException;
 
-	/**
-	 * Creates a shared non-durable subscription with the specified name on the
-	 * specified topic (if one does not already exist) specifying a message selector,
-	 * and creates a consumer on that subscription. 
-	 * <p>
-	 * If a shared non-durable subscription already exists with the same name
-	 * and client identifier (if set), and the same topic and message selector 
-	 * has been specified, then this method creates a
-	 * {@code MessageConsumer} on the existing subscription.
-	 * <p>
-	 * A non-durable shared subscription is used by a client which needs to be
-	 * able to share the work of receiving messages from a topic subscription
-	 * amongst multiple consumers. A non-durable shared subscription may
-	 * therefore have more than one consumer. Each message from the subscription
-	 * will be delivered to only one of the consumers on that subscription. Such
-	 * a subscription is not persisted and will be deleted (together with any
-	 * undelivered messages associated with it) when there are no consumers on
-	 * it. The term "consumer" here means a {@code MessageConsumer} or
-	 * {@code  JMSConsumer} object in any client.
-	 * <p>
-	 * A shared non-durable subscription is identified by a name specified by
-	 * the client and by the client identifier (which may be unset). An
-	 * application which subsequently wishes to create a consumer on that shared
-	 * non-durable subscription must use the same client identifier.
-	 * <p>
-	 * If a shared non-durable subscription already exists with the same name
-	 * and client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the subscription, then a {@code JMSException}
-	 * will be thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * 
-	 * @param topic
-	 *            the {@code Topic} to subscribe to
-	 * @param sharedSubscriptionName
-	 *            the name used to identify the shared non-durable subscription
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are added to the shared non-durable subscription. A
-	 *            value of null or an empty string indicates that there is no
-	 *            message selector for the shared non-durable subscription.
-	 * 
-	 * @throws JMSException
-	 *             if the session fails to create the shared non-durable
-	 *             subscription and {@code MessageConsumer} due to some
-	 *             internal error.
-	 * @throws InvalidDestinationException
-	 *             if an invalid topic is specified.
-	 * @throws InvalidSelectorException
-	 *             if the message selector is invalid.
-	 * 
-	 * @since JMS 2.0
-	 */ 
-	MessageConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName, java.lang.String messageSelector)
-			throws JMSException;
-    
-	/**
-	 * Creates a {@code Queue} object which encapsulates a specified
-	 * provider-specific queue name.
-	 * <p>
-	 * The use of provider-specific queue names in an application may render the
-	 * application non-portable. Portable applications are recommended to not
-	 * use this method but instead look up an administratively-defined
-	 * {@code Queue} object using JNDI.
-	 * <p>
-	 * Note that this method simply creates an object that encapsulates the name
-	 * of a queue. It does not create the physical queue in the JMS provider.
-	 * JMS does not provide a method to create the physical queue, since this
-	 * would be specific to a given JMS provider. Creating a physical queue is
-	 * provider-specific and is typically an administrative task performed by an 
-	 * administrator, though some providers may create them automatically when
-	 * needed. The one exception to this is the creation of a temporary queue,
-	 * which is done using the {@code createTemporaryQueue} method.
-	 * 
-	 * @param queueName
-	 *            A provider-specific queue name
-	 * @return a Queue object which encapsulates the specified name
-	 * 
-	 * @throws JMSException
-	 *             if a Queue object cannot be created due to some internal error 
-	 */
-	Queue createQueue(String queueName) throws JMSException;
-
-	/**
-	 * Creates a {@code Topic} object which encapsulates a specified
-	 * provider-specific topic name.
-	 * <p>
-	 * The use of provider-specific topic names in an application may render the
-	 * application non-portable. Portable applications are recommended to not
-	 * use this method but instead look up an administratively-defined
-	 * {@code Topic} object using JNDI.
-	 * <p>
-	 * Note that this method simply creates an object that encapsulates the name
-	 * of a topic. It does not create the physical topic in the JMS provider.
-	 * JMS does not provide a method to create the physical topic, since this
-	 * would be specific to a given JMS provider. Creating a physical topic is
-	 * provider-specific and is typically an administrative task performed by an
-	 * administrator, though some providers may create them automatically when
-	 * needed. The one exception to this is the creation of a temporary topic,
-	 * which is done using the {@code createTemporaryTopic} method.
-	 * 
-	 * @param topicName
-	 *            A provider-specific topic name
-	 * @return a Topic object which encapsulates the specified name
-	 * 
-	 * @throws JMSException
-	 *             if a Topic object cannot be created due to some internal
-	 *             error
-	 */
-	Topic createTopic(String topicName) throws JMSException;
-    
-	/**
-	 * Creates an unshared durable subscription on the specified topic (if one
-	 * does not already exist) and creates a consumer on that durable
-	 * subscription. This method creates the durable subscription without a
-	 * message selector and with a {@code noLocal} value of {@code false}.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with unshared durable subscriptions. Any
-	 * durable subscription created using this method will be unshared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by the
-	 * client and by the client identifier, which must be set. An application
-	 * which subsequently wishes to create a consumer on that unshared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and the same topic, message selector and
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then
-	 * this method creates a {@code TopicSubscriber} on the existing durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, then a {@code JMSException} will be
-	 * thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier but a different topic, message selector or
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId. Such subscriptions would
-	 * be completely separate.
-	 * <p>
-	 * This method is identical to the corresponding
-	 * {@code createDurableConsumer} method except that it returns a
-	 * {@code TopicSubscriber} rather than a {@code MessageConsumer} to
-	 * represent the consumer.
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @exception InvalidDestinationException
-	 *                if an invalid topic is specified.
-	 * @exception IllegalStateException
-	 *                if the client identifier is unset 
-	 * @exception JMSException
-	 *                <ul>
-	 *                <li>if the session fails to create the unshared durable
-	 *                subscription and {@code TopicSubscriber} due to some
-	 *                internal error 
-	 *                <li>
-	 *                if an unshared durable subscription already exists with
-	 *                the same name and client identifier, and there is a
-	 *                consumer already active 
-	 *                <li>if a shared durable subscription already exists 
-	 *                with the same name and client identifier
-	 *                </ul>
-	 *
- 	 * @since JMS 1.1
-	 */
-    TopicSubscriber createDurableSubscriber(Topic topic, 
-			    String name) throws JMSException;
-
-	/**
-	 * Creates an unshared durable subscription on the specified topic (if one
-	 * does not already exist), specifying a message selector and the
-	 * {@code noLocal} parameter, and creates a consumer on that durable
-	 * subscription.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with unshared durable subscriptions. Any
-	 * durable subscription created using this method will be unshared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by the
-	 * client and by the client identifier, which must be set. An application
-	 * which subsequently wishes to create a consumer on that unshared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and the same topic, message selector and
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then
-	 * this method creates a {@code TopicSubscriber} on the existing durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, then a {@code JMSException} will be
-	 * thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier but a different topic, message selector or
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * If {@code noLocal} is set to true then any messages published to the topic
-	 * using this session's connection, or any other connection with the same client
-	 * identifier, will not be added to the durable subscription. 
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId. Such subscriptions would
-	 * be completely separate.
-	 * <p>
-	 * This method is identical to the corresponding
-	 * {@code createDurableConsumer} method except that it returns a
-	 * {@code TopicSubscriber} rather than a {@code MessageConsumer} to
-	 * represent the consumer.
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are added to the durable subscription. A value of
-	 *            null or an empty string indicates that there is no message
-	 *            selector for the durable subscription.
-	 * @param noLocal
-	 *            if true then any messages published to the topic using this
-	 *            session's connection, or any other connection with the same
-	 *            client identifier, will not be added to the durable
-	 *            subscription.
-	 * @exception InvalidDestinationException
-	 *                if an invalid topic is specified.
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * @exception IllegalStateException
-	 *                if the client identifier is unset 
-	 * @exception JMSException
-	 *                <ul>
-	 *                <li>if the session fails to create the unshared durable
-	 *                subscription and {@code TopicSubscriber} due to some
-	 *                internal error 
-	 *                <li>
-	 *                if an unshared durable subscription already exists with
-	 *                the same name and client identifier, and there is a
-	 *                consumer already active 
-	 *                <li>if a shared durable
-	 *                subscription already exists with the same name and client
-	 *                identifier
-	 *                </ul>
-	 *
- 	 * @since JMS 1.1
-	 */
-	TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal)
-			throws JMSException;
-     
-	/**
-	 * Creates an unshared durable subscription on the specified topic (if one
-	 * does not already exist) and creates a consumer on that durable
-	 * subscription. This method creates the durable subscription without a
-	 * message selector and with a {@code noLocal} value of {@code false}.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with unshared durable subscriptions. Any
-	 * durable subscription created using this method will be unshared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by the
-	 * client and by the client identifier, which must be set. An application
-	 * which subsequently wishes to create a consumer on that unshared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and the same topic, message selector and
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then
-	 * this method creates a {@code MessageConsumer} on the existing durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, then a {@code JMSException} will be
-	 * thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier but a different topic, message selector or
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId. Such subscriptions would
-	 * be completely separate.
-	 * <p>
-	 * This method is identical to the corresponding
-	 * {@code createDurableSubscriber} method except that it returns a
-	 * {@code MessageConsumer} rather than a {@code TopicSubscriber} to
-	 * represent the consumer.
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @exception InvalidDestinationException
-	 *                if an invalid topic is specified.
-	 * @exception IllegalStateException
-	 *                if the client identifier is unset 
-	 * @exception JMSException
-	 *                <ul>
-	 *                <li>if the session fails to create the unshared durable
-	 *                subscription and {@code MessageConsumer} due to some
-	 *                internal error 
-	 *                <li>
-	 *                if an unshared durable subscription already exists with
-	 *                the same name and client identifier, and there is a
-	 *                consumer already active 
-	 *                <li>if a shared durable
-	 *                subscription already exists with the same name and client
-	 *                identifier
-	 *                </ul>
-	 * 
-	 * @since JMS 2.0
-	 */
-	MessageConsumer createDurableConsumer(Topic topic, String name) throws JMSException;
-
- 	/**
- 	 * Creates an unshared durable subscription on the specified topic (if one
- 	 * does not already exist), specifying a message selector and the
- 	 * {@code noLocal} parameter, and creates a consumer on that durable
- 	 * subscription.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with unshared durable subscriptions. Any
-	 * durable subscription created using this method will be unshared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by the
-	 * client and by the client identifier, which must be set. An application
-	 * which subsequently wishes to create a consumer on that unshared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and the same topic, message selector and
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then
-	 * this method creates a {@code MessageConsumer} on the existing durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, then a {@code JMSException} will be
-	 * thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name and
-	 * client identifier but a different topic, message selector or
-	 * {@code noLocal} value has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * If {@code noLocal} is set to true then any messages published to the topic
-	 * using this session's connection, or any other connection with the same client
-	 * identifier, will not be added to the durable subscription. 
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId. Such subscriptions would
-	 * be completely separate.
-	 * <p>
-	 * This method is identical to the corresponding
-	 * {@code createDurableSubscriber} method except that it returns a
-	 * {@code MessageConsumer} rather than a {@code TopicSubscriber} to
-	 * represent the consumer.
- 	 * 
- 	 * @param topic
- 	 *            the non-temporary {@code Topic} to subscribe to
- 	 * @param name
- 	 *            the name used to identify this subscription
- 	 * @param messageSelector
- 	 *            only messages with properties matching the message selector
- 	 *            expression are added to the durable subscription. A value of
- 	 *            null or an empty string indicates that there is no message
- 	 *            selector for the durable subscription.
- 	 * @param noLocal
- 	 *            if true then any messages published to the topic using this
- 	 *            session's connection, or any other connection with the same
- 	 *            client identifier, will not be added to the durable
- 	 *            subscription.
- 	 * @exception InvalidDestinationException
- 	 *                if an invalid topic is specified.
- 	 * @exception InvalidSelectorException
- 	 *                if the message selector is invalid.
-	 * @exception IllegalStateException
-	 *                if the client identifier is unset 
- 	 * @exception JMSException
- 	 *                <ul>
- 	 *                <li>if the session fails to create the unshared durable
- 	 *                subscription and {@code MessageConsumer} due to some
- 	 *                internal error 
- 	 *                <li>
- 	 *                if an unshared durable subscription already exists with
- 	 *                the same name and client identifier, and there is a
- 	 *                consumer already active 
- 	 *                <li>if a shared durable
- 	 *                subscription already exists with the same name and client
- 	 *                identifier
- 	 *                </ul>
- 	 * 
-	 * @since JMS 2.0
-	 */ 
-      MessageConsumer createDurableConsumer(Topic topic, String name, String messageSelector, boolean noLocal) throws JMSException;     
-      
-	/**
-	 * Creates a shared durable subscription on the specified topic (if one does
-	 * not already exist), specifying a message selector and the {@code noLocal}
-	 * parameter, and creates a consumer on that durable subscription. This
-	 * method creates the durable subscription without a message selector.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with shared durable subscriptions. Any
-	 * durable subscription created using this method will be shared. This means
-	 * that multiple active (i.e. not closed) consumers on the subscription may
-	 * exist at the same time. The term "consumer" here means a
-	 * {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
-	 * <p>
-	 * A shared durable subscription is identified by a name specified by the
-	 * client and by the client identifier (which may be unset). An application
-	 * which subsequently wishes to create a consumer on that shared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set), and the same topic and message selector 
-	 * has been specified, then this method creates a
-	 * {@code MessageConsumer} on the existing shared durable subscription.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the durable subscription, then a
-	 * {@code JMSException} will be thrown.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier (if set). If an unshared
-	 * durable subscription already exists with the same name and client
-	 * identifier (if set) then a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * <p>
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @exception JMSException
-	 *                <ul>
-	 *                <li>if the session fails to create the shared durable
-	 *                subscription and {@code MessageConsumer} due to some
-	 *                internal error 
-	 *                <li> if a shared durable subscription
-	 *                already exists with the same name and client identifier,
-	 *                but a different topic or message selector, 
-	 *                and there is a consumer already active 
-	 *                <li>if an
-	 *                unshared durable subscription already exists with the same
-	 *                name and client identifier
-	 *                </ul>
-	 * @exception InvalidDestinationException
-	 *                if an invalid topic is specified.
-	 * 
-	 * @since JMS 2.0
-	 */
-	MessageConsumer createSharedDurableConsumer(Topic topic, String name) throws JMSException;
-
-   	/**
-   	 * Creates a shared durable subscription on the specified topic (if one
-   	 * does not already exist), specifying a message selector,
-   	 * and creates a consumer on that durable subscription.
-   	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with shared durable subscriptions. Any
-	 * durable subscription created using this method will be shared. This means
-	 * that multiple active (i.e. not closed) consumers on the subscription may
-	 * exist at the same time. The term "consumer" here means a
-	 * {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
-	 * <p>
-	 * A shared durable subscription is identified by a name specified by the
-	 * client and by the client identifier (which may be unset). An application
-	 * which subsequently wishes to create a consumer on that shared durable
-	 * subscription must use the same client identifier.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set), and the same topic and message selector 
-	 * has been specified, then this method creates a
-	 * {@code MessageConsumer} on the existing shared durable subscription.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is no consumer
-	 * already active (i.e. not closed) on the durable subscription then this is
-	 * equivalent to unsubscribing (deleting) the old one and creating a new
-	 * one.
-	 * <p>
-	 * If a shared durable subscription already exists with the same name and
-	 * client identifier (if set) but a different topic or message selector 
-	 * has been specified, and there is a consumer already
-	 * active (i.e. not closed) on the durable subscription, then a
-	 * {@code JMSException} will be thrown.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier (if set). If an unshared
-	 * durable subscription already exists with the same name and client
-	 * identifier (if set) then a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable
-	 * subscriptions having the same name and clientId (which may be unset).
-	 * Such subscriptions would be completely separate.
-	 * <p>
-   	 * 
-   	 * @param topic
-   	 *            the non-temporary {@code Topic} to subscribe to
-   	 * @param name
-   	 *            the name used to identify this subscription
-   	 * @param messageSelector
-   	 *            only messages with properties matching the message selector
-   	 *            expression are added to the durable subscription. A value of
-   	 *            null or an empty string indicates that there is no message
-   	 *            selector for the durable subscription.
-   	 * @exception JMSException
-   	 *                <ul>
-   	 *                <li>if the session fails to create the shared durable
-   	 *                subscription and {@code MessageConsumer} due to some
-   	 *                internal error 
-   	 *                <li>
-   	 *                if a shared durable subscription already exists with
-   	 *                the same name and client identifier, but a different topic
-   	 *                or message selector,
-   	 *                and there is a consumer already active 
-   	 *                <li>if an unshared durable
-   	 *                subscription already exists with the same name and client
-   	 *                identifier
-   	 *                </ul>
-   	 * @exception InvalidDestinationException
-   	 *                if an invalid topic is specified.
-   	 * @exception InvalidSelectorException
-   	 *                if the message selector is invalid.
-   	 *
+    /**
+     * Creates a shared non-durable subscription with the specified name on the specified topic (if one does not already
+     * exist) and creates a consumer on that subscription. This method creates the non-durable subscription without a
+     * message selector.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set), and the same
+     * topic and message selector value has been specified, then this method creates a {@code MessageConsumer} on the
+     * existing subscription.
+     *
+     * <p>
+     * A non-durable shared subscription is used by a client which needs to be able to share the work of receiving messages
+     * from a topic subscription amongst multiple consumers. A non-durable shared subscription may therefore have more than
+     * one consumer. Each message from the subscription will be delivered to only one of the consumers on that subscription.
+     * Such a subscription is not persisted and will be deleted (together with any undelivered messages associated with it)
+     * when there are no consumers on it. The term "consumer" here means a {@code MessageConsumer} or {@code  JMSConsumer}
+     * object in any client.
+     *
+     * <p>
+     * A shared non-durable subscription is identified by a name specified by the client and by the client identifier (which
+     * may be unset). An application which subsequently wishes to create a consumer on that shared non-durable subscription
+     * must use the same client identifier.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the
+     * subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the {@code Topic} to subscribe to
+     * @param sharedSubscriptionName the name used to identify the shared non-durable subscription
+     *
+     * @return A shared non-durable subscription with the specified name on the specified topic.
+     *
+     * @throws JMSException if the session fails to create the shared non-durable subscription and {@code MessageConsumer}
+     * due to some internal error.
+     * @throws InvalidDestinationException if an invalid topic is specified.
+     * @throws InvalidSelectorException if the message selector is invalid.
+     *
      * @since JMS 2.0
-   	 */
-        MessageConsumer createSharedDurableConsumer(Topic topic, String name, String messageSelector) throws JMSException;           
-    
-  /** Creates a {@code QueueBrowser} object to peek at the messages on 
-      * the specified queue.
-      *  
-      * @param queue the {@code queue} to access
-      *
-      *  
-      * @exception JMSException if the session fails to create a browser
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid destination
-      *                         is specified 
-      *
-      * @since JMS 1.1 
-      */ 
-    QueueBrowser 
-    createBrowser(Queue queue) throws JMSException;
+     */
+    MessageConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName) throws JMSException;
 
+    /**
+     * Creates a shared non-durable subscription with the specified name on the specified topic (if one does not already
+     * exist) specifying a message selector, and creates a consumer on that subscription.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set), and the same
+     * topic and message selector has been specified, then this method creates a {@code MessageConsumer} on the existing
+     * subscription.
+     *
+     * <p>
+     * A non-durable shared subscription is used by a client which needs to be able to share the work of receiving messages
+     * from a topic subscription amongst multiple consumers. A non-durable shared subscription may therefore have more than
+     * one consumer. Each message from the subscription will be delivered to only one of the consumers on that subscription.
+     * Such a subscription is not persisted and will be deleted (together with any undelivered messages associated with it)
+     * when there are no consumers on it. The term "consumer" here means a {@code MessageConsumer} or {@code  JMSConsumer}
+     * object in any client.
+     *
+     * <p>
+     * A shared non-durable subscription is identified by a name specified by the client and by the client identifier (which
+     * may be unset). An application which subsequently wishes to create a consumer on that shared non-durable subscription
+     * must use the same client identifier.
+     *
+     * <p>
+     * If a shared non-durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the
+     * subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the {@code Topic} to subscribe to
+     * @param sharedSubscriptionName the name used to identify the shared non-durable subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the shared
+     * non-durable subscription. A value of null or an empty string indicates that there is no message selector for the
+     * shared non-durable subscription.
+     *
+     * @return A shared non-durable subscription with the specified name on the specified topic.
+     *
+     * @throws JMSException if the session fails to create the shared non-durable subscription and {@code MessageConsumer}
+     * due to some internal error.
+     * @throws InvalidDestinationException if an invalid topic is specified.
+     * @throws InvalidSelectorException if the message selector is invalid.
+     *
+     * @since JMS 2.0
+     */
+    MessageConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName, java.lang.String messageSelector) throws JMSException;
 
-	/**
-	 * Creates a {@code QueueBrowser} object to peek at the messages on the
-	 * specified queue using a message selector.
-	 * 
-	 * @param queue
-	 *            the {@code queue} to access
-	 * 
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are delivered. A value of null or an empty string
-	 *            indicates that there is no message selector for the message
-	 *            consumer.
-	 * 
-	 * @exception JMSException
-	 *                if the session fails to create a browser due to some
-	 *                internal error.
-	 * @exception InvalidDestinationException
-	 *                if an invalid destination is specified
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * 
-	 * @since JMS 1.1
-	 * 
-	 */
-	QueueBrowser createBrowser(Queue queue, String messageSelector)
-			throws JMSException;
+    /**
+     * Creates a {@code Queue} object which encapsulates a specified provider-specific queue name.
+     *
+     * <p>
+     * The use of provider-specific queue names in an application may render the application non-portable. Portable
+     * applications are recommended to not use this method but instead look up an administratively-defined {@code Queue}
+     * object using JNDI.
+     *
+     * <p>
+     * Note that this method simply creates an object that encapsulates the name of a queue. It does not create the physical
+     * queue in the JMS provider. JMS does not provide a method to create the physical queue, since this would be specific
+     * to a given JMS provider. Creating a physical queue is provider-specific and is typically an administrative task
+     * performed by an administrator, though some providers may create them automatically when needed. The one exception to
+     * this is the creation of a temporary queue, which is done using the {@code createTemporaryQueue} method.
+     *
+     * @param queueName A provider-specific queue name
+     *
+     * @return a Queue object which encapsulates the specified name
+     *
+     * @throws JMSException if a Queue object cannot be created due to some internal error
+     */
+    Queue createQueue(String queueName) throws JMSException;
 
-    
-     /** Creates a {@code TemporaryQueue} object. Its lifetime will be that 
-      * of the {@code Connection} unless it is deleted earlier.
-      *
-      * @return a temporary queue identity
-      *
-      * @exception JMSException if the session fails to create a temporary queue
-      *                         due to some internal error.
-      *
-      * @since JMS 1.1
-      */
+    /**
+     * Creates a {@code Topic} object which encapsulates a specified provider-specific topic name.
+     *
+     * <p>
+     * The use of provider-specific topic names in an application may render the application non-portable. Portable
+     * applications are recommended to not use this method but instead look up an administratively-defined {@code Topic}
+     * object using JNDI.
+     *
+     * <p>
+     * Note that this method simply creates an object that encapsulates the name of a topic. It does not create the physical
+     * topic in the JMS provider. JMS does not provide a method to create the physical topic, since this would be specific
+     * to a given JMS provider. Creating a physical topic is provider-specific and is typically an administrative task
+     * performed by an administrator, though some providers may create them automatically when needed. The one exception to
+     * this is the creation of a temporary topic, which is done using the {@code createTemporaryTopic} method.
+     *
+     * @param topicName A provider-specific topic name
+     *
+     * @return a Topic object which encapsulates the specified name
+     *
+     * @throws JMSException if a Topic object cannot be created due to some internal error
+     */
+    Topic createTopic(String topicName) throws JMSException;
 
-    TemporaryQueue
-    createTemporaryQueue() throws JMSException;
-   
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist) and creates a
+     * consumer on that durable subscription. This method creates the durable subscription without a message selector and
+     * with a {@code noLocal} value of {@code false}.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with unshared durable subscriptions. Any durable subscription created using this method
+     * will be unshared. This means that only one active (i.e. not closed) consumer on the subscription may exist at a time.
+     * The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer} object in
+     * any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that unshared durable subscription must
+     * use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and the same topic,
+     * message selector and {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this method creates a {@code TopicSubscriber} on the existing durable
+     * subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a
+     * new one.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a {@code JMSException}
+     * is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableConsumer} method except that it returns a
+     * {@code TopicSubscriber} rather than a {@code MessageConsumer} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     *
+     * @return An unshared durable subscription on the specified topic.
+     *
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception IllegalStateException if the client identifier is unset
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the unshared durable subscription and {@code TopicSubscriber} due to some internal
+     * error
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 1.1
+     */
+    TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException;
 
-     /** Creates a {@code TemporaryTopic} object. Its lifetime will be that 
-      * of the {@code Connection} unless it is deleted earlier.
-      *
-      * @return a temporary topic identity
-      *
-      * @exception JMSException if the session fails to create a temporary
-      *                         topic due to some internal error.
-      *
-      * @since JMS 1.1  
-      */
- 
-    TemporaryTopic
-    createTemporaryTopic() throws JMSException;
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector and the {@code noLocal} parameter, and creates a consumer on that durable subscription.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with unshared durable subscriptions. Any durable subscription created using this method
+     * will be unshared. This means that only one active (i.e. not closed) consumer on the subscription may exist at a time.
+     * The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer} object in
+     * any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that unshared durable subscription must
+     * use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and the same topic,
+     * message selector and {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this method creates a {@code TopicSubscriber} on the existing durable
+     * subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a
+     * new one.
+     *
+     * <p>
+     * If {@code noLocal} is set to true then any messages published to the topic using this session's connection, or any
+     * other connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a {@code JMSException}
+     * is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableConsumer} method except that it returns a
+     * {@code TopicSubscriber} rather than a {@code MessageConsumer} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the
+     * durable subscription. A value of null or an empty string indicates that there is no message selector for the durable
+     * subscription.
+     * @param noLocal if true then any messages published to the topic using this session's connection, or any other
+     * connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * @return An unshared durable subscription on the specified topic.
+     *
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception IllegalStateException if the client identifier is unset
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the unshared durable subscription and {@code TopicSubscriber} due to some internal
+     * error
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 1.1
+     */
+    TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal) throws JMSException;
 
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist) and creates a
+     * consumer on that durable subscription. This method creates the durable subscription without a message selector and
+     * with a {@code noLocal} value of {@code false}.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with unshared durable subscriptions. Any durable subscription created using this method
+     * will be unshared. This means that only one active (i.e. not closed) consumer on the subscription may exist at a time.
+     * The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer} object in
+     * any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that unshared durable subscription must
+     * use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and the same topic,
+     * message selector and {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this method creates a {@code MessageConsumer} on the existing durable
+     * subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a
+     * new one.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a {@code JMSException}
+     * is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableSubscriber} method except that it returns a
+     * {@code MessageConsumer} rather than a {@code TopicSubscriber} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     *
+     * @return An unshared durable subscription on the specified topic.
+     *
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception IllegalStateException if the client identifier is unset
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the unshared durable subscription and {@code MessageConsumer} due to some internal
+     * error
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 2.0
+     */
+    MessageConsumer createDurableConsumer(Topic topic, String name) throws JMSException;
 
-    /** Unsubscribes a durable subscription that has been created by a client.
-      *  
-      * <P>This method deletes the state being maintained on behalf of the 
-      * subscriber by its provider.
-      * <p> 
-      * A durable subscription is identified by a name specified by the client
-      * and by the client identifier if set. If the client identifier was set
-      * when the durable subscription was created then a client which 
-      * subsequently wishes to use this method to
-      * delete a durable subscription must use the same client identifier.
-      *
-      * <P>It is erroneous for a client to delete a durable subscription
-      * while there is an active (not closed) consumer for the 
-      * subscription, or while a consumed message is part of a pending 
-      * transaction or has not been acknowledged in the session.
-      *
-      * @param name the name used to identify this subscription
-      *  
-      * @exception JMSException if the session fails to unsubscribe to the 
-      *                         durable subscription due to some internal error.
-      * @exception InvalidDestinationException if an invalid subscription name
-      *                                        is specified.
-      *
-      * @since JMS 1.1
-      */
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector and the {@code noLocal} parameter, and creates a consumer on that durable subscription.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with unshared durable subscriptions. Any durable subscription created using this method
+     * will be unshared. This means that only one active (i.e. not closed) consumer on the subscription may exist at a time.
+     * The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer} object in
+     * any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that unshared durable subscription must
+     * use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and the same topic,
+     * message selector and {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this method creates a {@code MessageConsumer} on the existing durable
+     * subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a
+     * new one.
+     *
+     * <p>
+     * If {@code noLocal} is set to true then any messages published to the topic using this session's connection, or any
+     * other connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a {@code JMSException}
+     * is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableSubscriber} method except that it returns a
+     * {@code MessageConsumer} rather than a {@code TopicSubscriber} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the
+     * durable subscription. A value of null or an empty string indicates that there is no message selector for the durable
+     * subscription.
+     * @param noLocal if true then any messages published to the topic using this session's connection, or any other
+     * connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * @return An unshared durable subscription on the specified topic.
+     *
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception IllegalStateException if the client identifier is unset
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the unshared durable subscription and {@code MessageConsumer} due to some internal
+     * error
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     *
+     * @since JMS 2.0
+     */
+    MessageConsumer createDurableConsumer(Topic topic, String name, String messageSelector, boolean noLocal) throws JMSException;
 
-    void
-    unsubscribe(String name) throws JMSException;
-   
+    /**
+     * Creates a shared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector and the {@code noLocal} parameter, and creates a consumer on that durable subscription. This method creates
+     * the durable subscription without a message selector.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with shared durable subscriptions. Any durable subscription created using this method
+     * will be shared. This means that multiple active (i.e. not closed) consumers on the subscription may exist at the same
+     * time. The term "consumer" here means a {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
+     *
+     * <p>
+     * A shared durable subscription is identified by a name specified by the client and by the client identifier (which may
+     * be unset). An application which subsequently wishes to create a consumer on that shared durable subscription must use
+     * the same client identifier.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set), and the same topic
+     * and message selector has been specified, then this method creates a {@code MessageConsumer} on the existing shared
+     * durable subscription.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is no consumer already active (i.e. not closed) on the
+     * durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a new one.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the durable
+     * subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier
+     * (if set). If an unshared durable subscription already exists with the same name and client identifier (if set) then a
+     * {@code JMSException} is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     *
+     * @return A shared durable subscription on the specified topic.
+     *
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the shared durable subscription and {@code MessageConsumer} due to some internal
+     * error
+     * <li>if a shared durable subscription already exists with the same name and client identifier, but a different topic
+     * or message selector, and there is a consumer already active
+     * <li>if an unshared durable subscription already exists with the same name and client identifier
+     * </ul>
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     *
+     * @since JMS 2.0
+     */
+    MessageConsumer createSharedDurableConsumer(Topic topic, String name) throws JMSException;
+
+    /**
+     * Creates a shared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector, and creates a consumer on that durable subscription.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with shared durable subscriptions. Any durable subscription created using this method
+     * will be shared. This means that multiple active (i.e. not closed) consumers on the subscription may exist at the same
+     * time. The term "consumer" here means a {@code  MessageConsumer} or {@code JMSConsumer} object in any client.
+     *
+     * <p>
+     * A shared durable subscription is identified by a name specified by the client and by the client identifier (which may
+     * be unset). An application which subsequently wishes to create a consumer on that shared durable subscription must use
+     * the same client identifier.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set), and the same topic
+     * and message selector has been specified, then this method creates a {@code MessageConsumer} on the existing shared
+     * durable subscription.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is no consumer already active (i.e. not closed) on the
+     * durable subscription then this is equivalent to unsubscribing (deleting) the old one and creating a new one.
+     *
+     * <p>
+     * If a shared durable subscription already exists with the same name and client identifier (if set) but a different
+     * topic or message selector has been specified, and there is a consumer already active (i.e. not closed) on the durable
+     * subscription, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier
+     * (if set). If an unshared durable subscription already exists with the same name and client identifier (if set) then a
+     * {@code JMSException} is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId (which may be unset). Such subscriptions would be completely separate.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the
+     * durable subscription. A value of null or an empty string indicates that there is no message selector for the durable
+     * subscription.
+     *
+     * @return A shared durable subscription on the specified topic.
+     *
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the shared durable subscription and {@code MessageConsumer} due to some internal
+     * error
+     * <li>if a shared durable subscription already exists with the same name and client identifier, but a different topic
+     * or message selector, and there is a consumer already active
+     * <li>if an unshared durable subscription already exists with the same name and client identifier
+     * </ul>
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     * @since JMS 2.0
+     */
+    MessageConsumer createSharedDurableConsumer(Topic topic, String name, String messageSelector) throws JMSException;
+
+    /**
+     * Creates a {@code QueueBrowser} object to peek at the messages on the specified queue.
+     *
+     * @param queue the {@code queue} to access
+     *
+     * @return A {@code QueueBrowser} object to peek at the messages on the specified queue.
+     *
+     * @exception JMSException if the session fails to create a browser due to some internal error.
+     * @exception InvalidDestinationException if an invalid destination is specified
+     *
+     * @since JMS 1.1
+     */
+    QueueBrowser createBrowser(Queue queue) throws JMSException;
+
+    /**
+     * Creates a {@code QueueBrowser} object to peek at the messages on the specified queue using a message selector.
+     *
+     * @param queue the {@code queue} to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     *
+     * @return A {@code QueueBrowser} object to peek at the messages on the specified queue.
+     *
+     * @exception JMSException if the session fails to create a browser due to some internal error.
+     * @exception InvalidDestinationException if an invalid destination is specified
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     * @since JMS 1.1
+     */
+    QueueBrowser createBrowser(Queue queue, String messageSelector) throws JMSException;
+
+    /**
+     * Creates a {@code TemporaryQueue} object. Its lifetime will be that of the {@code Connection} unless it is deleted
+     * earlier.
+     *
+     * @return a temporary queue identity
+     *
+     * @exception JMSException if the session fails to create a temporary queue due to some internal error.
+     *
+     * @since JMS 1.1
+     */
+    TemporaryQueue createTemporaryQueue() throws JMSException;
+
+    /**
+     * Creates a {@code TemporaryTopic} object. Its lifetime will be that of the {@code Connection} unless it is deleted
+     * earlier.
+     *
+     * @return a temporary topic identity
+     *
+     * @exception JMSException if the session fails to create a temporary topic due to some internal error.
+     *
+     * @since JMS 1.1
+     */
+    TemporaryTopic createTemporaryTopic() throws JMSException;
+
+    /**
+     * Unsubscribes a durable subscription that has been created by a client.
+     *
+     * <p>
+     * This method deletes the state being maintained on behalf of the subscriber by its provider.
+     *
+     * <p>
+     * A durable subscription is identified by a name specified by the client and by the client identifier if set. If the
+     * client identifier was set when the durable subscription was created then a client which subsequently wishes to use
+     * this method to delete a durable subscription must use the same client identifier.
+     *
+     * <p>
+     * It is erroneous for a client to delete a durable subscription while there is an active (not closed) consumer for the
+     * subscription, or while a consumed message is part of a pending transaction or has not been acknowledged in the
+     * session.
+     *
+     * @param name the name used to identify this subscription
+     *
+     * @exception JMSException if the session fails to unsubscribe to the durable subscription due to some internal error.
+     * @exception InvalidDestinationException if an invalid subscription name is specified.
+     *
+     * @since JMS 1.1
+     */
+    void unsubscribe(String name) throws JMSException;
+
 }

--- a/src/main/java/javax/jms/StreamMessage.java
+++ b/src/main/java/javax/jms/StreamMessage.java
@@ -16,527 +16,391 @@
 
 package javax.jms;
 
-/** A {@code StreamMessage} object is used to send a stream of primitive
-  * types in the Java programming language. It is filled and read sequentially.
-  * It inherits from the {@code Message} interface
-  * and adds a stream message body. Its methods are based largely on those
-  * found in {@code java.io.DataInputStream} and
-  * {@code java.io.DataOutputStream}.
-  *
-  * <P>The primitive types can be read or written explicitly using methods
-  * for each type. They may also be read or written generically as objects.
-  * For instance, a call to {@code StreamMessage.writeInt(6)} is
-  * equivalent to {@code StreamMessage.writeObject(new Integer(6))}.
-  * Both forms are provided, because the explicit form is convenient for
-  * static programming, and the object form is needed when types are not known
-  * at compile time.
-  *
-  * <P>When the message is first created, and when {@code clearBody}
-  * is called, the body of the message is in write-only mode. After the 
-  * first call to {@code reset} has been made, the message body is in 
-  * read-only mode. 
-  * After a message has been sent, the client that sent it can retain and 
-  * modify it without affecting the message that has been sent. The same message
-  * object can be sent multiple times.
-  * When a message has been received, the provider has called 
-  * {@code reset} so that the message body is in read-only mode for the client.
-  * 
-  * <P>If {@code clearBody} is called on a message in read-only mode, 
-  * the message body is cleared and the message body is in write-only mode.
-  * 
-  * <P>If a client attempts to read a message in write-only mode, a 
-  * {@code MessageNotReadableException} is thrown.
-  * 
-  * <P>If a client attempts to write a message in read-only mode, a 
-  * {@code MessageNotWriteableException} is thrown.
-  *
-  * <P>{@code StreamMessage} objects support the following conversion 
-  * table. The marked cases must be supported. The unmarked cases must throw a 
-  * {@code JMSException}. The {@code String}-to-primitive conversions 
-  * may throw a runtime exception if the primitive's {@code valueOf()} 
-  * method does not accept it as a valid {@code String} representation of 
-  * the primitive.
-  *
-  * <P>A value written as the row type can be read as the column type.
-  *
-  * <PRE>
-  * |        | boolean byte short char int long float double String byte[]
-  * |----------------------------------------------------------------------
-  * |boolean |    X                                            X
-  * |byte    |          X     X         X   X                  X   
-  * |short   |                X         X   X                  X   
-  * |char    |                     X                           X
-  * |int     |                          X   X                  X   
-  * |long    |                              X                  X   
-  * |float   |                                    X     X      X   
-  * |double  |                                          X      X   
-  * |String  |    X     X     X         X   X     X     X      X   
-  * |byte[]  |                                                        X
-  * |----------------------------------------------------------------------
-  * </PRE>
-  *
-  * <P>Attempting to read a null value as a primitive type must be treated
-  * as calling the primitive's corresponding {@code valueOf(String)} 
-  * conversion method with a null value. Since {@code char} does not 
-  * support a {@code String} conversion, attempting to read a null value 
-  * as a {@code char} must throw a {@code NullPointerException}.
-  *
-  * @see         javax.jms.Session#createStreamMessage()
-  * @see         javax.jms.BytesMessage
-  * @see         javax.jms.MapMessage
-  * @see         javax.jms.Message
-  * @see         javax.jms.ObjectMessage
-  * @see         javax.jms.TextMessage
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code StreamMessage} object is used to send a stream of primitive types in the Java programming language. It is
+ * filled and read sequentially. It inherits from the {@code Message} interface and adds a stream message body. Its
+ * methods are based largely on those found in {@code java.io.DataInputStream} and {@code java.io.DataOutputStream}.
+ *
+ * <p>
+ * The primitive types can be read or written explicitly using methods for each type. They may also be read or written
+ * generically as objects. For instance, a call to {@code StreamMessage.writeInt(6)} is equivalent to
+ * {@code StreamMessage.writeObject(new Integer(6))}. Both forms are provided, because the explicit form is convenient
+ * for static programming, and the object form is needed when types are not known at compile time.
+ *
+ * <p>
+ * When the message is first created, and when {@code clearBody} is called, the body of the message is in write-only
+ * mode. After the first call to {@code reset} has been made, the message body is in read-only mode. After a message has
+ * been sent, the client that sent it can retain and modify it without affecting the message that has been sent. The
+ * same message object can be sent multiple times. When a message has been received, the provider has called
+ * {@code reset} so that the message body is in read-only mode for the client.
+ *
+ * <p>
+ * If {@code clearBody} is called on a message in read-only mode, the message body is cleared and the message body is in
+ * write-only mode.
+ *
+ * <p>
+ * If a client attempts to read a message in write-only mode, a {@code MessageNotReadableException} is thrown.
+ *
+ * <p>
+ * If a client attempts to write a message in read-only mode, a {@code MessageNotWriteableException} is thrown.
+ *
+ * <p>
+ * {@code StreamMessage} objects support the following conversion table. The marked cases must be supported. The
+ * unmarked cases must throw a {@code JMSException}. The {@code String}-to-primitive conversions may throw a runtime
+ * exception if the primitive's {@code valueOf()} method does not accept it as a valid {@code String} representation of
+ * the primitive.
+ *
+ * <p>
+ * A value written as the row type can be read as the column type.
+ *
+ * <pre>
+ * |        | boolean byte short char int long float double String byte[]
+ * |----------------------------------------------------------------------
+ * |boolean |    X                                            X
+ * |byte    |          X     X         X   X                  X
+ * |short   |                X         X   X                  X
+ * |char    |                     X                           X
+ * |int     |                          X   X                  X
+ * |long    |                              X                  X
+ * |float   |                                    X     X      X
+ * |double  |                                          X      X
+ * |String  |    X     X     X         X   X     X     X      X
+ * |byte[]  |                                                        X
+ * |----------------------------------------------------------------------
+ * </pre>
+ *
+ * <p>
+ * Attempting to read a null value as a primitive type must be treated as calling the primitive's corresponding
+ * {@code valueOf(String)} conversion method with a null value. Since {@code char} does not support a {@code String}
+ * conversion, attempting to read a null value as a {@code char} must throw a {@code NullPointerException}.
+ *
+ * @see javax.jms.Session#createStreamMessage()
+ * @see javax.jms.BytesMessage
+ * @see javax.jms.MapMessage
+ * @see javax.jms.Message
+ * @see javax.jms.ObjectMessage
+ * @see javax.jms.TextMessage
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface StreamMessage extends Message {
 
-
-    /** Reads a {@code boolean} from the stream message.
-      *
-      * @return the {@code boolean} value read
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */
-
-    boolean 
-    readBoolean() throws JMSException;
-
-
-    /** Reads a {@code byte} value from the stream message.
-      *
-      * @return the next byte from the stream message as a 8-bit
-      * {@code byte}
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    byte 
-    readByte() throws JMSException;
-
-
-    /** Reads a 16-bit integer from the stream message.
-      *
-      * @return a 16-bit integer from the stream message
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    short 
-    readShort() throws JMSException;
-
-
-    /** Reads a Unicode character value from the stream message.
-      *
-      * @return a Unicode character from the stream message
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid      
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    char 
-    readChar() throws JMSException;
-
-
-    /** Reads a 32-bit integer from the stream message.
-      *
-      * @return a 32-bit integer value from the stream message, interpreted
-      * as an {@code int}
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    int 
-    readInt() throws JMSException;
-
-
-    /** Reads a 64-bit integer from the stream message.
-      *
-      * @return a 64-bit integer value from the stream message, interpreted as
-      * a {@code long}
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    long 
-    readLong() throws JMSException;
-
-
-    /** Reads a {@code float} from the stream message.
-      *
-      * @return a {@code float} value from the stream message
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    float 
-    readFloat() throws JMSException;
-
-
-    /** Reads a {@code double} from the stream message.
-      *
-      * @return a {@code double} value from the stream message
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    double 
-    readDouble() throws JMSException;
-
-
-    /** Reads a {@code String} from the stream message.
-      *
-      * @return a Unicode string from the stream message
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      */ 
-
-    String 
-    readString() throws JMSException;
-
-
-    /** Reads a byte array field from the stream message into the 
-      * specified {@code byte[]} object (the read buffer). 
-      * 
-      * <P>To read the field value, {@code readBytes} should be 
-      * successively called 
-      * until it returns a value less than the length of the read buffer.
-      * The value of the bytes in the buffer following the last byte 
-      * read is undefined.
-      * 
-      * <P>If {@code readBytes} returns a value equal to the length of the 
-      * buffer, a subsequent {@code readBytes} call must be made. If there 
-      * are no more bytes to be read, this call returns -1.
-      * 
-      * <P>If the byte array field value is null, {@code readBytes} 
-      * returns -1.
-      *
-      * <P>If the byte array field value is empty, {@code readBytes} 
-      * returns 0.
-      * 
-      * <P>Once the first {@code readBytes} call on a {@code byte[]}
-      * field value has been made,
-      * the full value of the field must be read before it is valid to read 
-      * the next field. An attempt to read the next field before that has 
-      * been done will throw a {@code MessageFormatException}.
-      * 
-      * <P>To read the byte field value into a new {@code byte[]} object, 
-      * use the {@code readObject} method.
-      *
-      * @param value the buffer into which the data is read
-      *
-      * @return the total number of bytes read into the buffer, or -1 if 
-      * there is no more data because the end of the byte field has been 
-      * reached
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      * 
-      * @see #readObject()
-      */ 
-
-    int
-    readBytes(byte[] value) throws JMSException;
-
-
-    /** Reads an object from the stream message.
-      *
-      * <P>This method can be used to return, in objectified format,
-      * an object in the Java programming language ("Java object") that has 
-      * been written to the stream with the equivalent
-      * {@code writeObject} method call, or its equivalent primitive
-      * <code>write<I>type</I></code> method.
-      *  
-      * <P>Note that byte values are returned as {@code byte[]}, not 
-      * {@code Byte[]}.
-      *
-      * <P>An attempt to call {@code readObject} to read a byte field 
-      * value into a new {@code byte[]} object before the full value of the
-      * byte field has been read will throw a 
-      * {@code MessageFormatException}.
-      *
-      * @return a Java object from the stream message, in objectified
-      * format (for example, if the object was written as an {@code int}, 
-      * an {@code Integer} is returned)
-      *
-      * @exception JMSException if the JMS provider fails to read the message
-      *                         due to some internal error.
-      * @exception MessageEOFException if unexpected end of message stream has
-      *                                been reached.     
-      * @exception MessageFormatException if this type conversion is invalid.
-      * @exception MessageNotReadableException if the message is in write-only 
-      *                                        mode.
-      * 
-      * @see #readBytes(byte[] value)
-      */ 
-
-    Object 
-    readObject() throws JMSException;
-
-
-
-    /** Writes a {@code boolean} to the stream message.
-      * The value {@code true} is written as the value 
-      * {@code (byte)1}; the value {@code false} is written as 
-      * the value {@code (byte)0}.
-      *
-      * @param value the {@code boolean} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */
-
-    void 
-    writeBoolean(boolean value) 
-			throws JMSException;
-
-
-    /** Writes a {@code byte} to the stream message.
-      *
-      * @param value the {@code byte} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeByte(byte value) throws JMSException;
-
-
-    /** Writes a {@code short} to the stream message.
-      *
-      * @param value the {@code short} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeShort(short value) throws JMSException;
-
-
-    /** Writes a {@code char} to the stream message.
-      *
-      * @param value the {@code char} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeChar(char value) throws JMSException;
-
-
-    /** Writes an {@code int} to the stream message.
-      *
-      * @param value the {@code int} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeInt(int value) throws JMSException;
-
-
-    /** Writes a {@code long} to the stream message.
-      *
-      * @param value the {@code long} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeLong(long value) throws JMSException;
-
-
-    /** Writes a {@code float} to the stream message.
-      *
-      * @param value the {@code float} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeFloat(float value) throws JMSException;
-
-
-    /** Writes a {@code double} to the stream message.
-      *
-      * @param value the {@code double} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeDouble(double value) throws JMSException;
-
-
-    /** Writes a {@code String} to the stream message.
-      *
-      * @param value the {@code String} value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeString(String value) throws JMSException;
-
-
-    /** Writes a byte array field to the stream message.
-      *
-      * <P>The byte array {@code value} is written to the message
-      * as a byte array field. Consecutively written byte array fields are 
-      * treated as two distinct fields when the fields are read.
-      * 
-      * @param value the byte array value to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void
-    writeBytes(byte[] value) throws JMSException;
-
-
-    /** Writes a portion of a byte array as a byte array field to the stream 
-      * message.
-      *  
-      * <P>The a portion of the byte array {@code value} is written to the
-      * message as a byte array field. Consecutively written byte 
-      * array fields are treated as two distinct fields when the fields are 
-      * read.
-      *
-      * @param value the byte array value to be written
-      * @param offset the initial offset within the byte array
-      * @param length the number of bytes to use
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
- 
-    void
-    writeBytes(byte[] value, int offset, int length) 
-			throws JMSException;
-
-
-    /** Writes an object to the stream message.
-      *
-      * <P>This method works only for the objectified primitive
-      * object types ({@code Integer}, {@code Double}, 
-      * {@code Long}&nbsp;...), {@code String} objects, and byte 
-      * arrays.
-      *
-      * @param value the Java object to be written
-      *
-      * @exception JMSException if the JMS provider fails to write the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if the object is invalid.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
-
-    void 
-    writeObject(Object value) throws JMSException;
-
-
-    /** Puts the message body in read-only mode and repositions the stream
-      * to the beginning.
-      *  
-      * @exception JMSException if the JMS provider fails to reset the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if the message has an invalid
-      *                                   format.
-      */ 
- 
-    void
-    reset() throws JMSException;
+    /**
+     * Reads a {@code boolean} from the stream message.
+     *
+     * @return the {@code boolean} value read
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    boolean readBoolean() throws JMSException;
+
+    /**
+     * Reads a {@code byte} value from the stream message.
+     *
+     * @return the next byte from the stream message as a 8-bit {@code byte}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    byte readByte() throws JMSException;
+
+    /**
+     * Reads a 16-bit integer from the stream message.
+     *
+     * @return a 16-bit integer from the stream message
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    short readShort() throws JMSException;
+
+    /**
+     * Reads a Unicode character value from the stream message.
+     *
+     * @return a Unicode character from the stream message
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    char readChar() throws JMSException;
+
+    /**
+     * Reads a 32-bit integer from the stream message.
+     *
+     * @return a 32-bit integer value from the stream message, interpreted as an {@code int}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    int readInt() throws JMSException;
+
+    /**
+     * Reads a 64-bit integer from the stream message.
+     *
+     * @return a 64-bit integer value from the stream message, interpreted as a {@code long}
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    long readLong() throws JMSException;
+
+    /**
+     * Reads a {@code float} from the stream message.
+     *
+     * @return a {@code float} value from the stream message
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    float readFloat() throws JMSException;
+
+    /**
+     * Reads a {@code double} from the stream message.
+     *
+     * @return a {@code double} value from the stream message
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    double readDouble() throws JMSException;
+
+    /**
+     * Reads a {@code String} from the stream message.
+     *
+     * @return a Unicode string from the stream message
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     */
+    String readString() throws JMSException;
+
+    /**
+     * Reads a byte array field from the stream message into the specified {@code byte[]} object (the read buffer).
+     *
+     * <p>
+     * To read the field value, {@code readBytes} should be successively called until it returns a value less than the
+     * length of the read buffer. The value of the bytes in the buffer following the last byte read is undefined.
+     *
+     * <p>
+     * If {@code readBytes} returns a value equal to the length of the buffer, a subsequent {@code readBytes} call must be
+     * made. If there are no more bytes to be read, this call returns -1.
+     *
+     * <p>
+     * If the byte array field value is null, {@code readBytes} returns -1.
+     *
+     * <p>
+     * If the byte array field value is empty, {@code readBytes} returns 0.
+     *
+     * <p>
+     * Once the first {@code readBytes} call on a {@code byte[]} field value has been made, the full value of the field must
+     * be read before it is valid to read the next field. An attempt to read the next field before that has been done will
+     * throw a {@code MessageFormatException}.
+     *
+     * <p>
+     * To read the byte field value into a new {@code byte[]} object, use the {@code readObject} method.
+     *
+     * @param value the buffer into which the data is read
+     *
+     * @return the total number of bytes read into the buffer, or -1 if there is no more data because the end of the byte
+     * field has been reached
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     *
+     * @see #readObject()
+     */
+    int readBytes(byte[] value) throws JMSException;
+
+    /**
+     * Reads an object from the stream message.
+     *
+     * <p>
+     * This method can be used to return, in objectified format, an object in the Java programming language ("Java object")
+     * that has been written to the stream with the equivalent {@code writeObject} method call, or its equivalent primitive
+     * <code>write<I>type</I></code> method.
+     *
+     * <p>
+     * Note that byte values are returned as {@code byte[]}, not {@code Byte[]}.
+     *
+     * <p>
+     * An attempt to call {@code readObject} to read a byte field value into a new {@code byte[]} object before the full
+     * value of the byte field has been read will throw a {@code MessageFormatException}.
+     *
+     * @return a Java object from the stream message, in objectified format (for example, if the object was written as an
+     * {@code int}, an {@code Integer} is returned)
+     *
+     * @exception JMSException if the JMS provider fails to read the message due to some internal error.
+     * @exception MessageEOFException if unexpected end of message stream has been reached.
+     * @exception MessageFormatException if this type conversion is invalid.
+     * @exception MessageNotReadableException if the message is in write-only mode.
+     *
+     * @see #readBytes(byte[] value)
+     */
+    Object readObject() throws JMSException;
+
+    /**
+     * Writes a {@code boolean} to the stream message. The value {@code true} is written as the value {@code (byte)1}; the
+     * value {@code false} is written as the value {@code (byte)0}.
+     *
+     * @param value the {@code boolean} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeBoolean(boolean value) throws JMSException;
+
+    /**
+     * Writes a {@code byte} to the stream message.
+     *
+     * @param value the {@code byte} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeByte(byte value) throws JMSException;
+
+    /**
+     * Writes a {@code short} to the stream message.
+     *
+     * @param value the {@code short} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeShort(short value) throws JMSException;
+
+    /**
+     * Writes a {@code char} to the stream message.
+     *
+     * @param value the {@code char} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeChar(char value) throws JMSException;
+
+    /**
+     * Writes an {@code int} to the stream message.
+     *
+     * @param value the {@code int} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeInt(int value) throws JMSException;
+
+    /**
+     * Writes a {@code long} to the stream message.
+     *
+     * @param value the {@code long} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeLong(long value) throws JMSException;
+
+    /**
+     * Writes a {@code float} to the stream message.
+     *
+     * @param value the {@code float} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeFloat(float value) throws JMSException;
+
+    /**
+     * Writes a {@code double} to the stream message.
+     *
+     * @param value the {@code double} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeDouble(double value) throws JMSException;
+
+    /**
+     * Writes a {@code String} to the stream message.
+     *
+     * @param value the {@code String} value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeString(String value) throws JMSException;
+
+    /**
+     * Writes a byte array field to the stream message.
+     *
+     * <p>
+     * The byte array {@code value} is written to the message as a byte array field. Consecutively written byte array fields
+     * are treated as two distinct fields when the fields are read.
+     *
+     * @param value the byte array value to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeBytes(byte[] value) throws JMSException;
+
+    /**
+     * Writes a portion of a byte array as a byte array field to the stream message.
+     *
+     * <p>
+     * The a portion of the byte array {@code value} is written to the message as a byte array field. Consecutively written
+     * byte array fields are treated as two distinct fields when the fields are read.
+     *
+     * @param value the byte array value to be written
+     * @param offset the initial offset within the byte array
+     * @param length the number of bytes to use
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeBytes(byte[] value, int offset, int length) throws JMSException;
+
+    /**
+     * Writes an object to the stream message.
+     *
+     * <p>
+     * This method works only for the objectified primitive object types ({@code Integer}, {@code Double},
+     * {@code Long}&nbsp;...), {@code String} objects, and byte arrays.
+     *
+     * @param value the Java object to be written
+     *
+     * @exception JMSException if the JMS provider fails to write the message due to some internal error.
+     * @exception MessageFormatException if the object is invalid.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void writeObject(Object value) throws JMSException;
+
+    /**
+     * Puts the message body in read-only mode and repositions the stream to the beginning.
+     *
+     * @exception JMSException if the JMS provider fails to reset the message due to some internal error.
+     * @exception MessageFormatException if the message has an invalid format.
+     */
+    void reset() throws JMSException;
 }

--- a/src/main/java/javax/jms/SubscriptionName.java
+++ b/src/main/java/javax/jms/SubscriptionName.java
@@ -23,28 +23,28 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation specifies that a callback method on a JMS message-driven bean
- * that has been configured to consume messages from a topic using a durable
- * subscription must use the specified durable subscription name.
+ * This annotation specifies that a callback method on a JMS message-driven bean that has been configured to consume
+ * messages from a topic using a durable subscription must use the specified durable subscription name.
+ *
  * <p>
- * The method must also be annotated with {@code TopicListener} and
- * {@code DurableSubscription}. If it is not then deployment will fail.
- * <p>
- * 
+ * The method must also be annotated with {@code TopicListener} and {@code DurableSubscription}. If it is not then
+ * deployment will fail.
+ *
  * @see TopicListener
  * @see DurableSubscription
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
 @Retention(RUNTIME)
-@Target({ METHOD })
+@Target(METHOD)
 public @interface SubscriptionName {
 
-	/**
-	 * The subscription name that will be used.
-	 */
-	String value();
+    /**
+     * The subscription name that will be used.
+     *
+     * @return The subscription name.
+     */
+    String value();
 
 }

--- a/src/main/java/javax/jms/TemporaryQueue.java
+++ b/src/main/java/javax/jms/TemporaryQueue.java
@@ -16,35 +16,28 @@
 
 package javax.jms;
 
-/** A {@code TemporaryQueue} object is a unique {@code Queue} object 
-  * created for the duration of a {@code Connection}. It is a 
-  * system-defined queue that can be consumed only by the 
-  * {@code Connection} that created it.
-  *
-  *<P>A {@code TemporaryQueue} object can be created at either the 
-  * {@code Session} or {@code QueueSession} level. Creating it at the
-  * {@code Session} level allows to the {@code TemporaryQueue} to 
-  * participate in transactions with objects from the Pub/Sub  domain. 
-  * If it is created at the {@code QueueSession}, it will only
-  * be able participate in transactions with objects from the PTP domain.
-  *
-  * @see Session#createTemporaryQueue()
-  * @see QueueSession#createTemporaryQueue()
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code TemporaryQueue} object is a unique {@code Queue} object created for the duration of a {@code Connection}. It
+ * is a system-defined queue that can be consumed only by the {@code Connection} that created it.
+ *
+ * <p>
+ * A {@code TemporaryQueue} object can be created at either the {@code Session} or {@code QueueSession} level. Creating
+ * it at the {@code Session} level allows to the {@code TemporaryQueue} to participate in transactions with objects from
+ * the Pub/Sub domain. If it is created at the {@code QueueSession}, it will only be able participate in transactions
+ * with objects from the PTP domain.
+ *
+ * @see Session#createTemporaryQueue()
+ * @see QueueSession#createTemporaryQueue()
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TemporaryQueue extends Queue {
 
-    /** Deletes this temporary queue. If there are existing receivers
-      * still using it, a {@code JMSException} will be thrown.
-      *  
-      * @exception JMSException if the JMS provider fails to delete the 
-      *                         temporary queue due to some internal error.
-      */
-
-    void 
-    delete() throws JMSException; 
+    /**
+     * Deletes this temporary queue. If there are existing receivers still using it, a {@code JMSException} will be thrown.
+     *
+     * @exception JMSException if the JMS provider fails to delete the temporary queue due to some internal error.
+     */
+    void delete() throws JMSException;
 }

--- a/src/main/java/javax/jms/TemporaryTopic.java
+++ b/src/main/java/javax/jms/TemporaryTopic.java
@@ -16,36 +16,29 @@
 
 package javax.jms;
 
-/** A {@code TemporaryTopic} object is a unique {@code Topic} object 
-  * created for the duration of a {@code Connection}. It is a 
-  * system-defined topic that can be consumed only by the 
-  * {@code Connection} that created it.
-  *
-  *<P>A {@code TemporaryTopic} object can be created either at the 
-  * {@code Session} or {@code TopicSession} level. Creating it at the
-  * {@code Session} level allows the {@code TemporaryTopic} to participate
-  * in the same transaction with objects from the PTP domain. 
-  * If a {@code TemporaryTopic} is  created at the 
-  * {@code TopicSession}, it will only
-  * be able participate in transactions with objects from the Pub/Sub domain.
-  *
-  * @see Session#createTemporaryTopic()
-  * @see TopicSession#createTemporaryTopic()
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code TemporaryTopic} object is a unique {@code Topic} object created for the duration of a {@code Connection}. It
+ * is a system-defined topic that can be consumed only by the {@code Connection} that created it.
+ *
+ * <p>
+ * A {@code TemporaryTopic} object can be created either at the {@code Session} or {@code TopicSession} level. Creating
+ * it at the {@code Session} level allows the {@code TemporaryTopic} to participate in the same transaction with objects
+ * from the PTP domain. If a {@code TemporaryTopic} is created at the {@code TopicSession}, it will only be able
+ * participate in transactions with objects from the Pub/Sub domain.
+ *
+ * @see Session#createTemporaryTopic()
+ * @see TopicSession#createTemporaryTopic()
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TemporaryTopic extends Topic {
 
-    /** Deletes this temporary topic. If there are existing subscribers
-      * still using it, a {@code JMSException} will be thrown.
-      *  
-      * @exception JMSException if the JMS provider fails to delete the
-      *                         temporary topic due to some internal error.
-      */
-
-    void 
-    delete() throws JMSException; 
+    /**
+     * Deletes this temporary topic. If there are existing subscribers still using it, a {@code JMSException} will be
+     * thrown.
+     *
+     * @exception JMSException if the JMS provider fails to delete the temporary topic due to some internal error.
+     */
+    void delete() throws JMSException;
 }

--- a/src/main/java/javax/jms/TextMessage.java
+++ b/src/main/java/javax/jms/TextMessage.java
@@ -16,59 +16,48 @@
 
 package javax.jms;
 
-/** A {@code TextMessage} object is used to send a message containing a 
-  * {@code java.lang.String}.
-  * It inherits from the {@code Message} interface and adds a text message 
-  * body.
-  *
-  * <P>This message type can be used to transport text-based messages, including
-  *  those with XML content.
-  *
-  * <P>When a client receives a {@code TextMessage}, it is in read-only 
-  * mode. If a client attempts to write to the message at this point, a 
-  * {@code MessageNotWriteableException} is thrown. If 
-  * {@code clearBody} is 
-  * called, the message can now be both read from and written to.
-  *
-  * @see         javax.jms.Session#createTextMessage()
-  * @see         javax.jms.Session#createTextMessage(String)
-  * @see         javax.jms.BytesMessage
-  * @see         javax.jms.MapMessage
-  * @see         javax.jms.Message
-  * @see         javax.jms.ObjectMessage
-  * @see         javax.jms.StreamMessage
-  * @see         java.lang.String
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
- 
-public interface TextMessage extends Message { 
+/**
+ * A {@code TextMessage} object is used to send a message containing a {@code java.lang.String}. It inherits from the
+ * {@code Message} interface and adds a text message body.
+ *
+ * <p>
+ * This message type can be used to transport text-based messages, including those with XML content.
+ *
+ * <p>
+ * When a client receives a {@code TextMessage}, it is in read-only mode. If a client attempts to write to the message
+ * at this point, a {@code MessageNotWriteableException} is thrown. If {@code clearBody} is called, the message can now
+ * be both read from and written to.
+ *
+ * @see javax.jms.Session#createTextMessage()
+ * @see javax.jms.Session#createTextMessage(String)
+ * @see javax.jms.BytesMessage
+ * @see javax.jms.MapMessage
+ * @see javax.jms.Message
+ * @see javax.jms.ObjectMessage
+ * @see javax.jms.StreamMessage
+ * @see java.lang.String
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
+public interface TextMessage extends Message {
 
-    /** Sets the string containing this message's data.
-      *  
-      * @param string the {@code String} containing the message's data
-      *  
-      * @exception JMSException if the JMS provider fails to set the text due to
-      *                         some internal error.
-      * @exception MessageNotWriteableException if the message is in read-only 
-      *                                         mode.
-      */ 
+    /**
+     * Sets the string containing this message's data.
+     *
+     * @param string the {@code String} containing the message's data
+     *
+     * @exception JMSException if the JMS provider fails to set the text due to some internal error.
+     * @exception MessageNotWriteableException if the message is in read-only mode.
+     */
+    void setText(String string) throws JMSException;
 
-    void
-    setText(String string) throws JMSException;
-
-
-    /** Gets the string containing this message's data.  The default
-      * value is null.
-      *  
-      * @return the {@code String} containing the message's data
-      *  
-      * @exception JMSException if the JMS provider fails to get the text due to
-      *                         some internal error.
-      */ 
-
-    String
-    getText() throws JMSException;
+    /**
+     * Gets the string containing this message's data. The default value is null.
+     *
+     * @return the {@code String} containing the message's data
+     *
+     * @exception JMSException if the JMS provider fails to get the text due to some internal error.
+     */
+    String getText() throws JMSException;
 }

--- a/src/main/java/javax/jms/Topic.java
+++ b/src/main/java/javax/jms/Topic.java
@@ -16,67 +16,58 @@
 
 package javax.jms;
 
-
-/** A {@code Topic} object encapsulates a provider-specific topic name. 
-  * It is the way a client specifies the identity of a topic to JMS API methods.
- * For those methods that use a {@code Destination} as a parameter, a 
-  * {@code Topic} object may used as an argument . For 
-  * example, a Topic can be used to create a {@code MessageConsumer}
-  * and a {@code MessageProducer}
-  * by calling:
-  *<UL>
-  *<LI> {@code Session.CreateConsumer(Destination destination)}
-  *<LI> {@code Session.CreateProducer(Destination destination)}
-  *
-  *</UL>
-  *
-  * <P>Many publish/subscribe (pub/sub) providers group topics into hierarchies 
-  * and provide various options for subscribing to parts of the hierarchy. The 
-  * JMS API places no restriction on what a {@code Topic} object 
-  * represents. It may be a leaf in a topic hierarchy, or it may be a larger 
-  * part of the hierarchy.
-  *
-  * <P>The organization of topics and the granularity of subscriptions to 
-  * them is an important part of a pub/sub application's architecture. The JMS 
-  * API 
-  * does not specify a policy for how this should be done. If an application 
-  * takes advantage of a provider-specific topic-grouping mechanism, it 
-  * should document this. If the application is installed using a different 
-  * provider, it is the job of the administrator to construct an equivalent 
-  * topic architecture and create equivalent {@code Topic} objects.
-  *
-  * @see        Session#createConsumer(Destination)
-  * @see        Session#createProducer(Destination)
-  * @see        javax.jms.TopicSession#createTopic(String)
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code Topic} object encapsulates a provider-specific topic name.
+ *
+ * <p>
+ * It is the way a client specifies the identity of a topic to JMS API methods. For those methods that use a
+ * {@code Destination} as a parameter, a {@code Topic} object may used as an argument . For example, a Topic can be used
+ * to create a {@code MessageConsumer} and a {@code MessageProducer} by calling:
+ *
+ * <ul>
+ * <li>{@code Session.CreateConsumer(Destination destination)}
+ * <li>{@code Session.CreateProducer(Destination destination)}
+ * </ul>
+ *
+ * <p>
+ * Many publish/subscribe (pub/sub) providers group topics into hierarchies and provide various options for subscribing
+ * to parts of the hierarchy. The JMS API places no restriction on what a {@code Topic} object represents. It may be a
+ * leaf in a topic hierarchy, or it may be a larger part of the hierarchy.
+ *
+ * <p>
+ * The organization of topics and the granularity of subscriptions to them is an important part of a pub/sub
+ * application's architecture. The JMS API does not specify a policy for how this should be done. If an application
+ * takes advantage of a provider-specific topic-grouping mechanism, it should document this. If the application is
+ * installed using a different provider, it is the job of the administrator to construct an equivalent topic
+ * architecture and create equivalent {@code Topic} objects.
+ *
+ * @see Session#createConsumer(Destination)
+ * @see Session#createProducer(Destination)
+ * @see javax.jms.TopicSession#createTopic(String)
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface Topic extends Destination {
 
-    /** Gets the name of this topic.
-      *  
-      * <P>Clients that depend upon the name are not portable.
-      *  
-      * @return the topic name
-      *  
-      * @exception JMSException if the JMS provider implementation of 
-      *                         {@code Topic} fails to return the topic
-      *                         name due to some internal
-      *                         error.
-      */ 
+    /**
+     * Gets the name of this topic.
+     *
+     * <p>
+     * Clients that depend upon the name are not portable.
+     *
+     * @return the topic name
+     *
+     * @exception JMSException if the JMS provider implementation of {@code Topic} fails to return the topic name due to
+     * some internal error.
+     */
+    String getTopicName() throws JMSException;
 
-    String
-    getTopicName() throws JMSException;
-
-
-    /** Returns a string representation of this object.
-      *
-      * @return the provider-specific identity values for this topic
-      */
-
-    String
-    toString();
+    /**
+     * Returns a string representation of this object.
+     *
+     * @return the provider-specific identity values for this topic
+     */
+    @Override
+    String toString();
 }

--- a/src/main/java/javax/jms/TopicConnection.java
+++ b/src/main/java/javax/jms/TopicConnection.java
@@ -16,196 +16,149 @@
 
 package javax.jms;
 
-/** A {@code TopicConnection} object is an active connection to a 
-  * publish/subscribe JMS provider. A client uses a {@code TopicConnection} 
-  * object to create one or more {@code TopicSession} objects
-  * for producing and consuming messages.
-  *
-  *<P>A {@code TopicConnection} can be used to create a 
-  *{@code TopicSession}, from which
-  * specialized topic-related objects can be created. 
-  * A more general, and recommended approach is to use the 
-  * {@code Connection} object. 
-  *
-  *
-  * <P>The {@code TopicConnection} object
-  * should be used to support existing code.
-  *
-  * @see         javax.jms.Connection
-  * @see         javax.jms.ConnectionFactory
-  * @see	 javax.jms.TopicConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code TopicConnection} object is an active connection to a publish/subscribe JMS provider. A client uses a
+ * {@code TopicConnection} object to create one or more {@code TopicSession} objects for producing and consuming
+ * messages.
+ *
+ * <p>
+ * A {@code TopicConnection} can be used to create a {@code TopicSession}, from which specialized topic-related objects
+ * can be created. A more general, and recommended approach is to use the {@code Connection} object.
+ *
+ * <p>
+ * The {@code TopicConnection} object should be used to support existing code.
+ *
+ * @see javax.jms.Connection
+ * @see javax.jms.ConnectionFactory
+ * @see javax.jms.TopicConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TopicConnection extends Connection {
 
-    /** 
-     * Creates a {@code TopicSession} object, 
-     * specifying {@code transacted} and {@code acknowledgeMode}.
-     * <p> 
-     * The effect of setting the {@code transacted} and {@code acknowledgeMode} 
-     * arguments depends on whether this method is called in a Java SE environment, 
-     * in the Java EE application client container, or in the Java EE web or EJB container.
-     * If this method is called in the Java EE web or EJB container then the 
-     * effect of setting the transacted} and {@code acknowledgeMode} 
-     * arguments also depends on whether or not there is an active JTA transaction 
-     * in progress.  
+    /**
+     * Creates a {@code TopicSession} object, specifying {@code transacted} and {@code acknowledgeMode}.
+     *
+     * <p>
+     * The effect of setting the {@code transacted} and {@code acknowledgeMode} arguments depends on whether this method is
+     * called in a Java SE environment, in the Java EE application client container, or in the Java EE web or EJB container.
+     * If this method is called in the Java EE web or EJB container then the effect of setting the transacted} and
+     * {@code acknowledgeMode} arguments also depends on whether or not there is an active JTA transaction in progress.
+     *
      * <p>
      * In a <b>Java SE environment</b> or in <b>the Java EE application client container</b>:
+     *
      * <ul>
-     * <li>If {@code transacted} is set to {@code true} then the session 
-     * will use a local transaction which may subsequently be committed or rolled back 
-     * by calling the session's {@code commit} or {@code rollback} methods. 
-     * The argument {@code acknowledgeMode} is ignored.
-     * <li>If {@code transacted} is set to {@code false} then the session 
-     * will be non-transacted. In this case the argument {@code acknowledgeMode}
-     * is used to specify how messages received by this session will be acknowledged.
-     * The permitted values are 
-     * {@code Session.CLIENT_ACKNOWLEDGE}, 
-     * {@code Session.AUTO_ACKNOWLEDGE} and
-     * {@code Session.DUPS_OK_ACKNOWLEDGE}.
-     * For a definition of the meaning of these acknowledgement modes see the links below.
+     * <li>If {@code transacted} is set to {@code true} then the session will use a local transaction which may subsequently
+     * be committed or rolled back by calling the session's {@code commit} or {@code rollback} methods. The argument
+     * {@code acknowledgeMode} is ignored.
+     * <li>If {@code transacted} is set to {@code false} then the session will be non-transacted. In this case the argument
+     * {@code acknowledgeMode} is used to specify how messages received by this session will be acknowledged. The permitted
+     * values are {@code Session.CLIENT_ACKNOWLEDGE}, {@code Session.AUTO_ACKNOWLEDGE} and
+     * {@code Session.DUPS_OK_ACKNOWLEDGE}. For a definition of the meaning of these acknowledgement modes see the links
+     * below.
      * </ul>
+     *
      * <p>
      * In a <b>Java EE web or EJB container, when there is an active JTA transaction in progress</b>:
+     *
      * <ul>
-     * <li>Both arguments {@code transacted} and {@code acknowledgeMode} are ignored.
-     * The session will participate in the JTA transaction and will be committed or rolled back
-     * when that transaction is committed or rolled back, 
-     * not by calling the session's {@code commit} or {@code rollback} methods.
-     * Since both arguments are ignored, developers are recommended to use 
-     * {@code createSession()}, which has no arguments, instead of this method.
+     * <li>Both arguments {@code transacted} and {@code acknowledgeMode} are ignored. The session will participate in the
+     * JTA transaction and will be committed or rolled back when that transaction is committed or rolled back, not by
+     * calling the session's {@code commit} or {@code rollback} methods. Since both arguments are ignored, developers are
+     * recommended to use {@code createSession()}, which has no arguments, instead of this method.
      * </ul>
+     *
      * <p>
      * In the <b>Java EE web or EJB container, when there is no active JTA transaction in progress</b>:
+     *
      * <ul>
-     * <li>
-     * If {@code transacted} is set to false and {@code acknowledgeMode} is set to
-     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} then the
-     * session will be non-transacted and messages will be acknowledged according
-     * to the value of {@code acknowledgeMode}.
-     * <li>
-     * If {@code transacted} is set to false and {@code acknowledgeMode} is set to
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE} then the JMS provider is recommended to
-     * ignore the specified parameters and instead provide a non-transacted,
-     * auto-acknowledged session. However the JMS provider may alternatively
-     * provide a non-transacted session with client acknowledgement.
-     * <li>
-     * If {@code transacted} is set to true, then the JMS provider is recommended to
-     * ignore the specified parameters and instead provide a non-transacted,
-     * auto-acknowledged session. However the JMS provider may alternatively
-     * provide a local transacted session.
-     * <li>
-     * Applications are recommended to set {@code transacted} to false and
-     * {@code acknowledgeMode} to {@code JMSContext.AUTO_ACKNOWLEDGE} or
-     * {@code Session.DUPS_OK_ACKNOWLEDGE} since since applications which set
-     * {@code transacted} to false and set {@code acknowledgeMode} to
-     * {@code JMSContext.CLIENT_ACKNOWLEDGE}, or which set {@code transacted} 
-     * to true, may not be portable. 
-     * </ul> 
+     * <li>If {@code transacted} is set to false and {@code acknowledgeMode} is set to {@code JMSContext.AUTO_ACKNOWLEDGE}
+     * or {@code Session.DUPS_OK_ACKNOWLEDGE} then the session will be non-transacted and messages will be acknowledged
+     * according to the value of {@code acknowledgeMode}.
+     * <li>If {@code transacted} is set to false and {@code acknowledgeMode} is set to {@code JMSContext.CLIENT_ACKNOWLEDGE}
+     * then the JMS provider is recommended to ignore the specified parameters and instead provide a non-transacted,
+     * auto-acknowledged session. However the JMS provider may alternatively provide a non-transacted session with client
+     * acknowledgement.
+     * <li>If {@code transacted} is set to true, then the JMS provider is recommended to ignore the specified parameters and
+     * instead provide a non-transacted, auto-acknowledged session. However the JMS provider may alternatively provide a
+     * local transacted session.
+     * <li>Applications are recommended to set {@code transacted} to false and {@code acknowledgeMode} to
+     * {@code JMSContext.AUTO_ACKNOWLEDGE} or {@code Session.DUPS_OK_ACKNOWLEDGE} since since applications which set
+     * {@code transacted} to false and set {@code acknowledgeMode} to {@code JMSContext.CLIENT_ACKNOWLEDGE}, or which set
+     * {@code transacted} to true, may not be portable.
+     * </ul>
+     *
      * <p>
-     * Applications running in the Java EE web and EJB containers must not attempt 
-     * to create more than one active (not closed) {@code Session} object per connection. 
-     * If this method is called in a Java EE web or EJB container when an active
-     * {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
-     * 
-     * @param transacted indicates whether the session will use a local transaction,
-     * except in the cases described above when this value is ignored.
-     * 
-     * @param acknowledgeMode when transacted is false, indicates how messages received
-     * by the session will be acknowledged, except in the cases described above
+     * Applications running in the Java EE web and EJB containers must not attempt to create more than one active (not
+     * closed) {@code Session} object per connection. If this method is called in a Java EE web or EJB container when an
+     * active {@code Session} object already exists for this connection then a {@code JMSException} may be thrown.
+     *
+     * @param transacted indicates whether the session will use a local transaction, except in the cases described above
      * when this value is ignored.
-     * 
+     * @param acknowledgeMode when transacted is false, indicates how messages received by the session will be acknowledged,
+     * except in the cases described above when this value is ignored.
+     *
      * @return a newly created {@code TopicSession}
-     *  
-     * @exception JMSException if the {@code TopicConnection} object fails
-     *                         to create a {@code TopicSession} due to 
-     *                         <ul>
-     *                         <li>some internal error, 
-     *                         <li>lack of support for the specific transaction and acknowledgement mode, or
-     *                         <li>because this method is being called in a Java EE web or EJB application 
-     *                         and an active session already exists for this connection.
-     *                         </ul>
+     *
+     * @exception JMSException if the {@code TopicConnection} object fails to create a {@code TopicSession} due to
+     * <ul>
+     * <li>some internal error,
+     * <li>lack of support for the specific transaction and acknowledgement mode, or
+     * <li>because this method is being called in a Java EE web or EJB application and an active session already exists for
+     * this connection.
+     * </ul>
+     *
      * @since JMS 1.1
      *
-     * @see Session#AUTO_ACKNOWLEDGE 
-     * @see Session#CLIENT_ACKNOWLEDGE 
-     * @see Session#DUPS_OK_ACKNOWLEDGE 
-     * 
+     * @see Session#AUTO_ACKNOWLEDGE
+     * @see Session#CLIENT_ACKNOWLEDGE
+     * @see Session#DUPS_OK_ACKNOWLEDGE
      */
+    TopicSession createTopicSession(boolean transacted, int acknowledgeMode) throws JMSException;
 
-    TopicSession
-    createTopicSession(boolean transacted,
-                       int acknowledgeMode) throws JMSException;
+    /**
+     * Creates a connection consumer for this connection (optional operation). This is an expert facility not used by
+     * regular JMS clients.
+     *
+     * @param topic the topic to access
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the connection consumer
+     *
+     * @exception JMSException if the {@code TopicConnection} object fails to create a connection consumer due to some
+     * internal error or invalid arguments for {@code sessionPool} and {@code messageSelector}.
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     *
+     * @see javax.jms.ConnectionConsumer
+     */
+    ConnectionConsumer createConnectionConsumer(Topic topic, String messageSelector, ServerSessionPool sessionPool, int maxMessages) throws JMSException;
 
-
-    /** Creates a connection consumer for this connection (optional operation).
-      * This is an expert facility not used by regular JMS clients.
-      *  
-      * @param topic the topic to access
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered.  A value of null or
-      * an empty string indicates that there is no message selector  
-      * for the message consumer.
-      * @param sessionPool the server session pool to associate with this 
-      * connection consumer
-      * @param maxMessages the maximum number of messages that can be
-      * assigned to a server session at one time
-      *
-      * @return the connection consumer
-      *
-      * @exception JMSException if the {@code TopicConnection} object fails
-      *                         to create a connection consumer due to some
-      *                         internal error or invalid arguments for 
-      *                         {@code sessionPool} and 
-      *                         {@code messageSelector}.
-      * @exception InvalidDestinationException if an invalid topic is specified.
-      * @exception InvalidSelectorException if the message selector is invalid.
-      * @see javax.jms.ConnectionConsumer
-      */ 
-
-    ConnectionConsumer
-    createConnectionConsumer(Topic topic,
-                             String messageSelector,
-                             ServerSessionPool sessionPool,
-			     int maxMessages)
-			     throws JMSException;
-
-
-    /** Create a durable connection consumer for this connection (optional operation). 
-      * This is an expert facility not used by regular JMS clients.
-      *                
-      * @param topic the topic to access
-      * @param subscriptionName durable subscription name
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered.  A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer.
-      * @param sessionPool the server session pool to associate with this 
-      * durable connection consumer
-      * @param maxMessages the maximum number of messages that can be
-      * assigned to a server session at one time
-      *
-      * @return the durable connection consumer
-      *  
-      * @exception JMSException if the {@code TopicConnection} object fails
-      *                         to create a connection consumer due to some
-      *                         internal error or invalid arguments for 
-      *                         {@code sessionPool} and 
-      *                         {@code messageSelector}.
-      * @exception InvalidDestinationException if an invalid topic is specified.
-      * @exception InvalidSelectorException if the message selector is invalid.
-      * @see javax.jms.ConnectionConsumer
-      */
-
-    ConnectionConsumer
-    createDurableConnectionConsumer(Topic topic,
-				    String subscriptionName,
-                                    String messageSelector,
-                                    ServerSessionPool sessionPool,
-				    int maxMessages)
-                             throws JMSException;
+    /**
+     * Create a durable connection consumer for this connection (optional operation). This is an expert facility not used by
+     * regular JMS clients.
+     *
+     * @param topic the topic to access
+     * @param subscriptionName durable subscription name
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param sessionPool the server session pool to associate with this durable connection consumer
+     * @param maxMessages the maximum number of messages that can be assigned to a server session at one time
+     *
+     * @return the durable connection consumer
+     *
+     * @exception JMSException if the {@code TopicConnection} object fails to create a connection consumer due to some
+     * internal error or invalid arguments for {@code sessionPool} and {@code messageSelector}.
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @see javax.jms.ConnectionConsumer
+     */
+    @Override
+    ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool,
+            int maxMessages) throws JMSException;
 }

--- a/src/main/java/javax/jms/TopicConnectionFactory.java
+++ b/src/main/java/javax/jms/TopicConnectionFactory.java
@@ -16,60 +16,47 @@
 
 package javax.jms;
 
-/** A client uses a {@code TopicConnectionFactory} object to create 
-  * {@code TopicConnection} objects with a publish/subscribe JMS provider.
-  *
-  * <P>A{@code  TopicConnectionFactory} can be used to create a 
-  * {@code TopicConnection}, from which specialized topic-related objects
-  * can be  created. A more general, and recommended approach 
-  * is to use the {@code ConnectionFactory} object.
-  *  
-  * <P> The {@code TopicConnectionFactory} object
-  * should be used to support existing code.
-  *
-  * @see javax.jms.ConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A client uses a {@code TopicConnectionFactory} object to create {@code TopicConnection} objects with a
+ * publish/subscribe JMS provider.
+ *
+ * <p>
+ * A{@code  TopicConnectionFactory} can be used to create a {@code TopicConnection}, from which specialized
+ * topic-related objects can be created. A more general, and recommended approach is to use the
+ * {@code ConnectionFactory} object.
+ *
+ * <p>
+ * The {@code TopicConnectionFactory} object should be used to support existing code.
+ *
+ * @see javax.jms.ConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TopicConnectionFactory extends ConnectionFactory {
 
-    /** Creates a topic connection with the default user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *
-      * @return a newly created topic connection
-      *
-      * @exception JMSException if the JMS provider fails to create a topic 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException if client authentication fails due to 
-      *                                 an invalid user name or password.
-      */ 
+    /**
+     * Creates a topic connection with the default user identity. The connection is created in stopped mode. No messages
+     * will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @return a newly created topic connection
+     *
+     * @exception JMSException if the JMS provider fails to create a topic connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    TopicConnection createTopicConnection() throws JMSException;
 
-    TopicConnection
-    createTopicConnection() throws JMSException;
-
-
-    /** Creates a topic connection with the specified user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *  
-      * @param userName the caller's user name
-      * @param password the caller's password
-      *  
-      * @return a newly created topic connection
-      *
-      * @exception JMSException if the JMS provider fails to create a topic 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException if client authentication fails due to 
-      *                                 an invalid user name or password.
-      */ 
-
-    TopicConnection
-    createTopicConnection(String userName, String password) 
-					     throws JMSException;
+    /**
+     * Creates a topic connection with the specified user identity. The connection is created in stopped mode. No messages
+     * will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @param userName the caller's user name
+     * @param password the caller's password
+     *
+     * @return a newly created topic connection
+     *
+     * @exception JMSException if the JMS provider fails to create a topic connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    TopicConnection createTopicConnection(String userName, String password) throws JMSException;
 }

--- a/src/main/java/javax/jms/TopicListener.java
+++ b/src/main/java/javax/jms/TopicListener.java
@@ -23,39 +23,38 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * This annotation designates a callback method on a JMS message-driven bean
- * that will receive messages from a topic, and specifies the topic from which
- * messages will be received.
+ * This annotation designates a callback method on a JMS message-driven bean that will receive messages from a topic,
+ * and specifies the topic from which messages will be received.
+ *
  * <p>
- * By default a non-durable subscription is used. The
- * {@code DurableSubscription} annotation may be used in conjunction with this
- * annotation to specify that a durable subscription is required.
+ * By default a non-durable subscription is used. The {@code DurableSubscription} annotation may be used in conjunction
+ * with this annotation to specify that a durable subscription is required.
+ *
  * <p>
- * This annotation may only be used if the JMS message-driven bean implements
- * the {@code JMSMessageDrivenBean} marker interface and does not implement the
- * {@code MessageListener} interface. If this annotation is used on a
- * message-driven bean that implements the {@code MessageListener} interface
- * then deployment will fail.
+ * This annotation may only be used if the JMS message-driven bean implements the {@code JMSMessageDrivenBean} marker
+ * interface and does not implement the {@code MessageListener} interface. If this annotation is used on a
+ * message-driven bean that implements the {@code MessageListener} interface then deployment will fail.
+ *
  * <p>
- * Only one method may be designated as a callback method. If more than one
- * method on a JMS message-driven bean is annotated with {@code QueueListener}
- * or {@code TopicListener} then deployment will fail.
- * 
+ * Only one method may be designated as a callback method. If more than one method on a JMS message-driven bean is
+ * annotated with {@code QueueListener} or {@code TopicListener} then deployment will fail.
+ *
  * @see JMSMessageDrivenBean
  * @see QueueListener
  * @see DurableSubscription
- * 
+ *
  * @version JMS 2.1
  * @since JMS 2.1
- * 
  */
 @Retention(RUNTIME)
-@Target({ METHOD })
+@Target(METHOD)
 public @interface TopicListener {
 
-	/**
-	 * Lookup name of the Topic from which messages will be received.
-	 */
-	String value() default "";
+    /**
+     * Lookup name of the Topic from which messages will be received.
+     *
+     * @return The lookup name of the Topic.
+     */
+    String value() default "";
 
 }

--- a/src/main/java/javax/jms/TopicPublisher.java
+++ b/src/main/java/javax/jms/TopicPublisher.java
@@ -16,182 +16,138 @@
 
 package javax.jms;
 
-/** A client uses a {@code TopicPublisher} object to publish messages on a 
-  * topic. A {@code TopicPublisher} object is the publish-subscribe form
-  * of a message producer.
-  *
-  * <P>Normally, the {@code Topic} is specified when a 
-  * {@code TopicPublisher} is created.  In this case, an attempt to use 
-  * the {@code publish} methods for an unidentified 
-  * {@code TopicPublisher} will throw a 
-  * {@code java.lang.UnsupportedOperationException}.
-  *
-  * <P>If the {@code TopicPublisher} is created with an unidentified 
-  * {@code Topic}, an attempt to use the {@code publish} methods that 
-  * assume that the {@code Topic} has been identified will throw a 
-  * {@code java.lang.UnsupportedOperationException}.
-  *
-  * <P>During the execution of its {@code publish} method,
-  * a message must not be changed by other threads within the client. 
-  * If the message is modified, the result of the {@code publish} is 
-  * undefined.
-  * 
-  * <P>After publishing a message, a client may retain and modify it
-  * without affecting the message that has been published. The same message
-  * object may be published multiple times.
-  * 
-  * <P>The following message headers are set as part of publishing a 
-  * message: {@code JMSDestination}, {@code JMSDeliveryMode}, 
-  * {@code JMSExpiration}, {@code JMSPriority}, 
-  * {@code JMSMessageID} and {@code JMSTimeStamp}.
-  * When the message is published, the values of these headers are ignored. 
-  * After completion of the {@code publish}, the headers hold the values 
-  * specified by the method publishing the message. It is possible for the 
-  * {@code publish} method not to set {@code JMSMessageID} and 
-  * {@code JMSTimeStamp} if the 
-  * setting of these headers is explicitly disabled by the 
-  * {@code MessageProducer.setDisableMessageID} or
-  * {@code MessageProducer.setDisableMessageTimestamp} method.
-  *
-  *<P>Creating a {@code MessageProducer} provides the same features as
-  * creating a {@code TopicPublisher}. A {@code MessageProducer} object is 
-  * recommended when creating new code. The  {@code TopicPublisher} is
-  * provided to support existing code.
-
-  *
-  *<P>Because {@code TopicPublisher} inherits from 
-  * {@code MessageProducer}, it inherits the
-  * {@code send} methods that are a part of the {@code MessageProducer} 
-  * interface. Using the {@code send} methods will have the same
-  * effect as using the
-  * {@code publish} methods: they are functionally the same.
-  *
-  * @see Session#createProducer(Destination) 
-  * @see TopicSession#createPublisher(Topic)
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A client uses a {@code TopicPublisher} object to publish messages on a topic. A {@code TopicPublisher} object is the
+ * publish-subscribe form of a message producer.
+ *
+ * <p>
+ * Normally, the {@code Topic} is specified when a {@code TopicPublisher} is created. In this case, an attempt to use
+ * the {@code publish} methods for an unidentified {@code TopicPublisher} will throw a
+ * {@code java.lang.UnsupportedOperationException}.
+ *
+ * <p>
+ * If the {@code TopicPublisher} is created with an unidentified {@code Topic}, an attempt to use the {@code publish}
+ * methods that assume that the {@code Topic} has been identified will throw a
+ * {@code java.lang.UnsupportedOperationException}.
+ *
+ * <p>
+ * During the execution of its {@code publish} method, a message must not be changed by other threads within the client.
+ * If the message is modified, the result of the {@code publish} is undefined.
+ *
+ * <p>
+ * After publishing a message, a client may retain and modify it without affecting the message that has been published.
+ * The same message object may be published multiple times.
+ *
+ * <p>
+ * The following message headers are set as part of publishing a message: {@code JMSDestination},
+ * {@code JMSDeliveryMode}, {@code JMSExpiration}, {@code JMSPriority}, {@code JMSMessageID} and {@code JMSTimeStamp}.
+ * When the message is published, the values of these headers are ignored. After completion of the {@code publish}, the
+ * headers hold the values specified by the method publishing the message. It is possible for the {@code publish} method
+ * not to set {@code JMSMessageID} and {@code JMSTimeStamp} if the setting of these headers is explicitly disabled by
+ * the {@code MessageProducer.setDisableMessageID} or {@code MessageProducer.setDisableMessageTimestamp} method.
+ *
+ * <p>
+ * Creating a {@code MessageProducer} provides the same features as creating a {@code TopicPublisher}. A
+ * {@code MessageProducer} object is recommended when creating new code. The {@code TopicPublisher} is provided to
+ * support existing code.
+ *
+ * <p>
+ * Because {@code TopicPublisher} inherits from {@code MessageProducer}, it inherits the {@code send} methods that are a
+ * part of the {@code MessageProducer} interface. Using the {@code send} methods will have the same effect as using the
+ * {@code publish} methods: they are functionally the same.
+ *
+ * @see Session#createProducer(Destination)
+ * @see TopicSession#createPublisher(Topic)
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TopicPublisher extends MessageProducer {
 
-    /** Gets the topic associated with this {@code TopicPublisher}.
-      *
-      * @return this publisher's topic
-      *  
-      * @exception JMSException if the JMS provider fails to get the topic for
-      *                         this {@code TopicPublisher}
-      *                         due to some internal error.
-      */
+    /**
+     * Gets the topic associated with this {@code TopicPublisher}.
+     *
+     * @return this publisher's topic
+     *
+     * @exception JMSException if the JMS provider fails to get the topic for this {@code TopicPublisher} due to some
+     * internal error.
+     */
+    Topic getTopic() throws JMSException;
 
-    Topic 
-    getTopic() throws JMSException;
+    /**
+     * Publishes a message to the topic. Uses the {@code TopicPublisher}'s default delivery mode, priority, and time to
+     * live.
+     *
+     * @param message the message to publish
+     *
+     * @exception JMSException if the JMS provider fails to publish the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code TopicPublisher} with an invalid
+     * topic.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code TopicPublisher} that
+     * did not specify a topic at creation time.
+     *
+     * @see javax.jms.MessageProducer#getDeliveryMode()
+     * @see javax.jms.MessageProducer#getTimeToLive()
+     * @see javax.jms.MessageProducer#getPriority()
+     */
+    void publish(Message message) throws JMSException;
 
- 
-    /** Publishes a message to the topic.
-      * Uses the {@code TopicPublisher}'s default delivery mode, priority,
-      * and time to live.
-      *
-      * @param message the message to publish
-      *
-      * @exception JMSException if the JMS provider fails to publish the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses this method
-      *                         with a {@code TopicPublisher} with
-      *                         an invalid topic.
-      * @exception java.lang.UnsupportedOperationException if a client uses this
-      *                         method with a {@code TopicPublisher} that
-      *                         did not specify a topic at creation time.
-      * 
-      * @see javax.jms.MessageProducer#getDeliveryMode()
-      * @see javax.jms.MessageProducer#getTimeToLive()
-      * @see javax.jms.MessageProducer#getPriority()
-      */
+    /**
+     * Publishes a message to the topic, specifying delivery mode, priority, and time to live.
+     *
+     * @param message the message to publish
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     *
+     * @exception JMSException if the JMS provider fails to publish the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with a {@code TopicPublisher} with an invalid
+     * topic.
+     * @exception java.lang.UnsupportedOperationException if a client uses this method with a {@code TopicPublisher} that
+     * did not specify a topic at creation time.
+     */
+    void publish(Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
 
-    void 
-    publish(Message message) throws JMSException;
+    /**
+     * Publishes a message to a topic for an unidentified message producer. Uses the {@code TopicPublisher}'s default
+     * delivery mode, priority, and time to live.
+     *
+     * <p>
+     * Typically, a message producer is assigned a topic at creation time; however, the JMS API also supports unidentified
+     * message producers, which require that the topic be supplied every time a message is published.
+     *
+     * @param topic the topic to publish this message to
+     * @param message the message to publish
+     *
+     * @exception JMSException if the JMS provider fails to publish the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid topic.
+     *
+     * @see javax.jms.MessageProducer#getDeliveryMode()
+     * @see javax.jms.MessageProducer#getTimeToLive()
+     * @see javax.jms.MessageProducer#getPriority()
+     */
+    void publish(Topic topic, Message message) throws JMSException;
 
-
-    /** Publishes a message to the topic, specifying delivery mode,
-      * priority, and time to live.
-      *
-      * @param message the message to publish
-      * @param deliveryMode the delivery mode to use
-      * @param priority the priority for this message
-      * @param timeToLive the message's lifetime (in milliseconds)
-      *
-      * @exception JMSException if the JMS provider fails to publish the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses this method
-      *                         with a {@code TopicPublisher} with
-      *                         an invalid topic.
-      * @exception java.lang.UnsupportedOperationException if a client uses this
-      *                         method with a {@code TopicPublisher} that
-      *                         did not specify a topic at creation time.
-      */
- 
-    void
-    publish(Message message, 
-            int deliveryMode, 
-	    int priority,
-	    long timeToLive) throws JMSException;
-
-
-    /** Publishes a message to a topic for an unidentified message producer. 
-      * Uses the {@code TopicPublisher}'s default delivery mode, 
-      * priority, and time to live.
-      *  
-      * <P>Typically, a message producer is assigned a topic at creation 
-      * time; however, the JMS API also supports unidentified message producers,
-      * which require that the topic be supplied every time a message is
-      * published.
-      *
-      * @param topic the topic to publish this message to
-      * @param message the message to publish
-      *  
-      * @exception JMSException if the JMS provider fails to publish the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses
-      *                         this method with an invalid topic.
-      * 
-      * @see javax.jms.MessageProducer#getDeliveryMode()
-      * @see javax.jms.MessageProducer#getTimeToLive()
-      * @see javax.jms.MessageProducer#getPriority()
-      */ 
-
-    void
-    publish(Topic topic, Message message) throws JMSException;
-
-
-    /** Publishes a message to a topic for an unidentified message 
-      * producer, specifying delivery mode, priority and time to live.
-      *  
-      * <P>Typically, a message producer is assigned a topic at creation
-      * time; however, the JMS API also supports unidentified message producers,
-      * which require that the topic be supplied every time a message is
-      * published.
-      *
-      * @param topic the topic to publish this message to
-      * @param message the message to publish
-      * @param deliveryMode the delivery mode to use
-      * @param priority the priority for this message
-      * @param timeToLive the message's lifetime (in milliseconds)
-      *  
-      * @exception JMSException if the JMS provider fails to publish the message
-      *                         due to some internal error.
-      * @exception MessageFormatException if an invalid message is specified.
-      * @exception InvalidDestinationException if a client uses
-      *                         this method with an invalid topic.
-      */ 
-
-    void
-    publish(Topic topic, 
-            Message message, 
-            int deliveryMode, 
-            int priority,
-	    long timeToLive) throws JMSException;
+    /**
+     * Publishes a message to a topic for an unidentified message producer, specifying delivery mode, priority and time to
+     * live.
+     *
+     * <p>
+     * Typically, a message producer is assigned a topic at creation time; however, the JMS API also supports unidentified
+     * message producers, which require that the topic be supplied every time a message is published.
+     *
+     * @param topic the topic to publish this message to
+     * @param message the message to publish
+     * @param deliveryMode the delivery mode to use
+     * @param priority the priority for this message
+     * @param timeToLive the message's lifetime (in milliseconds)
+     *
+     * @exception JMSException if the JMS provider fails to publish the message due to some internal error.
+     * @exception MessageFormatException if an invalid message is specified.
+     * @exception InvalidDestinationException if a client uses this method with an invalid topic.
+     */
+    void publish(Topic topic, Message message, int deliveryMode, int priority, long timeToLive) throws JMSException;
 }

--- a/src/main/java/javax/jms/TopicRequestor.java
+++ b/src/main/java/javax/jms/TopicRequestor.java
@@ -16,103 +16,88 @@
 
 package javax.jms;
 
-/** The {@code TopicRequestor} helper class simplifies
-  * making service requests.
-  *
-  * <P>The {@code TopicRequestor} constructor is given a non-transacted 
-  * {@code TopicSession} and a destination {@code Topic}. It creates a 
-  * {@code TemporaryTopic} for the responses and provides a 
-  * {@code request} method that sends the request message and waits 
-  * for its reply.
-  * <p>
-  * This is a very basic request/reply abstraction which assumes the session 
-  * is non-transacted with a delivery mode of either AUTO_ACKNOWLEDGE or 
-  * DUPS_OK_ACKNOWLEDGE. It is expected that most applications will create 
-  * less basic implementations.
-  * 
-  * @see javax.jms.QueueRequestor
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * The {@code TopicRequestor} helper class simplifies making service requests.
+ *
+ * <p>
+ * The {@code TopicRequestor} constructor is given a non-transacted {@code TopicSession} and a destination
+ * {@code Topic}. It creates a {@code TemporaryTopic} for the responses and provides a {@code request} method that sends
+ * the request message and waits for its reply.
+ *
+ * <p>
+ * This is a very basic request/reply abstraction which assumes the session is non-transacted with a delivery mode of
+ * either AUTO_ACKNOWLEDGE or DUPS_OK_ACKNOWLEDGE. It is expected that most applications will create less basic
+ * implementations.
+ *
+ * @see javax.jms.QueueRequestor
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public class TopicRequestor {
 
-    TopicSession    session;    // The topic session the topic belongs to.
-    TemporaryTopic  tempTopic;
-    TopicPublisher  publisher;
+    TopicSession session; // The topic session the topic belongs to.
+    TemporaryTopic tempTopic;
+    TopicPublisher publisher;
     TopicSubscriber subscriber;
 
+    /**
+     * Constructor for the {@code TopicRequestor} class.
+     *
+     * <p>
+     * This implementation assumes the session parameter to be non-transacted, with a delivery mode of either
+     * {@code AUTO_ACKNOWLEDGE} or {@code DUPS_OK_ACKNOWLEDGE}.
+     *
+     * @param session the {@code TopicSession} the topic belongs to
+     * @param topic the topic to perform the request/reply call on
+     *
+     * @exception JMSException if the JMS provider fails to create the {@code TopicRequestor} due to some internal error.
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     */
 
-    /** Constructor for the {@code TopicRequestor} class.
-      * 
-      * <P>This implementation assumes the session parameter to be non-transacted,
-      * with a delivery mode of either {@code AUTO_ACKNOWLEDGE} or 
-      * {@code DUPS_OK_ACKNOWLEDGE}.
-      *
-      * @param session the {@code TopicSession} the topic belongs to
-      * @param topic the topic to perform the request/reply call on
-      *
-      * @exception JMSException if the JMS provider fails to create the
-      *                         {@code TopicRequestor} due to some internal
-      *                         error.
-      * @exception InvalidDestinationException if an invalid topic is specified.
-      */ 
+    public TopicRequestor(TopicSession session, Topic topic) throws JMSException {
+        if (topic == null) {
+            throw new InvalidDestinationException("topic==null");
+        }
 
-    public 
-    TopicRequestor(TopicSession session, Topic topic) throws JMSException {
-    	
-    	if (topic==null) throw new InvalidDestinationException("topic==null");
-
-	    this.session = session;
-        tempTopic    = session.createTemporaryTopic();
-        publisher    = session.createPublisher(topic);
-        subscriber   = session.createSubscriber(tempTopic);
+        this.session = session;
+        tempTopic = session.createTemporaryTopic();
+        publisher = session.createPublisher(topic);
+        subscriber = session.createSubscriber(tempTopic);
     }
 
-
-    /** Sends a request and waits for a reply. The temporary topic is used for
-      * the {@code JMSReplyTo} destination; the first reply is returned, 
-      * and any following replies are discarded.
-      *
-      * @param message the message to send
-      *  
-      * @return the reply message
-      *  
-      * @exception JMSException if the JMS provider fails to complete the
-      *                         request due to some internal error.
-      */
-
-    public Message
-    request(Message message) throws JMSException {
-	message.setJMSReplyTo(tempTopic);
+    /**
+     * Sends a request and waits for a reply. The temporary topic is used for the {@code JMSReplyTo} destination; the first
+     * reply is returned, and any following replies are discarded.
+     *
+     * @param message the message to send
+     *
+     * @return the reply message
+     *
+     * @exception JMSException if the JMS provider fails to complete the request due to some internal error.
+     */
+    public Message request(Message message) throws JMSException {
+        message.setJMSReplyTo(tempTopic);
         publisher.publish(message);
-	return(subscriber.receive());
+        return (subscriber.receive());
     }
 
-
-    /** Closes the {@code TopicRequestor} and its session.
-      *
-      * <P>Since a provider may allocate some resources on behalf of a 
-      * {@code TopicRequestor} outside the Java virtual machine, clients 
-      * should close them when they 
-      * are not needed. Relying on garbage collection to eventually reclaim 
-      * these resources may not be timely enough.
-      *
-      * <P>Note that this method closes the {@code TopicSession} object 
-      * passed to the {@code TopicRequestor} constructor.
-      *  
-      * @exception JMSException if the JMS provider fails to close the
-      *                         {@code TopicRequestor} due to some internal
-      *                         error.
-      */
-
-    public void
-    close() throws JMSException {
-
-	// publisher and consumer created by constructor are implicitly closed.
-	session.close();
-	tempTopic.delete();
+    /**
+     * Closes the {@code TopicRequestor} and its session.
+     *
+     * <p>
+     * Since a provider may allocate some resources on behalf of a {@code TopicRequestor} outside the Java virtual machine,
+     * clients should close them when they are not needed. Relying on garbage collection to eventually reclaim these
+     * resources may not be timely enough.
+     *
+     * <p>
+     * Note that this method closes the {@code TopicSession} object passed to the {@code TopicRequestor} constructor.
+     *
+     * @exception JMSException if the JMS provider fails to close the {@code TopicRequestor} due to some internal error.
+     */
+    public void close() throws JMSException {
+        // publisher and consumer created by constructor are implicitly closed.
+        session.close();
+        tempTopic.delete();
     }
 }

--- a/src/main/java/javax/jms/TopicSession.java
+++ b/src/main/java/javax/jms/TopicSession.java
@@ -16,377 +16,314 @@
 
 package javax.jms;
 
-/** A {@code TopicSession} object provides methods for creating 
-  * {@code TopicPublisher}, {@code TopicSubscriber}, and 
-  * {@code TemporaryTopic} objects. It also provides a method for 
-  * deleting its client's durable subscribers.
-  *
-  *<P>A {@code TopicSession} is used for creating Pub/Sub specific
-  * objects. In general, use the  {@code Session} object, and 
-  *  use {@code TopicSession}  only to support
-  * existing code. Using the {@code Session} object simplifies the 
-  * programming model, and allows transactions to be used across the two 
-  * messaging domains.
-  * 
-  * <P>A {@code TopicSession} cannot be used to create objects specific to the 
-  * point-to-point domain. The following methods inherit from 
-  * {@code Session}, but must throw an 
-  * {@code IllegalStateException} 
-  * if used from {@code TopicSession}:
-  *<UL>
-  *   <LI>{@code createBrowser}
-  *   <LI>{@code createQueue}
-  *   <LI>{@code createTemporaryQueue}
-  *</UL>
-  *
-  * @see javax.jms.Session
-  * @see javax.jms.Connection#createSession(boolean, int)
-  * @see javax.jms.TopicConnection#createTopicSession(boolean, int)
-  * @see javax.jms.XATopicSession#getTopicSession()
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A {@code TopicSession} object provides methods for creating {@code TopicPublisher}, {@code TopicSubscriber}, and
+ * {@code TemporaryTopic} objects. It also provides a method for deleting its client's durable subscribers.
+ *
+ * <p>
+ * A {@code TopicSession} is used for creating Pub/Sub specific objects. In general, use the {@code Session} object, and
+ * use {@code TopicSession} only to support existing code. Using the {@code Session} object simplifies the programming
+ * model, and allows transactions to be used across the two messaging domains.
+ *
+ * <p>
+ * A {@code TopicSession} cannot be used to create objects specific to the point-to-point domain. The following methods
+ * inherit from {@code Session}, but must throw an {@code IllegalStateException} if used from {@code TopicSession}:
+ *
+ * <ul>
+ * <li>{@code createBrowser}
+ * <li>{@code createQueue}
+ * <li>{@code createTemporaryQueue}
+ * </ul>
+ *
+ * @see javax.jms.Session
+ * @see javax.jms.Connection#createSession(boolean, int)
+ * @see javax.jms.TopicConnection#createTopicSession(boolean, int)
+ * @see javax.jms.XATopicSession#getTopicSession()
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TopicSession extends Session {
 
-    /** Creates a topic identity given a {@code Topic} name.
-      *
-      * <P>This facility is provided for the rare cases where clients need to
-      * dynamically manipulate topic identity. This allows the creation of a
-      * topic identity with a provider-specific name. Clients that depend 
-      * on this ability are not portable.
-      *
-      * <P>Note that this method is not for creating the physical topic. 
-      * The physical creation of topics is an administrative task and is not
-      * to be initiated by the JMS API. The one exception is the
-      * creation of temporary topics, which is accomplished with the 
-      * {@code createTemporaryTopic} method.
-      *  
-      * @param topicName the name of this {@code Topic}
-      *
-      * @return a {@code Topic} with the given name
-      *
-      * @exception JMSException if the session fails to create a topic
-      *                         due to some internal error.
-      */
-
-    Topic
-    createTopic(String topicName) throws JMSException;
-
-
-    /** Creates a nondurable subscriber to the specified topic.
-      *  
-      * <P>A client uses a {@code TopicSubscriber} object to receive 
-      * messages that have been published to a topic.
-      *
-      * <P>Regular {@code TopicSubscriber} objects are not durable. 
-      * They receive only messages that are published while they are active.
-      *
-      * <P>In some cases, a connection may both publish and subscribe to a 
-      * topic. The subscriber {@code NoLocal} attribute allows a subscriber
-      * to inhibit the delivery of messages published by its own connection.
-      * The default value for this attribute is false.
-      *
-      * @param topic the {@code Topic} to subscribe to
-      *  
-      * @exception JMSException if the session fails to create a subscriber
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid topic is specified.
-      */ 
-
-    TopicSubscriber
-    createSubscriber(Topic topic) throws JMSException;
-
-
-    /** Creates a nondurable subscriber to the specified topic, using a
-      * message selector or specifying whether messages published by its
-      * own connection should be delivered to it.
-      *
-      * <P>A client uses a {@code TopicSubscriber} object to receive 
-      * messages that have been published to a topic.
-      *  
-      * <P>Regular {@code TopicSubscriber} objects are not durable. 
-      * They receive only messages that are published while they are active.
-      *
-      * <P>Messages filtered out by a subscriber's message selector will 
-      * never be delivered to the subscriber. From the subscriber's 
-      * perspective, they do not exist.
-      *
-      * <P>In some cases, a connection may both publish and subscribe to a 
-      * topic. The subscriber {@code NoLocal} attribute allows a subscriber
-      * to inhibit the delivery of messages published by its own connection.
-      * The default value for this attribute is false.
-      *
-      * @param topic the {@code Topic} to subscribe to
-      * @param messageSelector only messages with properties matching the
-      * message selector expression are delivered. A value of null or
-      * an empty string indicates that there is no message selector 
-      * for the message consumer.
-      * @param noLocal if set, inhibits the delivery of messages published
-      * by its own connection
-      * 
-      * @exception JMSException if the session fails to create a subscriber
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid topic is specified.
-      * @exception InvalidSelectorException if the message selector is invalid.
-      */
-
-    TopicSubscriber 
-    createSubscriber(Topic topic, 
-		     String messageSelector,
-		     boolean noLocal) throws JMSException;
-
-
-	/**
-	 * Creates an unshared durable subscription on the specified topic (if one
-	 * does not already exist) and creates a consumer on that durable
-	 * subscription. 
-  	 * This method creates the durable subscription without a message selector 
-  	 * and with a {@code noLocal} value of {@code false}. 
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with non-shared durable subscriptions. Any
-	 * durable subscription created using this method will be non-shared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by
-	 * the client and by the client identifier, which must be set. An
-	 * application which subsequently wishes to create a consumer on that
-	 * non-shared durable subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name
-	 * and client identifier and the same topic and message selector, and there
-	 * is no consumer already active (i.e. not closed) on the durable
-	 * subscription, and no consumed messages from that subscription are still
-	 * part of a pending transaction or are not yet acknowledged in the session,
-	 * then this method creates a {@code TopicSubscriber} on the existing
-	 * durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name
-	 * and client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, or consumed messages from that
-	 * subscription are still part of a pending transaction or are not yet
-	 * acknowledged in the session, then a {@code JMSException} will be thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name
-	 * and client identifier but a different topic, message selector or {@code noLocal}
-	 * value has been specified, and there is no consumer already active (i.e.
-	 * not closed) on the durable subscription, and no consumed messages from
-	 * that subscription are still part of a pending transaction or are not yet
-	 * acknowledged in the session, then the durable subscription will be
-	 * deleted and a new one created.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSException} is thrown.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable subscriptions having
-	 * the same name and clientId. Such subscriptions would be completely
-	 * separate.
-	 * <p>
-	 * This method is identical to the corresponding
-	 * {@code createDurableConsumer} method except that it returns a
-	 * {@code TopicSubscriber} rather than a {@code MessageConsumer} to
-	 * represent the consumer.
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @exception InvalidDestinationException
-	 *                if an invalid topic is specified.
-	 * @exception JMSException
-	 *                <ul>
-	 *                <li>if the session fails to create the non-shared durable
-	 *                subscription and {@code TopicSubscriber} due to some
-	 *                internal error 
-	 *                <li>if the client identifier is unset 
-	 *                <li>
-	 *                if an unshared durable subscription already exists with
-	 *                the same name and client identifier, and there is a
-	 *                consumer already active 
-	 *                <li>if a shared durable subscription already exists 
-	 *                with the same name and client identifier
-	 *                </ul>
-	 *
-	 */
-    TopicSubscriber createDurableSubscriber(Topic topic, 
-			    String name) throws JMSException;
-
-	/**
-	 * Creates an unshared durable subscription on the specified topic (if one
-	 * does not already exist), specifying a message selector and the
-	 * {@code noLocal} parameter, and creates a consumer on that durable
-	 * subscription.
-	 * <p>
-	 * A durable subscription is used by an application which needs to receive
-	 * all the messages published on a topic, including the ones published when
-	 * there is no active consumer associated with it. The JMS provider retains
-	 * a record of this durable subscription and ensures that all messages from
-	 * the topic's publishers are retained until they are delivered to, and
-	 * acknowledged by, a consumer on this durable subscription or until they
-	 * have expired.
-	 * <p>
-	 * A durable subscription will continue to accumulate messages until it is
-	 * deleted using the {@code unsubscribe} method.
-	 * <p>
-	 * This method may only be used with non-shared durable subscriptions. Any
-	 * durable subscription created using this method will be non-shared. This
-	 * means that only one active (i.e. not closed) consumer on the subscription
-	 * may exist at a time. The term "consumer" here means a
-	 * {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
-	 * object in any client.
-	 * <p>
-	 * An unshared durable subscription is identified by a name specified by
-	 * the client and by the client identifier, which must be set. An
-	 * application which subsequently wishes to create a consumer on that
-	 * non-shared durable subscription must use the same client identifier.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name
-	 * and client identifier and the same topic and message selector, and there
-	 * is no consumer already active (i.e. not closed) on the durable
-	 * subscription, and no consumed messages from that subscription are still
-	 * part of a pending transaction or are not yet acknowledged in the session,
-	 * then this method creates a {@code TopicSubscriber} on the existing
-	 * durable subscription.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name
-	 * and client identifier, and there is a consumer already active (i.e. not
-	 * closed) on the durable subscription, or consumed messages from that
-	 * subscription are still part of a pending transaction or are not yet
-	 * acknowledged in the session, then a {@code JMSException} will be thrown.
-	 * <p>
-	 * If an unshared durable subscription already exists with the same name
-	 * and client identifier but a different topic, message selector or {@code noLocal}
-	 * value has been specified, and there is no consumer already active (i.e.
-	 * not closed) on the durable subscription, and no consumed messages from
-	 * that subscription are still part of a pending transaction or are not yet
-	 * acknowledged in the session, then the durable subscription will be
-	 * deleted and a new one created.
-	 * <p>
-	 * A shared durable subscription and an unshared durable subscription may
-	 * not have the same name and client identifier. If a shared durable
-	 * subscription already exists with the same name and client identifier then
-	 * a {@code JMSException} is thrown.
-	 * <p>
-	 * If {@code noLocal} is set to true then any messages published to the
-	 * topic using this session's connection, or any other connection with the
-	 * same client identifier, will not be added to the durable subscription.
-	 * <p>
-	 * There is no restriction on durable subscriptions and shared non-durable subscriptions having
-	 * the same name and clientId. Such subscriptions would be completely
-	 * separate.
-	 * <p>
-	 * This method is identical to the corresponding
-	 * {@code createDurableConsumer} method except that it returns a
-	 * {@code TopicSubscriber} rather than a {@code MessageConsumer} to
-	 * represent the consumer.
-	 * 
-	 * @param topic
-	 *            the non-temporary {@code Topic} to subscribe to
-	 * @param name
-	 *            the name used to identify this subscription
-	 * @param messageSelector
-	 *            only messages with properties matching the message selector
-	 *            expression are added to the durable subscription. A value of
-	 *            null or an empty string indicates that there is no message
-	 *            selector for the durable subscription.
-	 * @param noLocal
-	 *            if true then any messages published to the topic using this
-	 *            session's connection, or any other connection with the same
-	 *            client identifier, will not be added to the durable
-	 *            subscription.
-	 * @exception InvalidDestinationException
-	 *                if an invalid topic is specified.
-	 * @exception InvalidSelectorException
-	 *                if the message selector is invalid.
-	 * @exception JMSException
-	 *                <ul>
-	 *                <li>if the session fails to create the non-shared durable
-	 *                subscription and {@code TopicSubscriber} due to some
-	 *                internal error 
-	 *                <li>if the client identifier is unset 
-	 *                <li>
-	 *                if an unshared durable subscription already exists with
-	 *                the same name and client identifier, and there is a
-	 *                consumer already active 
-	 *                <li>if a shared durable
-	 *                subscription already exists with the same name and client
-	 *                identifier
-	 *                </ul>
-	 *                
-	 */
-	TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal)
-			throws JMSException;
-
-    /** Creates a publisher for the specified topic.
-      *
-      * <P>A client uses a {@code TopicPublisher} object to publish 
-      * messages on a topic.
-      * Each time a client creates a {@code TopicPublisher} on a topic, it
-      * defines a 
-      * new sequence of messages that have no ordering relationship with the 
-      * messages it has previously sent.
-      *
-      * @param topic the {@code Topic} to publish to, or null if this is an
-      * unidentified producer
-      *
-      * @exception JMSException if the session fails to create a publisher
-      *                         due to some internal error.
-      * @exception InvalidDestinationException if an invalid topic is specified.
+    /**
+     * Creates a topic identity given a {@code Topic} name.
+     *
+     * <p>
+     * This facility is provided for the rare cases where clients need to dynamically manipulate topic identity. This allows
+     * the creation of a topic identity with a provider-specific name. Clients that depend on this ability are not portable.
+     *
+     * <p>
+     * Note that this method is not for creating the physical topic. The physical creation of topics is an administrative
+     * task and is not to be initiated by the JMS API. The one exception is the creation of temporary topics, which is
+     * accomplished with the {@code createTemporaryTopic} method.
+     *
+     * @param topicName the name of this {@code Topic}
+     *
+     * @return a {@code Topic} with the given name
+     *
+     * @exception JMSException if the session fails to create a topic due to some internal error.
      */
+    @Override
+    Topic createTopic(String topicName) throws JMSException;
 
-    TopicPublisher 
-    createPublisher(Topic topic) throws JMSException;
+    /**
+     * Creates a nondurable subscriber to the specified topic.
+     *
+     * <p>
+     * A client uses a {@code TopicSubscriber} object to receive messages that have been published to a topic.
+     *
+     * <p>
+     * Regular {@code TopicSubscriber} objects are not durable. They receive only messages that are published while they are
+     * active.
+     *
+     * <p>
+     * In some cases, a connection may both publish and subscribe to a topic. The subscriber {@code NoLocal} attribute
+     * allows a subscriber to inhibit the delivery of messages published by its own connection. The default value for this
+     * attribute is false.
+     *
+     * @param topic the {@code Topic} to subscribe to
+     *
+     * @return A nondurable subscriber to the specified topic.
+     *
+     * @exception JMSException if the session fails to create a subscriber due to some internal error.
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     */
+    TopicSubscriber createSubscriber(Topic topic) throws JMSException;
 
+    /**
+     * Creates a nondurable subscriber to the specified topic, using a message selector or specifying whether messages
+     * published by its own connection should be delivered to it.
+     *
+     * <p>
+     * A client uses a {@code TopicSubscriber} object to receive messages that have been published to a topic.
+     *
+     * <p>
+     * Regular {@code TopicSubscriber} objects are not durable. They receive only messages that are published while they are
+     * active.
+     *
+     * <p>
+     * Messages filtered out by a subscriber's message selector will never be delivered to the subscriber. From the
+     * subscriber's perspective, they do not exist.
+     *
+     * <p>
+     * In some cases, a connection may both publish and subscribe to a topic. The subscriber {@code NoLocal} attribute
+     * allows a subscriber to inhibit the delivery of messages published by its own connection. The default value for this
+     * attribute is false.
+     *
+     * @param topic the {@code Topic} to subscribe to
+     * @param messageSelector only messages with properties matching the message selector expression are delivered. A value
+     * of null or an empty string indicates that there is no message selector for the message consumer.
+     * @param noLocal if set, inhibits the delivery of messages published by its own connection
+     *
+     * @return A nondurable subscriber to the specified topic.
+     *
+     * @exception JMSException if the session fails to create a subscriber due to some internal error.
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     */
+    TopicSubscriber createSubscriber(Topic topic, String messageSelector, boolean noLocal) throws JMSException;
 
-    /** Creates a {@code TemporaryTopic} object. Its lifetime will be that 
-      * of the {@code TopicConnection} unless it is deleted earlier.
-      *
-      * @return a temporary topic identity
-      *
-      * @exception JMSException if the session fails to create a temporary
-      *                         topic due to some internal error.
-      */
- 
-    TemporaryTopic
-    createTemporaryTopic() throws JMSException;
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist) and creates a
+     * consumer on that durable subscription. This method creates the durable subscription without a message selector and
+     * with a {@code noLocal} value of {@code false}.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with non-shared durable subscriptions. Any durable subscription created using this
+     * method will be non-shared. This means that only one active (i.e. not closed) consumer on the subscription may exist
+     * at a time. The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
+     * object in any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that non-shared durable subscription
+     * must use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier and the same topic and
+     * message selector, and there is no consumer already active (i.e. not closed) on the durable subscription, and no
+     * consumed messages from that subscription are still part of a pending transaction or are not yet acknowledged in the
+     * session, then this method creates a {@code TopicSubscriber} on the existing durable subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, or consumed messages from that subscription are still
+     * part of a pending transaction or are not yet acknowledged in the session, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription, and no consumed messages from that subscription are still part of a pending
+     * transaction or are not yet acknowledged in the session, then the durable subscription will be deleted and a new one
+     * created.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a {@code JMSException}
+     * is thrown.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableConsumer} method except that it returns a
+     * {@code TopicSubscriber} rather than a {@code MessageConsumer} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     *
+     * @return An unshared durable subscription on the specified topic.
+     *
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the non-shared durable subscription and {@code TopicSubscriber} due to some
+     * internal error
+     * <li>if the client identifier is unset
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     */
+    @Override
+    TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException;
 
+    /**
+     * Creates an unshared durable subscription on the specified topic (if one does not already exist), specifying a message
+     * selector and the {@code noLocal} parameter, and creates a consumer on that durable subscription.
+     *
+     * <p>
+     * A durable subscription is used by an application which needs to receive all the messages published on a topic,
+     * including the ones published when there is no active consumer associated with it. The JMS provider retains a record
+     * of this durable subscription and ensures that all messages from the topic's publishers are retained until they are
+     * delivered to, and acknowledged by, a consumer on this durable subscription or until they have expired.
+     *
+     * <p>
+     * A durable subscription will continue to accumulate messages until it is deleted using the {@code unsubscribe} method.
+     *
+     * <p>
+     * This method may only be used with non-shared durable subscriptions. Any durable subscription created using this
+     * method will be non-shared. This means that only one active (i.e. not closed) consumer on the subscription may exist
+     * at a time. The term "consumer" here means a {@code TopicSubscriber}, {@code  MessageConsumer} or {@code JMSConsumer}
+     * object in any client.
+     *
+     * <p>
+     * An unshared durable subscription is identified by a name specified by the client and by the client identifier, which
+     * must be set. An application which subsequently wishes to create a consumer on that non-shared durable subscription
+     * must use the same client identifier.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier and the same topic and
+     * message selector, and there is no consumer already active (i.e. not closed) on the durable subscription, and no
+     * consumed messages from that subscription are still part of a pending transaction or are not yet acknowledged in the
+     * session, then this method creates a {@code TopicSubscriber} on the existing durable subscription.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier, and there is a consumer
+     * already active (i.e. not closed) on the durable subscription, or consumed messages from that subscription are still
+     * part of a pending transaction or are not yet acknowledged in the session, then a {@code JMSException} will be thrown.
+     *
+     * <p>
+     * If an unshared durable subscription already exists with the same name and client identifier but a different topic,
+     * message selector or {@code noLocal} value has been specified, and there is no consumer already active (i.e. not
+     * closed) on the durable subscription, and no consumed messages from that subscription are still part of a pending
+     * transaction or are not yet acknowledged in the session, then the durable subscription will be deleted and a new one
+     * created.
+     *
+     * <p>
+     * A shared durable subscription and an unshared durable subscription may not have the same name and client identifier.
+     * If a shared durable subscription already exists with the same name and client identifier then a {@code JMSException}
+     * is thrown.
+     *
+     * <p>
+     * If {@code noLocal} is set to true then any messages published to the topic using this session's connection, or any
+     * other connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * <p>
+     * There is no restriction on durable subscriptions and shared non-durable subscriptions having the same name and
+     * clientId. Such subscriptions would be completely separate.
+     *
+     * <p>
+     * This method is identical to the corresponding {@code createDurableConsumer} method except that it returns a
+     * {@code TopicSubscriber} rather than a {@code MessageConsumer} to represent the consumer.
+     *
+     * @param topic the non-temporary {@code Topic} to subscribe to
+     * @param name the name used to identify this subscription
+     * @param messageSelector only messages with properties matching the message selector expression are added to the
+     * durable subscription. A value of null or an empty string indicates that there is no message selector for the durable
+     * subscription.
+     * @param noLocal if true then any messages published to the topic using this session's connection, or any other
+     * connection with the same client identifier, will not be added to the durable subscription.
+     *
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     * @exception InvalidSelectorException if the message selector is invalid.
+     * @exception JMSException
+     * <ul>
+     * <li>if the session fails to create the non-shared durable subscription and {@code TopicSubscriber} due to some
+     * internal error
+     * <li>if the client identifier is unset
+     * <li>if an unshared durable subscription already exists with the same name and client identifier, and there is a
+     * consumer already active
+     * <li>if a shared durable subscription already exists with the same name and client identifier
+     * </ul>
+     */
+    @Override
+    TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal) throws JMSException;
 
-    /** Unsubscribes a durable subscription that has been created by a client.
-      *  
-      * <P>This method deletes the state being maintained on behalf of the 
-      * subscriber by its provider.
-      *
-      * <P>It is erroneous for a client to delete a durable subscription
-      * while there is an active {@code TopicSubscriber} for the 
-      * subscription, or while a consumed message is part of a pending 
-      * transaction or has not been acknowledged in the session.
-      *
-      * @param name the name used to identify this subscription
-      *  
-      * @exception JMSException if the session fails to unsubscribe to the 
-      *                         durable subscription due to some internal error.
-      * @exception InvalidDestinationException if an invalid subscription name
-      *                                        is specified.
-      */
+    /**
+     * Creates a publisher for the specified topic.
+     *
+     * <p>
+     * A client uses a {@code TopicPublisher} object to publish messages on a topic. Each time a client creates a
+     * {@code TopicPublisher} on a topic, it defines a new sequence of messages that have no ordering relationship with the
+     * messages it has previously sent.
+     *
+     * @param topic the {@code Topic} to publish to, or null if this is an unidentified producer
+     *
+     * @return A publisher for the specified topic.
+     *
+     * @exception JMSException if the session fails to create a publisher due to some internal error.
+     * @exception InvalidDestinationException if an invalid topic is specified.
+     */
+    TopicPublisher createPublisher(Topic topic) throws JMSException;
 
-    void
-    unsubscribe(String name) throws JMSException;
+    /**
+     * Creates a {@code TemporaryTopic} object. Its lifetime will be that of the {@code TopicConnection} unless it is
+     * deleted earlier.
+     *
+     * @return a temporary topic identity
+     *
+     * @exception JMSException if the session fails to create a temporary topic due to some internal error.
+     */
+    @Override
+    TemporaryTopic createTemporaryTopic() throws JMSException;
+
+    /**
+     * Unsubscribes a durable subscription that has been created by a client.
+     *
+     * <p>
+     * This method deletes the state being maintained on behalf of the subscriber by its provider.
+     *
+     * <p>
+     * It is erroneous for a client to delete a durable subscription while there is an active {@code TopicSubscriber} for
+     * the subscription, or while a consumed message is part of a pending transaction or has not been acknowledged in the
+     * session.
+     *
+     * @param name the name used to identify this subscription
+     *
+     * @exception JMSException if the session fails to unsubscribe to the durable subscription due to some internal error.
+     * @exception InvalidDestinationException if an invalid subscription name is specified.
+     */
+    @Override
+    void unsubscribe(String name) throws JMSException;
 }

--- a/src/main/java/javax/jms/TopicSubscriber.java
+++ b/src/main/java/javax/jms/TopicSubscriber.java
@@ -16,100 +16,84 @@
 
 package javax.jms;
 
-/** A client uses a {@code TopicSubscriber} object to receive messages that
-  * have been published to a topic. A {@code TopicSubscriber} object is the
-  * publish/subscribe form of a message consumer. A {@code MessageConsumer}
-  * can be created by using {@code Session.createConsumer}. 
-  *
-  * <P>A {@code TopicSession} allows the creation of multiple 
-  * {@code TopicSubscriber} objects per topic.  It will deliver each 
-  * message for a topic to each
-  * subscriber eligible to receive it. Each copy of the message
-  * is treated as a completely separate message. Work done on one copy has
-  * no effect on the others; acknowledging one does not acknowledge the
-  * others; one message may be delivered immediately, while another waits
-  * for its subscriber to process messages ahead of it.
-  *
-  * <P>Regular {@code TopicSubscriber} objects are not durable. They 
-  * receive only messages that are published while they are active.
-  *
-  * <P>Messages filtered out by a subscriber's message selector will never 
-  * be delivered to the subscriber. From the subscriber's perspective, they 
-  * do not exist.
-  *
-  * <P>In some cases, a connection may both publish and subscribe to a topic.
-  * The subscriber {@code NoLocal} attribute allows a subscriber to inhibit
-  * the 
-  * delivery of messages published by its own connection.
-  *
-  * <P>If a client needs to receive all the messages published on a topic, 
-  * including the ones published while the subscriber is inactive, it uses 
-  * a durable {@code TopicSubscriber}. The JMS provider retains a record of
-  * this durable 
-  * subscription and insures that all messages from the topic's publishers 
-  * are retained until they are acknowledged by this durable 
-  * subscriber or they have expired.
-  *
-  * <P>Sessions with durable subscribers must always provide the same client 
-  * identifier. In addition, each client must specify a name that uniquely 
-  * identifies (within client identifier) each durable subscription it creates.
-  * Only one session at a time can have a {@code TopicSubscriber} for a 
-  * particular durable subscription. 
-  *
-  * <P>A client can change an existing durable subscription by creating a 
-  * durable {@code TopicSubscriber} with the same name and a new topic 
-  * and/or message 
-  * selector. Changing a durable subscription is equivalent to unsubscribing 
-  * (deleting) the old one and creating a new one.
-  *
-  * <P>The {@code unsubscribe} method is used to delete a durable 
-  * subscription. The {@code unsubscribe} method can be used at the 
-  * {@code Session} or {@code TopicSession} level.
-  * This method deletes the state being 
-  * maintained on behalf of the subscriber by its provider.
-  *
-  * <P>Creating a {@code MessageConsumer} provides the same features as
-  * creating a {@code TopicSubscriber}. To create a durable subscriber, 
-  * use of {@code Session.CreateDurableSubscriber} is recommended. The 
-  * {@code TopicSubscriber} is provided to support existing code.
-  * 
-  * @see         javax.jms.Session#createConsumer
-  * @see         javax.jms.Session#createDurableSubscriber
-  * @see         javax.jms.TopicSession
-  * @see         javax.jms.TopicSession#createSubscriber
-  * @see         javax.jms.MessageConsumer
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * A client uses a {@code TopicSubscriber} object to receive messages that have been published to a topic. A
+ * {@code TopicSubscriber} object is the publish/subscribe form of a message consumer. A {@code MessageConsumer} can be
+ * created by using {@code Session.createConsumer}.
+ *
+ * <p>
+ * A {@code TopicSession} allows the creation of multiple {@code TopicSubscriber} objects per topic. It will deliver
+ * each message for a topic to each subscriber eligible to receive it. Each copy of the message is treated as a
+ * completely separate message. Work done on one copy has no effect on the others; acknowledging one does not
+ * acknowledge the others; one message may be delivered immediately, while another waits for its subscriber to process
+ * messages ahead of it.
+ *
+ * <p>
+ * Regular {@code TopicSubscriber} objects are not durable. They receive only messages that are published while they are
+ * active.
+ *
+ * <p>
+ * Messages filtered out by a subscriber's message selector will never be delivered to the subscriber. From the
+ * subscriber's perspective, they do not exist.
+ *
+ * <p>
+ * In some cases, a connection may both publish and subscribe to a topic. The subscriber {@code NoLocal} attribute
+ * allows a subscriber to inhibit the delivery of messages published by its own connection.
+ *
+ * <p>
+ * If a client needs to receive all the messages published on a topic, including the ones published while the subscriber
+ * is inactive, it uses a durable {@code TopicSubscriber}. The JMS provider retains a record of this durable
+ * subscription and insures that all messages from the topic's publishers are retained until they are acknowledged by
+ * this durable subscriber or they have expired.
+ *
+ * <p>
+ * Sessions with durable subscribers must always provide the same client identifier. In addition, each client must
+ * specify a name that uniquely identifies (within client identifier) each durable subscription it creates. Only one
+ * session at a time can have a {@code TopicSubscriber} for a particular durable subscription.
+ *
+ * <p>
+ * A client can change an existing durable subscription by creating a durable {@code TopicSubscriber} with the same name
+ * and a new topic and/or message selector. Changing a durable subscription is equivalent to unsubscribing (deleting)
+ * the old one and creating a new one.
+ *
+ * <p>
+ * The {@code unsubscribe} method is used to delete a durable subscription. The {@code unsubscribe} method can be used
+ * at the {@code Session} or {@code TopicSession} level. This method deletes the state being maintained on behalf of the
+ * subscriber by its provider.
+ *
+ * <p>
+ * Creating a {@code MessageConsumer} provides the same features as creating a {@code TopicSubscriber}. To create a
+ * durable subscriber, use of {@code Session.CreateDurableSubscriber} is recommended. The {@code TopicSubscriber} is
+ * provided to support existing code.
+ *
+ * @see javax.jms.Session#createConsumer
+ * @see javax.jms.Session#createDurableSubscriber
+ * @see javax.jms.TopicSession
+ * @see javax.jms.TopicSession#createSubscriber
+ * @see javax.jms.MessageConsumer
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface TopicSubscriber extends MessageConsumer {
 
-    /** Gets the {@code Topic} associated with this subscriber.
-      *  
-      * @return this subscriber's {@code Topic}
-      *  
-      * @exception JMSException if the JMS provider fails to get the topic for
-      *                         this topic subscriber
-      *                         due to some internal error.
-      */ 
+    /**
+     * Gets the {@code Topic} associated with this subscriber.
+     *
+     * @return this subscriber's {@code Topic}
+     *
+     * @exception JMSException if the JMS provider fails to get the topic for this topic subscriber due to some internal
+     * error.
+     */
+    Topic getTopic() throws JMSException;
 
-    Topic
-    getTopic() throws JMSException;
-
-
-    /** Gets the {@code NoLocal} attribute for this subscriber. 
-      * The default value for this attribute is false.
-      *  
-      * @return true if locally published messages are being inhibited
-      *  
-      * @exception JMSException if the JMS provider fails to get the
-      *                         {@code NoLocal} attribute for
-      *                         this topic subscriber
-      *                         due to some internal error.
-      */ 
-
-    boolean
-    getNoLocal() throws JMSException;
+    /**
+     * Gets the {@code NoLocal} attribute for this subscriber. The default value for this attribute is false.
+     *
+     * @return true if locally published messages are being inhibited
+     *
+     * @exception JMSException if the JMS provider fails to get the {@code NoLocal} attribute for this topic subscriber due
+     * to some internal error.
+     */
+    boolean getNoLocal() throws JMSException;
 }

--- a/src/main/java/javax/jms/TransactionInProgressException.java
+++ b/src/main/java/javax/jms/TransactionInProgressException.java
@@ -17,46 +17,38 @@
 package javax.jms;
 
 /**
- * <P> This exception is thrown when an 
- *     operation is invalid because a transaction is in progress. 
- *     For instance, an attempt to call {@code Session.commit} when a 
- *     session is part of a distributed transaction should throw a 
- *     {@code TransactionInProgressException}.
+ * This exception is thrown when an operation is invalid because a transaction is in progress. For instance, an attempt
+ * to call {@code Session.commit} when a session is part of a distributed transaction should throw a
+ * {@code TransactionInProgressException}.
  *
- * 
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  */
-
 public class TransactionInProgressException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = -5611340150426335231L;
 
-  /** Constructs a {@code TransactionInProgressException} with the 
-   *  specified reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  TransactionInProgressException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = -5611340150426335231L;
 
-  /** Constructs a {@code TransactionInProgressException} with the 
-   *  specified reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  TransactionInProgressException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code TransactionInProgressException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public TransactionInProgressException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code TransactionInProgressException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public TransactionInProgressException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/TransactionInProgressRuntimeException.java
+++ b/src/main/java/javax/jms/TransactionInProgressRuntimeException.java
@@ -17,60 +17,48 @@
 package javax.jms;
 
 /**
- * <P> This unchecked exception is thrown when an 
- *     operation is invalid because a transaction is in progress. 
- *     For instance, an attempt to call {@code JMSContext.commit} when the 
- *     context is part of a distributed transaction should throw a 
- *     {@code TransactionInProgressRuntimeException}.
- * 
+ * This unchecked exception is thrown when an operation is invalid because a transaction is in progress. For instance,
+ * an attempt to call {@code JMSContext.commit} when the context is part of a distributed transaction should throw a
+ * {@code TransactionInProgressRuntimeException}.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
  */
 public class TransactionInProgressRuntimeException extends JMSRuntimeException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = -916492460069513065L;
 
-	/**
-	 * Constructs a {@code TransactionInProgressRuntimeException} with the
-	 * specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public TransactionInProgressRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = -916492460069513065L;
 
-	/**
-	 * Constructs a {@code TransactionInProgressRuntimeException} with the
-	 * specified detail message and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public TransactionInProgressRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage, errorCode);
-	}
-	
-	/**
-	 * Constructs a {@code TransactionInProgressRuntimeException} with the
-	 * specified detail message, error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public TransactionInProgressRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage, errorCode, cause);
-	}
+    /**
+     * Constructs a {@code TransactionInProgressRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public TransactionInProgressRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    /**
+     * Constructs a {@code TransactionInProgressRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public TransactionInProgressRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code TransactionInProgressRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public TransactionInProgressRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
 
 }

--- a/src/main/java/javax/jms/TransactionRolledBackException.java
+++ b/src/main/java/javax/jms/TransactionRolledBackException.java
@@ -17,43 +17,36 @@
 package javax.jms;
 
 /**
- * <P> This exception must be thrown when a 
- *     call to {@code Session.commit} results in a rollback of the current 
- *     transaction.
- * 
+ * This exception must be thrown when a call to {@code Session.commit} results in a rollback of the current transaction.
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  */
-
 public class TransactionRolledBackException extends JMSException {
-  
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
-   */
-  private static final long serialVersionUID = 9157976009672865857L;
 
-  /** Constructs a {@code TransactionRolledBackException} with the 
-   *  specified reason and error code.
-   *
-   *  @param  reason        a description of the exception
-   *  @param  errorCode     a string specifying the vendor-specific
-   *                        error code
-   *                        
-   **/
-  public 
-  TransactionRolledBackException(String reason, String errorCode) {
-    super(reason, errorCode);
-  }
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 1.1 version
+     */
+    private static final long serialVersionUID = 9157976009672865857L;
 
-  /** Constructs a {@code TransactionRolledBackException} with the 
-   *  specified reason. The error code defaults to null.
-   *
-   *  @param  reason        a description of the exception
-   **/
-  public 
-  TransactionRolledBackException(String reason) {
-    super(reason);
-  }
+    /**
+     * Constructs a {@code TransactionRolledBackException} with the specified reason and error code.
+     *
+     * @param reason a description of the exception
+     * @param errorCode a string specifying the vendor-specific error code
+     *
+     **/
+    public TransactionRolledBackException(String reason, String errorCode) {
+        super(reason, errorCode);
+    }
+
+    /**
+     * Constructs a {@code TransactionRolledBackException} with the specified reason. The error code defaults to null.
+     *
+     * @param reason a description of the exception
+     **/
+    public TransactionRolledBackException(String reason) {
+        super(reason);
+    }
 
 }

--- a/src/main/java/javax/jms/TransactionRolledBackRuntimeException.java
+++ b/src/main/java/javax/jms/TransactionRolledBackRuntimeException.java
@@ -17,58 +17,47 @@
 package javax.jms;
 
 /**
- * This unchecked exception must be thrown when a call to
- * {@code JMSContext.commit} results in a rollback of the current
+ * This unchecked exception must be thrown when a call to {@code JMSContext.commit} results in a rollback of the current
  * transaction.
- * 
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
  */
 public class TransactionRolledBackRuntimeException extends JMSRuntimeException {
 
-  /**
-   * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
-   */
-  private static final long serialVersionUID = 2157965166257651703L;
+    /**
+     * Explicitly set serialVersionUID to be the same as the implicit serialVersionUID of the JMS 2.0 version
+     */
+    private static final long serialVersionUID = 2157965166257651703L;
 
-	/**
-	 * Constructs a {@code TransactionRolledBackRuntimeException} with the
-	 * specified detail message
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 **/
-	public TransactionRolledBackRuntimeException(String detailMessage) {
-		super(detailMessage);
-	}
+    /**
+     * Constructs a {@code TransactionRolledBackRuntimeException} with the specified detail message
+     *
+     * @param detailMessage a description of the exception
+     **/
+    public TransactionRolledBackRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
 
-	/**
-	 * Constructs a {@code TransactionRolledBackRuntimeException} with the
-	 * specified detail message and error code.
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 **/
-	public TransactionRolledBackRuntimeException(String detailMessage, String errorCode) {
-		super(detailMessage, errorCode);
-	}
-	
-	/**
-	 * Constructs a {@code TransactionRolledBackRuntimeException} with the
-	 * specified detail message, error code and cause
-	 * 
-	 * @param detailMessage
-	 *            a description of the exception
-	 * @param errorCode
-	 *            a provider-specific error code
-	 * @param cause
-	 *            the underlying cause of this exception
-	 */
-	public TransactionRolledBackRuntimeException(String detailMessage, String errorCode, Throwable cause) {
-		super(detailMessage, errorCode, cause);
-	}
+    /**
+     * Constructs a {@code TransactionRolledBackRuntimeException} with the specified detail message and error code.
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     **/
+    public TransactionRolledBackRuntimeException(String detailMessage, String errorCode) {
+        super(detailMessage, errorCode);
+    }
+
+    /**
+     * Constructs a {@code TransactionRolledBackRuntimeException} with the specified detail message, error code and cause
+     *
+     * @param detailMessage a description of the exception
+     * @param errorCode a provider-specific error code
+     * @param cause the underlying cause of this exception
+     */
+    public TransactionRolledBackRuntimeException(String detailMessage, String errorCode, Throwable cause) {
+        super(detailMessage, errorCode, cause);
+    }
 
 }

--- a/src/main/java/javax/jms/XAConnection.java
+++ b/src/main/java/javax/jms/XAConnection.java
@@ -17,58 +17,47 @@
 package javax.jms;
 
 /**
- * The {@code XAConnection} interface extends the capability of
- * {@code Connection} by providing an {@code XASession} (optional).
- * 
- * <P>
- * The {@code XAConnection} interface is optional. JMS providers are not required
- * to support this interface. This interface is for use by JMS providers to
- * support transactional environments. Client programs are strongly encouraged
- * to use the transactional support available in their environment, rather than
- * use these XA interfaces directly.
- * 
+ * The {@code XAConnection} interface extends the capability of {@code Connection} by providing an {@code XASession}
+ * (optional).
+ *
+ * <p>
+ * The {@code XAConnection} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than use these XA interfaces directly.
+ *
  * @see javax.jms.XAQueueConnection
  * @see javax.jms.XATopicConnection
- * 
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  */
-
 public interface XAConnection extends Connection {
 
-	/**
-	 * Creates an {@code XASession} object.
-	 * 
-	 * @return a newly created {@code XASession}
-	 * 
-	 * @exception JMSException
-	 *                if the {@code XAConnection} object fails to create an
-	 *                {@code XASession} due to some internal error.
-	 * 
-	 * @since JMS 1.1
-	 * 
-	 */
+    /**
+     * Creates an {@code XASession} object.
+     *
+     * @return a newly created {@code XASession}
+     *
+     * @exception JMSException if the {@code XAConnection} object fails to create an {@code XASession} due to some internal
+     * error.
+     *
+     * @since JMS 1.1
+     */
+    XASession createXASession() throws JMSException;
 
-	XASession createXASession() throws JMSException;
-
-	/**
-	 * Creates an {@code Session} object.
-	 * 
-	 * @param transacted
-	 *            usage undefined
-	 * @param acknowledgeMode
-	 *            usage undefined
-	 * 
-	 * @return a newly created {@code Session}
-	 * 
-	 * @exception JMSException
-	 *                if the {@code XAConnection} object fails to create a
-	 *                {@code Session} due to some internal error.
-	 * 
-	 * @since JMS 1.1
-	 * 
-	 */
-	Session createSession(boolean transacted, int acknowledgeMode)
-			throws JMSException;
+    /**
+     * Creates an {@code Session} object.
+     *
+     * @param transacted usage undefined
+     * @param acknowledgeMode usage undefined
+     *
+     * @return a newly created {@code Session}
+     *
+     * @exception JMSException if the {@code XAConnection} object fails to create a {@code Session} due to some internal
+     * error.
+     *
+     * @since JMS 1.1
+     */
+    @Override
+    Session createSession(boolean transacted, int acknowledgeMode) throws JMSException;
 }

--- a/src/main/java/javax/jms/XAConnectionFactory.java
+++ b/src/main/java/javax/jms/XAConnectionFactory.java
@@ -16,117 +16,93 @@
 
 package javax.jms;
 
-/** The {@code XAConnectionFactory} interface is a base interface for the
-  * {@code XAQueueConnectionFactory} and 
-  * {@code XATopicConnectionFactory} interfaces.
-  *
-  * <P>Some application servers provide support for grouping JTA capable 
-  * resource use into a distributed transaction (optional). To include JMS API transactions 
-  * in a JTA transaction, an application server requires a JTA aware JMS
-  * provider. A JMS provider exposes its JTA support using an
-  * {@code XAConnectionFactory} object, which an application server uses 
-  * to create {@code XAConnection} objects.
-  *
-  * <P>{@code XAConnectionFactory} objects are JMS administered objects, 
-  * just like {@code ConnectionFactory} objects. It is expected that 
-  * application servers will find them using the Java Naming and Directory
-  * Interface (JNDI) API.
-  *
-  *<P>The {@code XAConnectionFactory} interface is optional. JMS providers 
-  * are not required to support this interface. This interface is for 
-  * use by JMS providers to support transactional environments. 
-  * Client programs are strongly encouraged to use the transactional support
-  * available in their environment, rather than use these XA
-  * interfaces directly. 
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
+/**
+ * The {@code XAConnectionFactory} interface is a base interface for the {@code XAQueueConnectionFactory} and
+ * {@code XATopicConnectionFactory} interfaces.
+ *
+ * <p>
+ * Some application servers provide support for grouping JTA capable resource use into a distributed transaction
+ * (optional). To include JMS API transactions in a JTA transaction, an application server requires a JTA aware JMS
+ * provider. A JMS provider exposes its JTA support using an {@code XAConnectionFactory} object, which an application
+ * server uses to create {@code XAConnection} objects.
+ *
+ * <p>
+ * {@code XAConnectionFactory} objects are JMS administered objects, just like {@code ConnectionFactory} objects. It is
+ * expected that application servers will find them using the Java Naming and Directory Interface (JNDI) API.
+ *
+ * <p>
+ * The {@code XAConnectionFactory} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than use these XA interfaces directly.
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface XAConnectionFactory {
-    
-     /** Creates an {@code XAConnection} with the default user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *
-      * @return a newly created {@code XAConnection}
-      *
-      * @exception JMSException if the JMS provider fails to create an XA  
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      * 
-      * @since JMS 1.1 
-      * 
-      */ 
 
-    XAConnection
-    createXAConnection() throws JMSException;
+    /**
+     * Creates an {@code XAConnection} with the default user identity. The connection is created in stopped mode. No
+     * messages will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @return a newly created {@code XAConnection}
+     *
+     * @exception JMSException if the JMS provider fails to create an XA connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     *
+     * @since JMS 1.1
+     */
+    XAConnection createXAConnection() throws JMSException;
 
-
-    /** Creates an {@code XAConnection} with the specified user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *  
-      * @param userName the caller's user name
-      * @param password the caller's password
-      *  
-      * @return a newly created {@code XAConnection}
-      *
-      * @exception JMSException if the JMS provider fails to create an XA  
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      *
-      * @since JMS 1.1 
-      * 
-      */ 
-
-    XAConnection
-    createXAConnection(String userName, String password) 
-					     throws JMSException;
-    
-	/**
-	 * Creates a {@code XAJMSContext} with the default user identity
-	 * <p>
-     * A connection and session are created for use by the new {@code XAJMSContext}. 
-     * The connection is created in stopped mode but will be automatically started
-     * when a {@code JMSConsumer} is created.
-	 * 
-	 * @return a newly created {@code XAJMSContext}
-	 * 
-	 * @exception JMSRuntimeException
-	 *                if the JMS provider fails to create the {@code XAJMSContext} due
-	 *                to some internal error.
-	 * @exception JMSSecurityRuntimeException
-	 *                if client authentication fails due to an invalid user name
-	 *                or password.
-	 * @since JMS 2.0
-	 * 
-	 */
-	XAJMSContext createXAContext();
-   
-    /** 
-     * Creates a JMSContext with the specified user identity
-	 * <p>
-     * A connection and session are created for use by the new {@code XAJMSContext}. 
-     * The connection is created in stopped mode but will be automatically started
-     * when a {@code JMSConsumer} is created.
-     * 
+    /**
+     * Creates an {@code XAConnection} with the specified user identity. The connection is created in stopped mode. No
+     * messages will be delivered until the {@code Connection.start} method is explicitly called.
+     *
      * @param userName the caller's user name
      * @param password the caller's password
-     *  
+     *
+     * @return a newly created {@code XAConnection}
+     *
+     * @exception JMSException if the JMS provider fails to create an XA connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     *
+     * @since JMS 1.1
+     */
+    XAConnection createXAConnection(String userName, String password) throws JMSException;
+
+    /**
+     * Creates a {@code XAJMSContext} with the default user identity
+     *
+     * <p>
+     * A connection and session are created for use by the new {@code XAJMSContext}. The connection is created in stopped
+     * mode but will be automatically started when a {@code JMSConsumer} is created.
+     *
+     * @return a newly created {@code XAJMSContext}
+     *
+     * @exception JMSRuntimeException if the JMS provider fails to create the {@code XAJMSContext} due to some internal
+     * error.
+     * @exception JMSSecurityRuntimeException if client authentication fails due to an invalid user name or password.
+     *
+     * @since JMS 2.0
+     */
+    XAJMSContext createXAContext();
+
+    /**
+     * Creates a JMSContext with the specified user identity
+     *
+     * <p>
+     * A connection and session are created for use by the new {@code XAJMSContext}. The connection is created in stopped
+     * mode but will be automatically started when a {@code JMSConsumer} is created.
+     *
+     * @param userName the caller's user name
+     * @param password the caller's password
+     *
      * @return a newly created JMSContext
      *
-     * @exception JMSRuntimeException if the JMS provider fails to create the 
-     *                         JMSContext due to some internal error.
-     * @exception JMSSecurityRuntimeException  if client authentication fails due to 
-     *                         an invalid user name or password.
-     * @since JMS 2.0 
-     * 
+     * @exception JMSRuntimeException if the JMS provider fails to create the JMSContext due to some internal error.
+     * @exception JMSSecurityRuntimeException if client authentication fails due to an invalid user name or password.
+     *
+     * @since JMS 2.0
      */
-    XAJMSContext createXAContext(String userName, String password);    
-   
+    XAJMSContext createXAContext(String userName, String password);
+
 }

--- a/src/main/java/javax/jms/XAJMSContext.java
+++ b/src/main/java/javax/jms/XAJMSContext.java
@@ -19,95 +19,74 @@ package javax.jms;
 import javax.transaction.xa.XAResource;
 
 /**
- * The {@code XAJMSContext} interface extends the capability of
- * {@code JMSContext} by adding access to a JMS provider's support for the Java
- * Transaction API (JTA) (optional). This support takes the form of a
- * {@code javax.transaction.xa.XAResource} object. The functionality of this
- * object closely resembles that defined by the standard X/Open XA Resource
- * interface.
- * 
- * <P>
- * An application server controls the transactional assignment of an
- * {@code XASession} by obtaining its {@code XAResource}. It uses the
- * {@code XAResource} to assign the session to a transaction, prepare and commit
- * work on the transaction, and so on.
- * 
- * <P>
- * An {@code XAResource} provides some fairly sophisticated facilities for
- * interleaving work on multiple transactions, recovering a list of transactions
- * in progress, and so on. A JTA aware JMS provider must fully implement this
- * functionality. This could be done by using the services of a database that
- * supports XA, or a JMS provider may choose to implement this functionality
- * from scratch.
- * 
- * <P>
- * A client of the application server is given what it thinks is an ordinary
- * {@code JMSContext}. Behind the scenes, the application server controls the
- * transaction management of the underlying {@code XAJMSContext}.
- * 
- * <P>
- * The {@code XAJMSContext} interface is optional. JMS providers are not
- * required to support this interface. This interface is for use by JMS
- * providers to support transactional environments. Client programs are strongly
- * encouraged to use the transactional support available in their environment,
- * rather than use these XA interfaces directly.
- * 
+ * The {@code XAJMSContext} interface extends the capability of {@code JMSContext} by adding access to a JMS provider's
+ * support for the Java Transaction API (JTA) (optional). This support takes the form of a
+ * {@code javax.transaction.xa.XAResource} object. The functionality of this object closely resembles that defined by
+ * the standard X/Open XA Resource interface.
+ *
+ * <p>
+ * An application server controls the transactional assignment of an {@code XASession} by obtaining its
+ * {@code XAResource}. It uses the {@code XAResource} to assign the session to a transaction, prepare and commit work on
+ * the transaction, and so on.
+ *
+ * <p>
+ * An {@code XAResource} provides some fairly sophisticated facilities for interleaving work on multiple transactions,
+ * recovering a list of transactions in progress, and so on. A JTA aware JMS provider must fully implement this
+ * functionality. This could be done by using the services of a database that supports XA, or a JMS provider may choose
+ * to implement this functionality from scratch.
+ *
+ * <p>
+ * A client of the application server is given what it thinks is an ordinary {@code JMSContext}. Behind the scenes, the
+ * application server controls the transaction management of the underlying {@code XAJMSContext}.
+ *
+ * <p>
+ * The {@code XAJMSContext} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than use these XA interfaces directly.
+ *
  * @version JMS 2.0
  * @since JMS 2.0
- * 
  */
-
 public interface XAJMSContext extends JMSContext {
 
-	/**
-	 * Returns the {@code JMSContext} object associated with this
-	 * {@code XAJMSContext}.
-	 * 
-	 * @return the {@code JMSContext} object associated with this
-	 *         {@code XAJMSContext}
-	 * 
-	 */
-	JMSContext getContext();
+    /**
+     * Returns the {@code JMSContext} object associated with this {@code XAJMSContext}.
+     *
+     * @return the {@code JMSContext} object associated with this {@code XAJMSContext}
+     */
+    JMSContext getContext();
 
-	/**
-	 * Returns an {@code XAResource} to the caller.
-	 * 
-	 * @return an {@code XAResource}
-	 */
-	XAResource getXAResource();
+    /**
+     * Returns an {@code XAResource} to the caller.
+     *
+     * @return an {@code XAResource}
+     */
+    XAResource getXAResource();
 
-	/**
-	 * Returns whether the session is in transacted mode; this method always
-	 * returns true.
-	 * 
-	 * @return true
-	 * 
-	 */
-	@Override
-	boolean getTransacted();
+    /**
+     * Returns whether the session is in transacted mode; this method always returns true.
+     *
+     * @return true
+     */
+    @Override
+    boolean getTransacted();
 
-	/**
-	 * Throws a {@code TransactionInProgressRuntimeException}, since it should
-	 * not be called for an {@code XAJMSContext} object.
-	 * 
-	 * @exception TransactionInProgressRuntimeException
-	 *                if the method is called on an {@code XAJMSContext}.
-	 * 
-	 */
+    /**
+     * Throws a {@code TransactionInProgressRuntimeException}, since it should not be called for an {@code XAJMSContext}
+     * object.
+     *
+     * @exception TransactionInProgressRuntimeException if the method is called on an {@code XAJMSContext}.
+     */
+    @Override
+    void commit();
 
-	@Override
-	void commit();
-
-	/**
-	 * Throws a {@code TransactionInProgressRuntimeException}, since it should
-	 * not be called for an {@code XAJMSContext} object.
-	 * 
-	 * @exception TransactionInProgressRuntimeException
-	 *                if the method is called on an {@code XAJMSContext}.
-	 * 
-	 */
-
-	@Override
-	void rollback();
+    /**
+     * Throws a {@code TransactionInProgressRuntimeException}, since it should not be called for an {@code XAJMSContext}
+     * object.
+     *
+     * @exception TransactionInProgressRuntimeException if the method is called on an {@code XAJMSContext}.
+     */
+    @Override
+    void rollback();
 
 }

--- a/src/main/java/javax/jms/XAQueueConnection.java
+++ b/src/main/java/javax/jms/XAQueueConnection.java
@@ -17,52 +17,42 @@
 package javax.jms;
 
 /**
- * An {@code XAQueueConnection} provides the same create options as
- * {@code QueueConnection} (optional). The only difference is that an
- * {@code XAConnection} is by definition transacted.
- * 
- * <P>
- * The {@code XAQueueConnection} interface is optional. JMS providers are not
- * required to support this interface. This interface is for use by JMS
- * providers to support transactional environments. Client programs are strongly
- * encouraged to use the transactional support available in their environment,
- * rather than use these XA interfaces directly.
- * 
+ * An {@code XAQueueConnection} provides the same create options as {@code QueueConnection} (optional). The only
+ * difference is that an {@code XAConnection} is by definition transacted.
+ *
+ * <p>
+ * The {@code XAQueueConnection} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than use these XA interfaces directly.
+ *
  * @see javax.jms.XAConnection
- * 
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  */
-
 public interface XAQueueConnection extends XAConnection, QueueConnection {
 
-	/**
-	 * Creates an {@code XAQueueSession} object.
-	 * 
-	 * @return a newly created {@code XAQueueSession}
-	 * 
-	 * @exception JMSException
-	 *                if the {@code XAQueueConnection} object fails to create an
-	 *                {@code XAQueueSession} due to some internal error.
-	 */
+    /**
+     * Creates an {@code XAQueueSession} object.
+     *
+     * @return a newly created {@code XAQueueSession}
+     *
+     * @exception JMSException if the {@code XAQueueConnection} object fails to create an {@code XAQueueSession} due to some
+     * internal error.
+     */
+    XAQueueSession createXAQueueSession() throws JMSException;
 
-	XAQueueSession createXAQueueSession() throws JMSException;
-
-	/**
-	 * Creates a {@code QueueSession} object.
-	 * 
-	 * @param transacted
-	 *            usage undefined
-	 * @param acknowledgeMode
-	 *            usage undefined
-	 * 
-	 * @return a newly created {@code QueueSession}
-	 * 
-	 * @exception JMSException
-	 *                if the {@code XAQueueConnection} object fails to create a
-	 *                {@code QueueSession} due to some internal error.
-	 */
-	QueueSession createQueueSession(boolean transacted, int acknowledgeMode)
-			throws JMSException;
+    /**
+     * Creates a {@code QueueSession} object.
+     *
+     * @param transacted usage undefined
+     * @param acknowledgeMode usage undefined
+     *
+     * @return a newly created {@code QueueSession}
+     *
+     * @exception JMSException if the {@code XAQueueConnection} object fails to create a {@code QueueSession} due to some
+     * internal error.
+     */
+    @Override
+    QueueSession createQueueSession(boolean transacted, int acknowledgeMode) throws JMSException;
 }

--- a/src/main/java/javax/jms/XAQueueConnectionFactory.java
+++ b/src/main/java/javax/jms/XAQueueConnectionFactory.java
@@ -16,61 +16,45 @@
 
 package javax.jms;
 
-/** An {@code XAQueueConnectionFactory} provides the same create options as
-  * a {@code QueueConnectionFactory} (optional).
-  *
-  * <P>The {@code XATopicConnectionFactory} interface is optional.  JMS providers 
-  * are not required to support this interface. This interface is for 
-  * use by JMS providers to support transactional environments. 
-  * Client programs are strongly encouraged to use the transactional support
-  * available in their environment, rather than use these XA
-  * interfaces directly. 
-  *
-  * @see         javax.jms.QueueConnectionFactory
-  * @see         javax.jms.XAConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
+/**
+ * An {@code XAQueueConnectionFactory} provides the same create options as a {@code QueueConnectionFactory} (optional).
+ *
+ * <p>
+ * The {@code XATopicConnectionFactory} interface is optional. JMS providers are not required to support this interface.
+ * This interface is for use by JMS providers to support transactional environments. Client programs are strongly
+ * encouraged to use the transactional support available in their environment, rather than use these XA interfaces
+ * directly.
+ *
+ * @see javax.jms.QueueConnectionFactory
+ * @see javax.jms.XAConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
+public interface XAQueueConnectionFactory extends XAConnectionFactory, QueueConnectionFactory {
 
-public interface XAQueueConnectionFactory 
-       extends XAConnectionFactory, QueueConnectionFactory {
+    /**
+     * Creates an XA queue connection with the default user identity. The connection is created in stopped mode. No messages
+     * will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @return a newly created XA queue connection
+     *
+     * @exception JMSException if the JMS provider fails to create an XA queue connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    XAQueueConnection createXAQueueConnection() throws JMSException;
 
-    /** Creates an XA queue connection with the default user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *
-      * @return a newly created XA queue connection
-      *
-      * @exception JMSException if the JMS provider fails to create an XA queue 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-       */ 
-
-    XAQueueConnection
-    createXAQueueConnection() throws JMSException;
-
-
-    /** Creates an XA queue connection with the specified user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *  
-      * @param userName the caller's user name
-      * @param password the caller's password
-      *  
-      * @return a newly created XA queue connection
-      *
-      * @exception JMSException if the JMS provider fails to create an XA queue 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      */ 
-
-    XAQueueConnection
-    createXAQueueConnection(String userName, String password) 
-					     throws JMSException;
+    /**
+     * Creates an XA queue connection with the specified user identity. The connection is created in stopped mode. No
+     * messages will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @param userName the caller's user name
+     * @param password the caller's password
+     *
+     * @return a newly created XA queue connection
+     *
+     * @exception JMSException if the JMS provider fails to create an XA queue connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    XAQueueConnection createXAQueueConnection(String userName, String password) throws JMSException;
 }

--- a/src/main/java/javax/jms/XAQueueSession.java
+++ b/src/main/java/javax/jms/XAQueueSession.java
@@ -16,34 +16,28 @@
 
 package javax.jms;
 
-/** An {@code XAQueueSession} provides a regular {@code QueueSession},
-  * which can be used to
-  * create {@code QueueReceiver}, {@code QueueSender}, and 
-  *{@code QueueBrowser} objects (optional).
-  *
-  * <P>The {@code XAQueueSession} interface is optional. JMS providers 
-  * are not required to support this interface. This interface is for 
-  * use by JMS providers to support transactional environments. 
-  * Client programs are strongly encouraged to use the transactional support
-  * available in their environment, rather than use these XA
-  * interfaces directly. 
-  *
-  * @see javax.jms.XASession
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
-
+/**
+ * An {@code XAQueueSession} provides a regular {@code QueueSession}, which can be used to create {@code QueueReceiver},
+ * {@code QueueSender}, and {@code QueueBrowser} objects (optional).
+ *
+ * <p>
+ * The {@code XAQueueSession} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than use these XA interfaces directly.
+ *
+ * @see javax.jms.XASession
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface XAQueueSession extends XASession {
 
-    /** Gets the queue session associated with this {@code XAQueueSession}.
-      *  
-      * @return the queue session object
-      *  
-      * @exception JMSException if an internal error occurs.
-      */ 
- 
-    QueueSession
-    getQueueSession() throws JMSException;
+    /**
+     * Gets the queue session associated with this {@code XAQueueSession}.
+     *
+     * @return the queue session object
+     *
+     * @exception JMSException if an internal error occurs.
+     */
+    QueueSession getQueueSession() throws JMSException;
 }

--- a/src/main/java/javax/jms/XASession.java
+++ b/src/main/java/javax/jms/XASession.java
@@ -18,97 +18,80 @@ package javax.jms;
 
 import javax.transaction.xa.XAResource;
 
-/** The {@code XASession} interface extends the capability of 
-  * {@code Session} by adding access to a JMS provider's support for the
-  * Java Transaction API (JTA) (optional). This support takes the form of a 
-  * {@code javax.transaction.xa.XAResource} object. The functionality of 
-  * this object closely resembles that defined by the standard X/Open XA 
-  * Resource interface.
-  *
-  * <P>An application server controls the transactional assignment of an 
-  * {@code XASession} by obtaining its {@code XAResource}. It uses 
-  * the {@code XAResource} to assign the session to a transaction, prepare 
-  * and commit work on the transaction, and so on.
-  *
-  * <P>An {@code XAResource} provides some fairly sophisticated facilities 
-  * for interleaving work on multiple transactions, recovering a list of 
-  * transactions in progress, and so on. A JTA aware JMS provider must fully 
-  * implement this functionality. This could be done by using the services 
-  * of a database that supports XA, or a JMS provider may choose to implement 
-  * this functionality from scratch.
-  *
-  * <P>A client of the application server is given what it thinks is a 
-  * regular JMS {@code Session}. Behind the scenes, the application server 
-  * controls the transaction management of the underlying 
-  * {@code XASession}.
-  *
-  * <P>The {@code XASession} interface is optional.  JMS providers 
-  * are not required to support this interface. This interface is for 
-  * use by JMS providers to support transactional environments. 
-  * Client programs are strongly encouraged to use the transactional support
-  * available in their environment, rather than use these XA
-  * interfaces directly. 
-  *
-  * @see javax.jms.Session
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
- 
+/**
+ * The {@code XASession} interface extends the capability of {@code Session} by adding access to a JMS provider's
+ * support for the Java Transaction API (JTA) (optional). This support takes the form of a
+ * {@code javax.transaction.xa.XAResource} object. The functionality of this object closely resembles that defined by
+ * the standard X/Open XA Resource interface.
+ *
+ * <p>
+ * An application server controls the transactional assignment of an {@code XASession} by obtaining its
+ * {@code XAResource}. It uses the {@code XAResource} to assign the session to a transaction, prepare and commit work on
+ * the transaction, and so on.
+ *
+ * <p>
+ * An {@code XAResource} provides some fairly sophisticated facilities for interleaving work on multiple transactions,
+ * recovering a list of transactions in progress, and so on. A JTA aware JMS provider must fully implement this
+ * functionality. This could be done by using the services of a database that supports XA, or a JMS provider may choose
+ * to implement this functionality from scratch.
+ *
+ * <p>
+ * A client of the application server is given what it thinks is a regular JMS {@code Session}. Behind the scenes, the
+ * application server controls the transaction management of the underlying {@code XASession}.
+ *
+ * <p>
+ * The {@code XASession} interface is optional. JMS providers are not required to support this interface. This interface
+ * is for use by JMS providers to support transactional environments. Client programs are strongly encouraged to use the
+ * transactional support available in their environment, rather than use these XA interfaces directly.
+ *
+ * @see javax.jms.Session
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
 public interface XASession extends Session {
 
-   /** Gets the session associated with this {@code XASession}.
-      *  
-      * @return the  session object
-      *  
-      * @exception JMSException if an internal error occurs.
-      *
-      * @since JMS 1.1
-      */ 
-     Session
-     getSession() throws JMSException;
-  
-    /** Returns an XA resource to the caller.
-      *
-      * @return an XA resource to the caller
-      */
+    /**
+     * Gets the session associated with this {@code XASession}.
+     *
+     * @return the session object
+     *
+     * @exception JMSException if an internal error occurs.
+     *
+     * @since JMS 1.1
+     */
+    Session getSession() throws JMSException;
 
-     XAResource
-     getXAResource();
+    /**
+     * Returns an XA resource to the caller.
+     *
+     * @return an XA resource to the caller
+     */
+    XAResource getXAResource();
 
-    /** Indicates whether the session is in transacted mode.
-      *  
-      * @return true
-      *  
-      * @exception JMSException if the JMS provider fails to return the 
-      *                         transaction mode due to some internal error.
-      */ 
+    /**
+     * Indicates whether the session is in transacted mode.
+     *
+     * @return true
+     *
+     * @exception JMSException if the JMS provider fails to return the transaction mode due to some internal error.
+     */
+    @Override
+    boolean getTransacted() throws JMSException;
 
-    boolean
-    getTransacted() throws JMSException;
+    /**
+     * Throws a {@code TransactionInProgressException}, since it should not be called for an {@code XASession} object.
+     *
+     * @exception TransactionInProgressException if the method is called on an {@code XASession}.
+     */
+    @Override
+    void commit() throws JMSException;
 
-
-    /** Throws a {@code TransactionInProgressException}, since it should 
-      * not be called for an {@code XASession} object.
-      *
-      * @exception TransactionInProgressException if the method is called on 
-      *                         an {@code XASession}.
-      *                                     
-      */
-
-    void
-    commit() throws JMSException;
-
-
-    /** Throws a {@code TransactionInProgressException}, since it should 
-      * not be called for an {@code XASession} object.
-      *
-      * @exception TransactionInProgressException if the method is called on 
-      *                         an {@code XASession}.
-      *                                     
-      */
-
-    void
-    rollback() throws JMSException;
+    /**
+     * Throws a {@code TransactionInProgressException}, since it should not be called for an {@code XASession} object.
+     *
+     * @exception TransactionInProgressException if the method is called on an {@code XASession}.
+     */
+    @Override
+    void rollback() throws JMSException;
 }

--- a/src/main/java/javax/jms/XATopicConnection.java
+++ b/src/main/java/javax/jms/XATopicConnection.java
@@ -17,53 +17,42 @@
 package javax.jms;
 
 /**
- * An {@code XATopicConnection} provides the same create options as
- * {@code TopicConnection} (optional). The Topic connections created are
- * transactional.
- * 
- * <P>
- * The {@code XATopicConnection} interface is optional. JMS providers are not
- * required to support this interface. This interface is for use by JMS
- * providers to support transactional environments. Client programs are strongly
- * encouraged to use the transactional support available in their environment,
- * rather than use these XA interfaces directly.
- * 
+ * An {@code XATopicConnection} provides the same create options as {@code TopicConnection} (optional). The Topic
+ * connections created are transactional.
+ *
+ * <p>
+ * The {@code XATopicConnection} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than use these XA interfaces directly.
+ *
  * @see javax.jms.XAConnection
- * 
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  */
-
 public interface XATopicConnection extends XAConnection, TopicConnection {
 
-	/**
-	 * Creates an {@code XATopicSession} object.
-	 * 
-	 * @return a newly created {@code XATopicSession}
-	 * 
-	 * @exception JMSException
-	 *                if the {@code XATopicConnection} object fails to create an
-	 *                {@code XATopicSession} due to some internal error.
-	 */
+    /**
+     * Creates an {@code XATopicSession} object.
+     *
+     * @return a newly created {@code XATopicSession}
+     *
+     * @exception JMSException if the {@code XATopicConnection} object fails to create an {@code XATopicSession} due to some
+     * internal error.
+     */
+    XATopicSession createXATopicSession() throws JMSException;
 
-	XATopicSession createXATopicSession() throws JMSException;
-
-	/**
-	 * Creates a {@code TopicSession} object.
-	 * 
-	 * @param transacted
-	 *            usage undefined
-	 * @param acknowledgeMode
-	 *            usage undefined
-	 * 
-	 * @return a newly created {@code TopicSession}
-	 * 
-	 * @exception JMSException
-	 *                if the {@code XATopicConnection} object fails to create a
-	 *                {@code TopicSession} due to some internal error.
-	 */
-
-	TopicSession createTopicSession(boolean transacted, int acknowledgeMode)
-			throws JMSException;
+    /**
+     * Creates a {@code TopicSession} object.
+     *
+     * @param transacted usage undefined
+     * @param acknowledgeMode usage undefined
+     *
+     * @return a newly created {@code TopicSession}
+     *
+     * @exception JMSException if the {@code XATopicConnection} object fails to create a {@code TopicSession} due to some
+     * internal error.
+     */
+    @Override
+    TopicSession createTopicSession(boolean transacted, int acknowledgeMode) throws JMSException;
 }

--- a/src/main/java/javax/jms/XATopicConnectionFactory.java
+++ b/src/main/java/javax/jms/XATopicConnectionFactory.java
@@ -16,61 +16,45 @@
 
 package javax.jms;
 
-/** An {@code XATopicConnectionFactory} provides the same create options as 
-  * a {@code TopicConnectionFactory} (optional).
-  *
-  * <P>The {@code XATopicConnectionFactory} interface is optional.  JMS providers 
-  * are not required to support this interface. This interface is for 
-  * use by JMS providers to support transactional environments. 
-  * Client programs are strongly encouraged to use the transactional support
-  * available in their environment, rather than use these XA
-  * interfaces directly. 
-  *
-  * @see         javax.jms.TopicConnectionFactory
-  * @see         javax.jms.XAConnectionFactory
-  * 
-  * @version JMS 2.0
-  * @since JMS 1.0
-  * 
-  */
+/**
+ * An {@code XATopicConnectionFactory} provides the same create options as a {@code TopicConnectionFactory} (optional).
+ *
+ * <p>
+ * The {@code XATopicConnectionFactory} interface is optional. JMS providers are not required to support this interface.
+ * This interface is for use by JMS providers to support transactional environments. Client programs are strongly
+ * encouraged to use the transactional support available in their environment, rather than use these XA interfaces
+ * directly.
+ *
+ * @see javax.jms.TopicConnectionFactory
+ * @see javax.jms.XAConnectionFactory
+ *
+ * @version JMS 2.0
+ * @since JMS 1.0
+ */
+public interface XATopicConnectionFactory extends XAConnectionFactory, TopicConnectionFactory {
 
-public interface XATopicConnectionFactory 
-	extends XAConnectionFactory, TopicConnectionFactory {
+    /**
+     * Creates an XA topic connection with the default user identity. The connection is created in stopped mode. No messages
+     * will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @return a newly created XA topic connection
+     *
+     * @exception JMSException if the JMS provider fails to create an XA topic connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    XATopicConnection createXATopicConnection() throws JMSException;
 
-    /** Creates an XA topic connection with the default user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *
-      * @return a newly created XA topic connection
-      *
-      * @exception JMSException if the JMS provider fails to create an XA topic 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      */ 
-
-    XATopicConnection
-    createXATopicConnection() throws JMSException;
-
-
-    /** Creates an XA topic connection with the specified user identity.
-      * The connection is created in stopped mode. No messages 
-      * will be delivered until the {@code Connection.start} method
-      * is explicitly called.
-      *  
-      * @param userName the caller's user name
-      * @param password the caller's password
-      *  
-      * @return a newly created XA topic connection
-      *
-      * @exception JMSException if the JMS provider fails to create an XA topic 
-      *                         connection due to some internal error.
-      * @exception JMSSecurityException  if client authentication fails due to 
-      *                         an invalid user name or password.
-      */ 
-
-    XATopicConnection
-    createXATopicConnection(String userName, String password) 
-					     throws JMSException;
+    /**
+     * Creates an XA topic connection with the specified user identity. The connection is created in stopped mode. No
+     * messages will be delivered until the {@code Connection.start} method is explicitly called.
+     *
+     * @param userName the caller's user name
+     * @param password the caller's password
+     *
+     * @return a newly created XA topic connection
+     *
+     * @exception JMSException if the JMS provider fails to create an XA topic connection due to some internal error.
+     * @exception JMSSecurityException if client authentication fails due to an invalid user name or password.
+     */
+    XATopicConnection createXATopicConnection(String userName, String password) throws JMSException;
 }

--- a/src/main/java/javax/jms/XATopicSession.java
+++ b/src/main/java/javax/jms/XATopicSession.java
@@ -17,34 +17,28 @@
 package javax.jms;
 
 /**
- * An {@code XATopicSession} provides a regular {@code TopicSession}. which can
- * be used to create {@code TopicSubscriber} and {@code TopicPublisher} objects
- * (optional).
- * 
- * <P>
- * The {@code XATopicSession} interface is optional. JMS providers are not
- * required to support this interface. This interface is for use by JMS
- * providers to support transactional environments. Client programs are strongly
- * encouraged to use the transactional support available in their environment,
- * rather than using these XA interfaces directly.
- * 
+ * An {@code XATopicSession} provides a regular {@code TopicSession}. which can be used to create
+ * {@code TopicSubscriber} and {@code TopicPublisher} objects (optional).
+ *
+ * <p>
+ * The {@code XATopicSession} interface is optional. JMS providers are not required to support this interface. This
+ * interface is for use by JMS providers to support transactional environments. Client programs are strongly encouraged
+ * to use the transactional support available in their environment, rather than using these XA interfaces directly.
+ *
  * @see javax.jms.XASession
  * @see javax.jms.TopicSession
- * 
+ *
  * @version JMS 2.0
  * @since JMS 1.0
- * 
  */
-
 public interface XATopicSession extends XASession {
 
-	/**
-	 * Gets the topic session associated with this {@code XATopicSession}.
-	 * 
-	 * @return the topic session object
-	 * 
-	 * @exception JMSException
-	 *                if an internal error occurs.
-	 */
-	TopicSession getTopicSession() throws JMSException;
+    /**
+     * Gets the topic session associated with this {@code XATopicSession}.
+     *
+     * @return the topic session object
+     *
+     * @exception JMSException if an internal error occurs.
+     */
+    TopicSession getTopicSession() throws JMSException;
 }

--- a/src/main/java/javax/jms/package.html
+++ b/src/main/java/javax/jms/package.html
@@ -20,53 +20,53 @@
 
 </HEAD>
 <BODY>
-<P>
+<p>
 The Java Message Service (JMS) API provides a common way for Java programs to create, send, receive and read an enterprise messaging system's messages. 
 
 <H3>JMS Applications</H3>
 
-<P>A JMS application is composed of the following parts:</P>
+<p>A JMS application is composed of the following parts:</P>
 
-<UL>
-  <LI>JMS provider - a messaging system that implements the JMS API
+<ul>
+  <li>JMS provider - a messaging system that implements the JMS API
       in addition to the other administrative and control functionality required 
       of a full-featured messaging product</LI>
-  <LI>JMS clients - the Java language programs that send and receive 
+  <li>JMS clients - the Java language programs that send and receive 
       messages</LI>
 
-  <LI>Messages - objects that are used to communicate information between the 
+  <li>Messages - objects that are used to communicate information between the 
       clients of an application</LI>
-  <LI>Administered objects - provider-specific objects that clients look up
+  <li>Administered objects - provider-specific objects that clients look up
       and use to interact portably with a JMS provider</LI>
-  <LI>Non-JMS clients - clients that use a message system's native 
+  <li>Non-JMS clients - clients that use a message system's native 
       client API instead of the JMS API. If the application predated the 
       availability of the JMS API, it is likely that it will include both JMS 
       clients and non-JMS clients.</LI>
-</UL>
+</ul>
 
 <H3>Administration</H3>
 
-<P>JMS providers differ significantly in their implementations of 
+<p>JMS providers differ significantly in their implementations of 
 underlying messaging technology. There are also major 
 differences in how a JMS provider's system is installed and administered.</P>
 
-<P>For JMS clients to be portable, they must be isolated from these 
+<p>For JMS clients to be portable, they must be isolated from these 
 proprietary aspects of a provider. This is done by defining JMS administered
 objects that are created and customised by a provider's administrator and 
 later used by clients. The client uses them through JMS interfaces that are 
 portable. The administrator creates them using provider-specific facilities.</P>
 
-<P>There are two types of JMS administered objects:</P>
+<p>There are two types of JMS administered objects:</P>
 
-<UL>
-  <LI>{@code ConnectionFactory} - the object a client uses to create a 
+<ul>
+  <li>{@code ConnectionFactory} - the object a client uses to create a 
       connection with a JMS provider</LI>
-  <LI>{@code Destination} - the object a client uses to specify the 
+  <li>{@code Destination} - the object a client uses to specify the 
       destination of messages it is sending and the source of messages 
       it receives</LI>
-</UL>
+</ul>
 
-<P>Administered objects are placed by an administrator in a JNDI (Java Naming and Directory 
+<p>Administered objects are placed by an administrator in a JNDI (Java Naming and Directory 
 Interface) namespace.
 A JMS client typically notes in its documentation the JMS administered objects 
 it requires and how the JNDI names of these objects should be provided to it.</P>
@@ -99,7 +99,7 @@ and receiving messages. However they all share a common set of interfaces for re
 messages and message destinations and to provide various utility features.
 <p>
 All interfaces are in the {@code javax.jms} package. 
-<P>
+<p>
 <h4>Interfaces common to multiple APIs</h4>
 <p>
 The main interfaces common to multiple APIs are as follows:
@@ -170,14 +170,14 @@ It means giving a message to a JMS provider for delivery to a destination.
 
 <H3>Developing a JMS Application</H3>
 
-<P>Broadly speaking, a JMS application is one or more JMS clients that exchange 
+<p>Broadly speaking, a JMS application is one or more JMS clients that exchange 
 messages. The application may also involve non-JMS clients; however, these 
 clients use the JMS provider's native API in place of the JMS API.</P>
 
-<P>A JMS application can be architected and deployed as a unit. In many cases, 
+<p>A JMS application can be architected and deployed as a unit. In many cases, 
 JMS clients are added incrementally to an existing application.</P>
 
-<P>The message definitions used by an application may originate with JMS, or they 
+<p>The message definitions used by an application may originate with JMS, or they 
 may have been defined by the non-JMS part of the application.</P>
 
 <H3>Developing a JMS Client</H3>


### PR DESCRIPTION
* Formatting according to Jakarta EE rules
* Fixed many errors in Javadoc that prevented javadoc generation without disabling errors
* Added generation of Javadoc jar by default

Signed-off-by: arjantijms <arjan.tijms@gmail.com>