### PR TITLE
Fix license text

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -212,7 +212,7 @@
                             <header><![CDATA[<br>Jakarta Messaging API v${project.version}]]></header>
                             <bottom><![CDATA[
 Comments to: <a href="mailto:jms-dev@eclipse.org">jms-dev@eclipse.org</a>.<br>
-Copyright &#169; 2019 Eclipse Foundation. All rights reserved.<br>
+Copyright &#169; 2018, 2020 Eclipse Foundation. All rights reserved.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
                             </bottom>
                             <docfilessubdirs>true</docfilessubdirs>

--- a/api/src/main/javadoc/doc-files/speclicense.html
+++ b/api/src/main/javadoc/doc-files/speclicense.html
@@ -20,7 +20,7 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
       &quot;
   </li>
 </ul>
@@ -42,7 +42,7 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; [$date-of-document] Eclipse Foundation. This software or
   document includes material copied from or derived from [title and URI
   of the Eclipse Foundation specification document].&quot;</p>
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -9,9 +9,10 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-=== Copyright
+== Copyright
 
-Copyright (c) 2020 Eclipse Foundation.
+Copyright (c) 2018, 2020 Eclipse Foundation.
+https://www.eclipse.org/legal/efsl.php[]
 
 === Eclipse Foundation Specification License
 
@@ -30,7 +31,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. <<url to this license>>"
+  Eclipse Foundation, Inc. \<<url to this license>>"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -49,7 +50,7 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2018 Eclipse Foundation. This software or
+"Copyright (c) [$date-of-document] Eclipse Foundation. This software or
 document includes material copied from or derived from [title and URI
 of the Eclipse Foundation specification document]."
 


### PR DESCRIPTION
- Update copyright years in javadoc footer to 2018, 2020
- Fix license text to match original EFSL text
