### PR TITLE
Ensuring that LICENSE/NOTICE shows up in META-INF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,17 @@
     <url>https://projects.eclipse.org/projects/ee4j.jms</url>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>LICENSE.md</include>
+                    <include>NOTICE.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
+    
         <plugins>
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR makes the `LICENSE.md` and `NOTICE.md` files show up in the META-INF directory of the artifact we produce.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>