### PR TITLE
update parent, add missing osg headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,17 +21,82 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>jakarta.jms</groupId>
     <artifactId>jakarta.jms-api</artifactId>
     <version>2.0.2-SNAPSHOT</version>
-    
+
     <name>jms</name>
     <url>https://projects.eclipse.org/projects/ee4j.jms</url>
 
+    <properties>
+        <!--
+            After every promotion build:
+              - increment spec.build
+            To re-spin a promotion build:
+              - change the project <version> back to the previous value
+              - commit the change
+
+            When the spec turns final:
+              - change spec.non.final to false
+              - change spec.version to the value of spec.newVersion
+              - comment out spec.newVersion
+              - comment out spec.build
+              - update the project <version> to not have -bXX
+        -->
+        <spec.title>Java(TM) Message Service Specification</spec.title>
+        <spec.version>2.0</spec.version>
+        <spec.newVersion>2.1</spec.newVersion>
+        <spec.build>01</spec.build>
+        <spec.impl.version>2.0.2</spec.impl.version>
+        <spec.extension.name>javax.jms</spec.extension.name>
+        <spec.non.final>false</spec.non.final>
+        <spec.api.package>jakarta.jms</spec.api.package>
+    </properties>
+
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.glassfish.build</groupId>
+                    <artifactId>spec-version-maven-plugin</artifactId>
+                    <version>1.5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.5.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <resources>
             <resource>
                 <directory>${project.basedir}</directory>
@@ -42,22 +107,87 @@
                 <targetPath>META-INF</targetPath>
             </resource>
         </resources>
-    
+
         <plugins>
            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            
+
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>spec-version-maven-plugin</artifactId>
+                <configuration>
+                    <specMode>jakarta</specMode>
+                    <spec>
+                        <nonFinal>${spec.non.final}</nonFinal>
+                        <jarType>api</jarType>
+                        <specVersion>${spec.version}</specVersion>
+                        <specBuild>${spec.build}</specBuild>
+                        <specImplVersion>${spec.impl.version}</specImplVersion>
+                        <apiPackage>${spec.api.package}</apiPackage>
+                        <newSpecVersion>${spec.new.spec.version}</newSpecVersion>
+                    </spec>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-spec-properties</goal>
+                            <!-- TODO:
+                            glassfish-spec-version-maven-plugin needs to be updated
+                            in order to check 'jakarta.' prefixed values in manifest entries
+                            -->
+                            <!--<goal>check-module</goal>-->
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-Version>${spec.bundle.version}</Bundle-Version>
+                        <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
+                        <Extension-Name>${spec.extension.name}</Extension-Name>
+                        <Implementation-Version>${spec.implementation.version}</Implementation-Version>
+                        <Specification-Version>${spec.specification.version}</Specification-Version>
+                        <Bundle-Description>
+                            Java(TM) Message Service (JMS) ${spec.version} Specification
+                        </Bundle-Description>
+                        <Implementation-Vendor-Id>org.glassfish.mq</Implementation-Vendor-Id>
+                        <Specification-Vendor>Oracle Corporation</Specification-Vendor>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
                 <configuration>
                     <groups>
                         <group>
@@ -67,30 +197,22 @@
                             </packages>
                         </group>
                     </groups>
-                
+
                     <!-- Specifies the text to be placed at the bottom of each output file. -->
                     <bottom>Copyright 1997-2018 Oracle America Inc. All rights reserved. Use is subject to &lt;a
                         href="http://java.net/downloads/jms-spec/Licences/JSR 368 Java Message Service EDR 10.8.15.pdf"&gt;licence
                         terms&lt;/a&gt; &lt;br/&gt;</bottom>
-                    
+
                     <!-- Specifies the header text to be placed at the top of each output file, to the right of the upper navigation bar. -->
-                    <header>JMS 2.1</header>
-                    
+                    <header>JMS ${spec.version}</header>
+
                     <!-- Specifies the footer text to be placed at the top of each output file, to the right of the lower navigation bar. -->
-                    <footer>JMS 2.1</footer>
+                    <footer>JMS ${spec.version}</footer>
 
                     <links>
                         <link>https://javaee.github.io/javaee-spec/javadocs/</link>
                     </links>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                     </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
* update parent to 1.0.5
* add missing osgi headers
* avoid warnings during build

'mvn clean install' as well as 'mvn clean install -Poss-release' produces what I would consider as correct output. Double-check I used correct spec version etc numbers, please.

Thanks!
 
Fixes: #216

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>